### PR TITLE
feat: add datastream/fold with basic terminal reducers

### DIFF
--- a/src/datastream/fold.gleam
+++ b/src/datastream/fold.gleam
@@ -1,0 +1,90 @@
+//// Pure terminal reductions over `Stream(a)`.
+////
+//// This module is the `fold` half of the terminal layer: every function
+//// here drives a stream to completion (or until an early-exit decision)
+//// and returns a plain value. Side-effecting terminals live in `sink`.
+////
+//// Building combinators alone has no observable effect — calling one of
+//// these functions is what actually pulls elements from the source.
+//// Pipelines re-run the source on every terminal call; there is no
+//// implicit caching.
+
+import datastream.{type Stream, Done, Next}
+import gleam/list
+import gleam/option.{type Option, None, Some}
+
+/// Materialise the stream into a list, preserving source order.
+///
+/// Pulls every element. On a `Stream` of `n` elements this allocates
+/// `O(n)` cons cells. For terminating streams only.
+pub fn to_list(stream: Stream(a)) -> List(a) {
+  stream
+  |> fold(from: [], with: fn(acc, element) { [element, ..acc] })
+  |> list.reverse
+}
+
+/// Count the number of elements the stream produces.
+///
+/// Drives the stream to completion without retaining elements. Returns
+/// `0` on an empty stream.
+pub fn count(stream: Stream(a)) -> Int {
+  fold(over: stream, from: 0, with: fn(acc, _) { acc + 1 })
+}
+
+/// Return the first element produced by the stream, if any.
+///
+/// Pulls at most one element from upstream and stops; this makes `first`
+/// safe on infinite streams. Returns `None` if the stream is empty.
+pub fn first(stream: Stream(a)) -> Option(a) {
+  case datastream.pull(stream) {
+    Next(element, _) -> Some(element)
+    Done -> None
+  }
+}
+
+/// Return the last element produced by the stream, if any.
+///
+/// Drives the stream to completion. Returns `None` on an empty stream.
+/// Does not terminate on an infinite stream.
+pub fn last(stream: Stream(a)) -> Option(a) {
+  fold(over: stream, from: None, with: fn(_, element) { Some(element) })
+}
+
+/// Left-fold over the stream, seeded with `initial`.
+///
+/// Returns `initial` unchanged on an empty stream. The accumulator is
+/// updated by `step(acc, element)` in source order.
+pub fn fold(
+  over stream: Stream(a),
+  from initial: b,
+  with step: fn(b, a) -> b,
+) -> b {
+  case datastream.pull(stream) {
+    Next(element, rest) ->
+      fold(over: rest, from: step(initial, element), with: step)
+    Done -> initial
+  }
+}
+
+/// Left-fold without an explicit seed: the head element seeds the fold.
+///
+/// Returns `None` on an empty stream, `Some(only)` on a one-element
+/// stream, and `Some(fold_of_tail_seeded_with_head)` otherwise.
+pub fn reduce(over stream: Stream(a), with step: fn(a, a) -> a) -> Option(a) {
+  case datastream.pull(stream) {
+    Next(head, rest) -> Some(fold(over: rest, from: head, with: step))
+    Done -> None
+  }
+}
+
+/// Drive the stream to completion and discard every element.
+///
+/// Useful when the pipeline is built purely for traversal (for example
+/// to walk a `tap`-instrumented chain) and the caller does not want to
+/// import `sink` for a no-op consumer.
+pub fn drain(stream: Stream(a)) -> Nil {
+  case datastream.pull(stream) {
+    Next(_, rest) -> drain(rest)
+    Done -> Nil
+  }
+}

