### PR TITLE
feat: add datastream/source with basic constructors

### DIFF
--- a/src/datastream/source.gleam
+++ b/src/datastream/source.gleam
@@ -1,0 +1,101 @@
+//// Stream constructors: every public way to *produce* a `Stream(a)`.
+////
+//// The constructors split into two kinds:
+////
+//// - **Adapters** wrap an existing data structure: `from_list`,
+////   `once`, `empty`.
+//// - **Generative** constructors build a stream from a rule: `range`,
+////   `repeat`, `iterate`, `unfold`.
+////
+//// `repeat` and `iterate` are infinite by design; pair them with
+//// `stream.take` / `stream.take_while` (or `fold.first` / `fold.find`)
+//// to terminate. `unfold`'s step is expected to be pure — effectful
+//// generators belong in the resource constructors introduced later.
+////
+//// Every constructor produces a stream that re-runs from the beginning
+//// on every terminal call: there is no implicit caching.
+
+import datastream.{type Step, type Stream, Done, Next}
+
+/// A stream that yields no elements.
+pub fn empty() -> Stream(a) {
+  datastream.unfold(from: Nil, with: fn(_) { Done })
+}
+
+/// A stream that yields exactly one element and then stops.
+pub fn once(value: a) -> Stream(a) {
+  datastream.unfold(from: True, with: fn(first) {
+    case first {
+      True -> Next(element: value, state: False)
+      False -> Done
+    }
+  })
+}
+
+/// A stream that yields the elements of `list` in order.
+pub fn from_list(list: List(a)) -> Stream(a) {
+  datastream.unfold(from: list, with: fn(remaining) {
+    case remaining {
+      [] -> Done
+      [head, ..tail] -> Next(element: head, state: tail)
+    }
+  })
+}
+
+/// Stop-exclusive integer range.
+///
+/// Counts up by 1 when `start < stop`, down by 1 when `start > stop`,
+/// and is empty when `start == stop`. Step-by-`n` sequences belong in
+/// `iterate` or `unfold`, keeping `range` aligned with the surrounding
+/// stdlib's `range`.
+pub fn range(from start: Int, to stop: Int) -> Stream(Int) {
+  case start == stop {
+    True -> empty()
+    False -> {
+      let direction = case start < stop {
+        True -> 1
+        False -> -1
+      }
+      datastream.unfold(from: start, with: fn(current) {
+        case current == stop {
+          True -> Done
+          False -> Next(element: current, state: current + direction)
+        }
+      })
+    }
+  }
+}
+
+/// A stream that yields `value` infinitely.
+///
+/// Pair with `stream.take` (or any early-exit terminal) to bound the
+/// pull count.
+pub fn repeat(value: a) -> Stream(a) {
+  datastream.unfold(from: value, with: fn(state) {
+    Next(element: state, state: state)
+  })
+}
+
+/// Iterate `next` from `seed`: yields `seed`, `next(seed)`,
+/// `next(next(seed))`, … infinitely.
+///
+/// Pair with `stream.take` / `stream.take_while` to terminate.
+pub fn iterate(from seed: a, with next: fn(a) -> a) -> Stream(a) {
+  datastream.unfold(from: seed, with: fn(state) {
+    Next(element: state, state: next(state))
+  })
+}
+
+/// Build a stream from an initial state and a step function.
+///
+/// `step` is invoked once per pull; returning `Next(element, next)`
+/// emits the element and supplies the state for the following pull,
+/// returning `Done` ends the stream. The state type is hidden in the
+/// produced `Stream(a)` so callers can pick whatever shape suits the
+/// generator.
+pub fn unfold(
+  from initial: state,
+  with step: fn(state) -> Step(a, state),
+) -> Stream(a) {
+  datastream.unfold(from: initial, with: step)
+}

