### PR TITLE
feat: introduce Stream(a) opaque type and Step enum

### DIFF
--- a/src/datastream.gleam
+++ b/src/datastream.gleam
@@ -5,10 +5,71 @@
 //// both the Erlang and JavaScript targets. The `datastream/erlang/*`
 //// extension modules are quarantined to the Erlang target.
 ////
+//// This module defines the foundational types every later module builds
+//// on: the opaque pipeline value `Stream(a)` and the pull-result enum
+//// `Step(a, state)`.
+////
 //// See `doc/reference/spec.md` for the full specification.
 
-/// Library version. Replaced by the actual implementation surface as
-/// the Phase 1 issues land (see GitHub issue #2).
-pub fn version() -> String {
-  "0.1.0"
+/// A lazy, pull-based pipeline that yields elements of type `a`.
+///
+/// Values of this type are pipeline *definitions*, not materialised
+/// collections. Each terminal operation (in `fold` / `sink`) re-runs the
+/// pipeline from its source — there is no implicit caching. Callers that
+/// want replay should materialise once with `fold.to_list`.
+///
+/// The internal representation is intentionally hidden so the library is
+/// free to change it (list-backed, function-backed, chunk-batched, …)
+/// without a breaking change. `==` / `!=` carry no specified meaning;
+/// observational equality is via terminal reduction.
+pub opaque type Stream(a) {
+  Stream(pull: fn() -> Step(a, Stream(a)))
+}
+
+/// The result of pulling one element from a stream-like producer.
+///
+/// `Next(element, state)` carries the produced element together with the
+/// continuation needed to pull the next one. `Done` signals end-of-stream.
+/// Once `Done` is observed the producer MUST NOT be pulled again.
+///
+/// There is intentionally no `Error` variant: the core does not impose a
+/// failure model. Callers that need errors carry them as element-shaped
+/// values (`Stream(Result(a, e))`, `Stream(Validated(a, e))`, …).
+pub type Step(a, state) {
+  Next(element: a, state: state)
+  Done
+}
+
+/// Build a `Stream(a)` from an initial state and a step function.
+///
+/// `step` is invoked once per pull; the returned `Step` either yields
+/// the next element together with the updated state, or signals `Done`.
+/// The state type `s` is a private implementation detail of the
+/// constructed stream and never appears in the public surface.
+///
+/// This constructor is internal to the library — it is the substrate the
+/// `source`, `stream`, `fold`, and `sink` modules build on. It is not
+/// part of the public API.
+@internal
+pub fn unfold(from state: s, with step: fn(s) -> Step(a, s)) -> Stream(a) {
+  Stream(pull: fn() {
+    case step(state) {
+      Next(element, next_state) ->
+        Next(element, unfold(from: next_state, with: step))
+      Done -> Done
+    }
+  })
+}
+
+/// Pull one element from a stream.
+///
+/// Returns `Next(element, next_stream)` or `Done`. After `Done` is
+/// observed the same stream MUST NOT be pulled again; doing so is a
+/// programmer error and the result is unspecified.
+///
+/// Internal to the library: terminal operations live in `fold` / `sink`
+/// and call this helper. It is not part of the public API.
+@internal
+pub fn pull(stream: Stream(a)) -> Step(a, Stream(a)) {
+  stream.pull()
 }

--- a/test/datastream_test.gleam
+++ b/test/datastream_test.gleam
@@ -1,4 +1,4 @@
-import datastream
+import datastream.{Done, Next}
 import gleeunit
 import gleeunit/should
 
@@ -6,7 +6,64 @@ pub fn main() -> Nil {
   gleeunit.main()
 }
 
-pub fn version_test() {
-  datastream.version()
-  |> should.equal("0.1.0")
+pub fn unfold_yields_one_then_done_test() {
+  let stream =
+    datastream.unfold(from: 0, with: fn(s) {
+      case s {
+        0 -> Next(element: 1, state: 1)
+        _ -> Done
+      }
+    })
+
+  let assert Next(1, rest) = datastream.pull(stream)
+  datastream.pull(rest) |> should.equal(Done)
+}
+
+pub fn unfold_done_immediately_test() {
+  let stream = datastream.unfold(from: Nil, with: fn(_) { Done })
+
+  datastream.pull(stream) |> should.equal(Done)
+}
+
+pub fn unfold_yields_two_then_done_test() {
+  let stream =
+    datastream.unfold(from: 0, with: fn(s) {
+      case s {
+        0 -> Next(element: "a", state: 1)
+        1 -> Next(element: "b", state: 2)
+        _ -> Done
+      }
+    })
+
+  let assert Next("a", after_a) = datastream.pull(stream)
+  let assert Next("b", after_b) = datastream.pull(after_a)
+  datastream.pull(after_b) |> should.equal(Done)
+}
+
+pub fn pull_re_runs_from_source_each_time_test() {
+  let stream =
+    datastream.unfold(from: 0, with: fn(s) {
+      case s {
+        0 -> Next(element: 1, state: 1)
+        1 -> Next(element: 2, state: 2)
+        _ -> Done
+      }
+    })
+
+  let assert Next(1, _) = datastream.pull(stream)
+  let assert Next(1, _) = datastream.pull(stream)
+}
+
+pub fn unfold_state_is_private_to_constructed_stream_test() {
+  let stream =
+    datastream.unfold(from: #(0, "x"), with: fn(s) {
+      let #(i, label) = s
+      case i {
+        0 -> Next(element: label, state: #(1, label))
+        _ -> Done
+      }
+    })
+
+  let assert Next("x", rest) = datastream.pull(stream)
+  datastream.pull(rest) |> should.equal(Done)
 }


### PR DESCRIPTION
## Summary

Establish the foundational types every later cross-target module builds on (Phase 1, root of the implementation tree).

- `Stream(a)` is exposed as `pub opaque` so the internal representation (currently a continuation) can change without a breaking release.
- `Step(a, state)` is the `Next | Done` pull-result enum. There is intentionally no `Error` variant — failures travel as element-shaped values (`Result`, `Validated`, …) per the spec.
- The pull machinery is internal: `unfold` and `pull` are marked `@internal pub`, callable from the upcoming `source`, `stream`, `fold`, and `sink` modules without joining the public API.

## Design decisions

- **Continuation form**: `Stream` carries `pull: fn() -> Step(a, Stream(a))`. The state type used by `unfold` (`s`) is closed over and never appears in `Stream(a)`'s type, so callers cannot couple to it.
- **Replay**: each `pull(stream)` re-runs from the captured initial state; there is no implicit caching. Verified by a dedicated test.
- **Internal helpers via `@internal`**: lets the next Phase 1 modules (`source`, `fold`, `stream`) construct and drive streams without exposing the constructor publicly.

## Tests

`just all` is green on both Erlang and JavaScript targets:

- the three Issue-defined pull sequences (`Next/Done`, `Done` immediately, two `Next` then `Done`)
- a replay test confirming pulling the same stream twice restarts from the initial state
- a state-shape test confirming the private state can be a tuple without affecting the public type

Closes #2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new streaming API for building lazy, composable data processing pipelines.

* **Breaking Changes**
  * Removed the `version()` function. Applications relying on version detection will need to update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->