### PR TITLE
feat: add datastream/stream with basic middle combinators

### DIFF
--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -1,0 +1,182 @@
+//// Single-stream middle combinators over `Stream(a)`.
+////
+//// These are the lazy, order-preserving transforms whose names callers
+//// already know from list-style APIs: `map`, `filter`, `take`, `drop`,
+//// `take_while`, `drop_while`, and binary `append`. Multi-source
+//// composition (`flat_map`, `flatten`, `concat`, `scan`, …) lives in a
+//// later issue.
+////
+//// Building a pipeline with these combinators triggers no user
+//// callbacks. Callbacks fire only when a terminal in `fold` or `sink`
+//// pulls the result.
+////
+//// Early-exit combinators (`take`, `take_while`) stop pulling upstream
+//// the moment their result is determined, which is what makes them safe
+//// on infinite sources.
+
+import datastream.{type Stream, Done, Next}
+
+/// Apply `f` to every element. Cardinality and order are preserved.
+pub fn map(over stream: Stream(a), with f: fn(a) -> b) -> Stream(b) {
+  datastream.unfold(from: stream, with: fn(current) {
+    case datastream.pull(current) {
+      Next(element, rest) -> Next(element: f(element), state: rest)
+      Done -> Done
+    }
+  })
+}
+
+/// Keep only the elements for which `predicate` returns `True`.
+///
+/// Relative order of the survivors is preserved.
+pub fn filter(
+  over stream: Stream(a),
+  keeping predicate: fn(a) -> Bool,
+) -> Stream(a) {
+  datastream.unfold(from: stream, with: fn(current) {
+    do_filter(current, predicate)
+  })
+}
+
+fn do_filter(stream: Stream(a), predicate: fn(a) -> Bool) -> Step(a, Stream(a)) {
+  case datastream.pull(stream) {
+    Next(element, rest) ->
+      case predicate(element) {
+        True -> Next(element: element, state: rest)
+        False -> do_filter(rest, predicate)
+      }
+    Done -> Done
+  }
+}
+
+/// Yield at most the first `n` elements; `n <= 0` yields the empty stream.
+///
+/// Stops pulling upstream the moment the `n`th element has been emitted,
+/// which is what makes `take` safe on infinite sources.
+pub fn take(from stream: Stream(a), up_to n: Int) -> Stream(a) {
+  datastream.unfold(from: #(n, stream), with: fn(state) {
+    let #(remaining, current) = state
+    case remaining <= 0 {
+      True -> Done
+      False ->
+        case datastream.pull(current) {
+          Next(element, rest) ->
+            Next(element: element, state: #(remaining - 1, rest))
+          Done -> Done
+        }
+    }
+  })
+}
+
+/// Discard the first `n` elements; `n <= 0` is the identity.
+pub fn drop(from stream: Stream(a), up_to n: Int) -> Stream(a) {
+  datastream.unfold(from: #(n, stream), with: fn(state) {
+    let #(remaining, current) = state
+    do_drop(remaining, current)
+  })
+}
+
+fn do_drop(remaining: Int, stream: Stream(a)) -> Step(a, #(Int, Stream(a))) {
+  case remaining <= 0 {
+    True ->
+      case datastream.pull(stream) {
+        Next(element, rest) -> Next(element: element, state: #(0, rest))
+        Done -> Done
+      }
+    False ->
+      case datastream.pull(stream) {
+        Next(_, rest) -> do_drop(remaining - 1, rest)
+        Done -> Done
+      }
+  }
+}
+
+/// Yield the longest prefix where `predicate` holds, then stop.
+///
+/// Stops pulling upstream as soon as `predicate` returns `False`, so
+/// `take_while` terminates on infinite sources whose prefix eventually
+/// fails the predicate.
+pub fn take_while(
+  in stream: Stream(a),
+  satisfying predicate: fn(a) -> Bool,
+) -> Stream(a) {
+  datastream.unfold(from: stream, with: fn(current) {
+    case datastream.pull(current) {
+      Next(element, rest) ->
+        case predicate(element) {
+          True -> Next(element: element, state: rest)
+          False -> Done
+        }
+      Done -> Done
+    }
+  })
+}
+
+/// Discard the longest prefix where `predicate` holds, then yield the rest.
+pub fn drop_while(
+  in stream: Stream(a),
+  satisfying predicate: fn(a) -> Bool,
+) -> Stream(a) {
+  datastream.unfold(from: DropWhilePending(stream), with: fn(state) {
+    drop_while_step(state, predicate)
+  })
+}
+
+type DropWhile(a) {
+  DropWhilePending(stream: Stream(a))
+  DropWhileSettled(stream: Stream(a))
+}
+
+fn drop_while_step(
+  state: DropWhile(a),
+  predicate: fn(a) -> Bool,
+) -> Step(a, DropWhile(a)) {
+  case state {
+    DropWhilePending(stream) ->
+      case datastream.pull(stream) {
+        Next(element, rest) ->
+          case predicate(element) {
+            True -> drop_while_step(DropWhilePending(rest), predicate)
+            False -> Next(element: element, state: DropWhileSettled(rest))
+          }
+        Done -> Done
+      }
+    DropWhileSettled(stream) ->
+      case datastream.pull(stream) {
+        Next(element, rest) ->
+          Next(element: element, state: DropWhileSettled(rest))
+        Done -> Done
+      }
+  }
+}
+
+/// Yield all of `first`, then all of `second`. If `first` is infinite,
+/// `second` is never reached.
+pub fn append(first: Stream(a), second: Stream(a)) -> Stream(a) {
+  datastream.unfold(from: AppendInFirst(first, second), with: append_step)
+}
+
+type Append(a) {
+  AppendInFirst(first: Stream(a), second: Stream(a))
+  AppendInSecond(stream: Stream(a))
+}
+
+fn append_step(state: Append(a)) -> Step(a, Append(a)) {
+  case state {
+    AppendInFirst(first, second) ->
+      case datastream.pull(first) {
+        Next(element, rest) ->
+          Next(element: element, state: AppendInFirst(rest, second))
+        Done -> append_step(AppendInSecond(second))
+      }
+    AppendInSecond(stream) ->
+      case datastream.pull(stream) {
+        Next(element, rest) ->
+          Next(element: element, state: AppendInSecond(rest))
+        Done -> Done
+      }
+  }
+}
+
+type Step(a, state) =
+  datastream.Step(a, state)

--- a/test/datastream/stream_test.gleam
+++ b/test/datastream/stream_test.gleam
@@ -1,0 +1,188 @@
+import datastream.{Done, Next}
+import datastream/fold
+import datastream/stream
+import gleeunit
+import gleeunit/should
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+fn from_list(list) {
+  datastream.unfold(from: list, with: fn(xs) {
+    case xs {
+      [] -> Done
+      [head, ..tail] -> Next(element: head, state: tail)
+    }
+  })
+}
+
+fn repeat(value) {
+  datastream.unfold(from: value, with: fn(s) { Next(element: s, state: s) })
+}
+
+fn iterate(start, with f) {
+  datastream.unfold(from: start, with: fn(s) { Next(element: s, state: f(s)) })
+}
+
+pub fn map_doubles_each_element_test() {
+  from_list([1, 2, 3])
+  |> stream.map(with: fn(x) { x * 2 })
+  |> fold.to_list
+  |> should.equal([2, 4, 6])
+}
+
+pub fn map_on_empty_returns_empty_test() {
+  from_list([])
+  |> stream.map(with: fn(x) { x * 2 })
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn filter_keeps_matching_elements_test() {
+  from_list([1, 2, 3, 4])
+  |> stream.filter(keeping: fn(x) { x > 2 })
+  |> fold.to_list
+  |> should.equal([3, 4])
+}
+
+pub fn filter_with_constant_false_yields_empty_test() {
+  from_list([1, 2, 3])
+  |> stream.filter(keeping: fn(_) { False })
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn take_yields_first_n_test() {
+  from_list([1, 2, 3])
+  |> stream.take(up_to: 2)
+  |> fold.to_list
+  |> should.equal([1, 2])
+}
+
+pub fn take_zero_yields_empty_test() {
+  from_list([1, 2, 3])
+  |> stream.take(up_to: 0)
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn take_negative_yields_empty_test() {
+  from_list([1, 2, 3])
+  |> stream.take(up_to: -5)
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn take_more_than_available_yields_all_test() {
+  from_list([1, 2, 3])
+  |> stream.take(up_to: 99)
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+}
+
+pub fn take_terminates_on_infinite_source_test() {
+  repeat(7)
+  |> stream.take(up_to: 3)
+  |> fold.to_list
+  |> should.equal([7, 7, 7])
+}
+
+pub fn drop_skips_first_n_test() {
+  from_list([1, 2, 3])
+  |> stream.drop(up_to: 1)
+  |> fold.to_list
+  |> should.equal([2, 3])
+}
+
+pub fn drop_zero_is_identity_test() {
+  from_list([1, 2, 3])
+  |> stream.drop(up_to: 0)
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+}
+
+pub fn drop_negative_is_identity_test() {
+  from_list([1, 2, 3])
+  |> stream.drop(up_to: -5)
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+}
+
+pub fn drop_more_than_available_yields_empty_test() {
+  from_list([1, 2, 3])
+  |> stream.drop(up_to: 99)
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn take_while_yields_longest_passing_prefix_test() {
+  from_list([1, 2, 1, 4])
+  |> stream.take_while(satisfying: fn(x) { x < 3 })
+  |> fold.to_list
+  |> should.equal([1, 2, 1])
+}
+
+pub fn take_while_with_constant_false_yields_empty_test() {
+  from_list([5, 6, 7])
+  |> stream.take_while(satisfying: fn(_) { False })
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn take_while_terminates_on_infinite_source_test() {
+  iterate(1, with: fn(x) { x + 1 })
+  |> stream.take_while(satisfying: fn(x) { x < 4 })
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+}
+
+pub fn drop_while_skips_longest_passing_prefix_test() {
+  from_list([1, 2, 1, 4])
+  |> stream.drop_while(satisfying: fn(x) { x < 3 })
+  |> fold.to_list
+  |> should.equal([4])
+}
+
+pub fn drop_while_with_constant_false_is_identity_test() {
+  from_list([1, 2, 1])
+  |> stream.drop_while(satisfying: fn(_) { False })
+  |> fold.to_list
+  |> should.equal([1, 2, 1])
+}
+
+pub fn append_concatenates_two_streams_test() {
+  stream.append(from_list([1, 2]), from_list([3, 4]))
+  |> fold.to_list
+  |> should.equal([1, 2, 3, 4])
+}
+
+pub fn append_with_empty_first_yields_second_test() {
+  stream.append(from_list([]), from_list([3, 4]))
+  |> fold.to_list
+  |> should.equal([3, 4])
+}
+
+pub fn append_with_empty_second_yields_first_test() {
+  stream.append(from_list([1, 2]), from_list([]))
+  |> fold.to_list
+  |> should.equal([1, 2])
+}
+
+pub fn map_is_lazy_until_terminal_test() {
+  let _pipeline =
+    from_list([1, 2, 3])
+    |> stream.map(with: fn(_) {
+      panic as "map must not run its function before a terminal"
+    })
+
+  Nil
+}
+
+pub fn map_invokes_callback_once_per_element_on_terminal_test() {
+  let pipeline =
+    from_list([1, 2, 3])
+    |> stream.map(with: fn(x) { x + 100 })
+
+  pipeline |> fold.to_list |> should.equal([101, 102, 103])
+}


### PR DESCRIPTION
## Summary

Phase 1 middle layer: introduce `datastream/stream` with the seven single-stream combinators in scope for #4 (`map`, `filter`, `take`, `drop`, `take_while`, `drop_while`, binary `append`). Composition combinators (`flat_map`, `flatten`, `concat`, `scan`, …) stay deferred to #7.

## Design decisions

- **Each combinator is an `unfold` wrapper.** State is either the upstream `Stream(a)` itself, a `#(Int, Stream(a))` pair (for `take` / `drop`), or a small private sum type (`DropWhile`, `Append`). This keeps the lazy guarantee: building a pipeline never invokes a user callback.
- **`take(n)` / `take_while(p)` short-circuit on the state machine.** `take` looks at `remaining <= 0` *before* pulling, so the upstream is never asked for the `n+1`th element. `take_while` returns `Done` the moment the predicate fails. Both are exercised against `repeat` / `iterate` infinite sources.
- **`n <= 0` collapses to identity.** `take(-5)` → empty; `drop(-5)` → upstream unchanged. Matches `gleam/list` and avoids surprising the caller with a panic.
- **`append` uses a two-state private sum type.** `AppendInFirst(first, second)` drains `first` while remembering `second`; once `first` is `Done`, the state transitions to `AppendInSecond(second)` and stays there. `second` is never pulled while `first` is still producing.

## Spec note

Issue #4's example table for `take_while` lists ` from_list([1, 2, 1, 4]) |> take_while(fn(x) { x < 3 })` as `[1, 2]`. The behavior text immediately above says \"yields the longest prefix where p holds\", and the matching `drop_while` row expects `[4]` — both of which require the longest prefix to be `[1, 2, 1]`. The expected value in the example table appears to be a typo. This PR follows the behavior text and the `drop_while` row: the test asserts `[1, 2, 1]`. Happy to flip back if the table was the intent.

## Tests

`just all` is green on Erlang and JavaScript (46 total: 23 prior + 23 new):

- the full Issue #4 case table for each combinator (with the take_while expected value adjusted as noted above)
- two infinite-source termination tests using `repeat(7) |> take(3)` and `iterate(1, +1) |> take_while(< 4)`
- a laziness test that wires a `panic`-on-call function through `map` and only succeeds because no terminal runs

Tests use private `unfold`-backed `from_list` / `repeat` / `iterate` helpers, keeping this module decoupled from the not-yet-implemented `source` constructors (#3).

Closes #4.