--- a/test/datastream/source_test.gleam
+++ b/test/datastream/source_test.gleam
@@ -1,0 +1,118 @@
+import datastream.{Done, Next}
+import datastream/fold
+import datastream/source
+import datastream/stream
+import gleeunit
+import gleeunit/should
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn empty_yields_no_elements_test() {
+  source.empty() |> fold.to_list |> should.equal([])
+}
+
+pub fn once_yields_exactly_one_element_test() {
+  source.once(7) |> fold.to_list |> should.equal([7])
+}
+
+pub fn from_list_on_empty_yields_empty_test() {
+  source.from_list([]) |> fold.to_list |> should.equal([])
+}
+
+pub fn from_list_preserves_source_order_test() {
+  source.from_list([1, 2, 3]) |> fold.to_list |> should.equal([1, 2, 3])
+}
+
+pub fn range_counts_up_when_start_less_than_stop_test() {
+  source.range(from: 0, to: 5) |> fold.to_list |> should.equal([0, 1, 2, 3, 4])
+}
+
+pub fn range_counts_down_when_start_greater_than_stop_test() {
+  source.range(from: 5, to: 0) |> fold.to_list |> should.equal([5, 4, 3, 2, 1])
+}
+
+pub fn range_is_empty_when_start_equals_stop_test() {
+  source.range(from: 3, to: 3) |> fold.to_list |> should.equal([])
+}
+
+pub fn repeat_with_take_yields_n_copies_test() {
+  source.repeat(0)
+  |> stream.take(up_to: 3)
+  |> fold.to_list
+  |> should.equal([0, 0, 0])
+}
+
+pub fn iterate_with_take_yields_seeded_sequence_test() {
+  source.iterate(from: 1, with: fn(x) { x * 2 })
+  |> stream.take(up_to: 4)
+  |> fold.to_list
+  |> should.equal([1, 2, 4, 8])
+}
+
+pub fn unfold_halts_on_done_test() {
+  source.unfold(from: 0, with: fn(s) {
+    case s < 3 {
+      True -> Next(element: s, state: s + 1)
+      False -> Done
+    }
+  })
+  |> fold.to_list
+  |> should.equal([0, 1, 2])
+}
+
+pub fn unfold_immediate_done_yields_empty_test() {
+  source.unfold(from: 0, with: fn(_) { Done })
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn from_list_is_repeatable_test() {
+  let s = source.from_list([1, 2, 3])
+  fold.to_list(s) |> should.equal([1, 2, 3])
+  fold.to_list(s) |> should.equal([1, 2, 3])
+}
+
+pub fn range_is_repeatable_test() {
+  let s = source.range(from: 0, to: 3)
+  fold.to_list(s) |> should.equal([0, 1, 2])
+  fold.to_list(s) |> should.equal([0, 1, 2])
+}
+
+pub fn empty_is_repeatable_test() {
+  let s = source.empty()
+  fold.to_list(s) |> should.equal([])
+  fold.to_list(s) |> should.equal([])
+}
+
+pub fn once_is_repeatable_test() {
+  let s = source.once("x")
+  fold.to_list(s) |> should.equal(["x"])
+  fold.to_list(s) |> should.equal(["x"])
+}
+
+pub fn repeat_with_take_is_repeatable_test() {
+  let s = source.repeat(9) |> stream.take(up_to: 2)
+  fold.to_list(s) |> should.equal([9, 9])
+  fold.to_list(s) |> should.equal([9, 9])
+}
+
+pub fn iterate_with_take_is_repeatable_test() {
+  let s =
+    source.iterate(from: 0, with: fn(x) { x + 1 }) |> stream.take(up_to: 4)
+  fold.to_list(s) |> should.equal([0, 1, 2, 3])
+  fold.to_list(s) |> should.equal([0, 1, 2, 3])
+}
+
+pub fn unfold_is_repeatable_test() {
+  let s =
+    source.unfold(from: 0, with: fn(s) {
+      case s < 2 {
+        True -> Next(element: s, state: s + 1)
+        False -> Done
+      }
+    })
+  fold.to_list(s) |> should.equal([0, 1])
+  fold.to_list(s) |> should.equal([0, 1])
+}


### PR DESCRIPTION
## Summary

Phase 1 generation layer: introduce `datastream/source` with the seven Phase 1 constructors (`empty`, `once`, `from_list`, `range`, `repeat`, `iterate`, `unfold`). Together with `datastream/stream` (#26) and `datastream/fold` (#25) this completes the Phase 1 surface — callers now have a working generate / transform / consume pipeline.

## Design decisions

- **Adapters vs generative split.** `from_list` / `once` / `empty` adapt existing data; `range` / `repeat` / `iterate` / `unfold` build from a rule. Two predictable buckets keep the module small and the docs scannable.
- **`range` is stop-exclusive and step-less.** Step direction (`+1` / `-1`) is decided once at construction so the per-pull step is a single equality check. Step-by-`n` belongs in `iterate` / `unfold`, matching `gleam_stdlib`'s `list.range` shape.
- **`repeat` / `iterate` are infinite by design.** Termination is the caller's responsibility via `stream.take` / `take_while` / `fold.first`. The test suite verifies the `take`-paired bounded behaviour.
- **`source.unfold` re-exports `datastream.unfold`.** The internal substrate already has the right shape and laziness guarantees; `source.unfold` is a one-line wrapper so callers see a single entry point.
- **Repeatability is explicit.** Every constructor is built on `unfold`, which closes over an *initial* state. Each terminal call re-runs from that initial state, so the same `Stream` value can be drained twice and produce the same sequence — verified per-constructor with paired `to_list` calls.

## Tests

`just all` is green on Erlang and JavaScript (64 total: 46 prior + 18 new):

- the full Issue #3 case table for each constructor
- a re-execution test per constructor confirming the same `Stream` value yields the same sequence on a second `to_list`
- `repeat` / `iterate` are exercised through `stream.take` to confirm the bounded behaviour

Closes #3.