--- a/test/datastream/fold_test.gleam
+++ b/test/datastream/fold_test.gleam
@@ -1,0 +1,114 @@
+import datastream.{Done, Next}
+import datastream/fold
+import gleam/option.{None, Some}
+import gleeunit
+import gleeunit/should
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+fn from_list(list) {
+  datastream.unfold(from: list, with: fn(xs) {
+    case xs {
+      [] -> Done
+      [head, ..tail] -> Next(element: head, state: tail)
+    }
+  })
+}
+
+fn repeat(value) {
+  datastream.unfold(from: value, with: fn(s) { Next(element: s, state: s) })
+}
+
+pub fn to_list_returns_elements_in_source_order_test() {
+  from_list([1, 2, 3]) |> fold.to_list |> should.equal([1, 2, 3])
+}
+
+pub fn to_list_on_empty_returns_empty_test() {
+  from_list([]) |> fold.to_list |> should.equal([])
+}
+
+pub fn count_returns_number_of_elements_test() {
+  from_list([1, 2, 3]) |> fold.count |> should.equal(3)
+}
+
+pub fn count_on_empty_returns_zero_test() {
+  from_list([]) |> fold.count |> should.equal(0)
+}
+
+pub fn first_returns_some_singleton_test() {
+  from_list([10]) |> fold.first |> should.equal(Some(10))
+}
+
+pub fn first_returns_some_head_of_many_test() {
+  from_list([1, 2, 3]) |> fold.first |> should.equal(Some(1))
+}
+
+pub fn first_on_empty_returns_none_test() {
+  from_list([]) |> fold.first |> should.equal(None)
+}
+
+pub fn first_terminates_on_infinite_stream_test() {
+  repeat(7) |> fold.first |> should.equal(Some(7))
+}
+
+pub fn first_pulls_at_most_one_element_test() {
+  let stream =
+    datastream.unfold(from: 0, with: fn(s) {
+      case s {
+        0 -> Next(element: s, state: 1)
+        _ -> panic as "first must not pull beyond the first Next"
+      }
+    })
+
+  fold.first(stream) |> should.equal(Some(0))
+}
+
+pub fn last_returns_some_tail_test() {
+  from_list([1, 2, 3]) |> fold.last |> should.equal(Some(3))
+}
+
+pub fn last_on_empty_returns_none_test() {
+  from_list([]) |> fold.last |> should.equal(None)
+}
+
+pub fn fold_sums_ints_test() {
+  from_list([1, 2, 3])
+  |> fold.fold(from: 0, with: fn(acc, x) { acc + x })
+  |> should.equal(6)
+}
+
+pub fn fold_returns_initial_on_empty_test() {
+  from_list([])
+  |> fold.fold(from: 10, with: fn(acc, x) { acc + x })
+  |> should.equal(10)
+}
+
+pub fn fold_concatenates_strings_test() {
+  from_list(["a", "b", "c"])
+  |> fold.fold(from: "", with: fn(acc, x) { acc <> x })
+  |> should.equal("abc")
+}
+
+pub fn reduce_seeds_with_head_then_folds_tail_test() {
+  from_list([1, 2, 3])
+  |> fold.reduce(with: fn(a, b) { a + b })
+  |> should.equal(Some(6))
+}
+
+pub fn reduce_returns_some_only_on_singleton_test() {
+  from_list([1])
+  |> fold.reduce(with: fn(a, b) { a + b })
+  |> should.equal(Some(1))
+}
+
+pub fn reduce_on_empty_returns_none_test() {
+  from_list([])
+  |> fold.reduce(with: fn(a, b) { a + b })
+  |> should.equal(None)
+}
+
+pub fn drain_returns_nil_test() {
+  from_list([1, 2, 3]) |> fold.drain |> should.equal(Nil)
+}


### PR DESCRIPTION
## Summary

Phase 1 terminal layer: introduce the `datastream/fold` module so pipelines have a working evaluation boundary. Covers the seven pure reducers in scope for #5: `to_list`, `count`, `first`, `last`, `fold`, `reduce`, `drain`.

Arithmetic / result helpers are intentionally deferred to #8.

## Design decisions

- **`first` is a single `pull`** — the early-exit MUST in #5 turns into one pattern match; the rest of the stream is dropped on the floor. This is what makes `first` safe on infinite streams.
- **`reduce` returns `Option(a)`** so `first` / `last` / `find` (later) share a return shape; the head element seeds the fold so a singleton stream yields `Some(only)` rather than degenerating into the binary-op base case.
- **`to_list` reverses once at the end** rather than appending — `O(n)` cons + one reverse beats `O(n²)` append.
- **`count` and `last` reuse `fold`** — the implementations stay one-liners and the `fold` invariant carries.

## Tests

`just all` is green on Erlang and JavaScript (23 total: 5 prior + 18 new).

- the full Issue #5 case table for each function
- early-exit invariant for `first`: the test installs an `unfold` step that `panic`s if pulled a second time, so the test only passes when `first` stops after the head
- `repeat` infinite-stream termination test for `first`

Tests use a private `unfold`-backed `from_list` / `repeat` helper so this module does not depend on the not-yet-implemented `source` constructors (#3).

Closes #5.