### PR TITLE
feat: extend source with Option/Result/Dict/BitArray adapters

### DIFF
--- a/src/datastream/source.gleam
+++ b/src/datastream/source.gleam
@@ -16,6 +16,8 @@
 //// on every terminal call: there is no implicit caching.
 
 import datastream.{type Step, type Stream, Done, Next}
+import gleam/dict.{type Dict}
+import gleam/option.{type Option, None, Some}
 
 /// A stream that yields no elements.
 pub fn empty() -> Stream(a) {
@@ -83,6 +85,48 @@ pub fn repeat(value: a) -> Stream(a) {
 pub fn iterate(from seed: a, with next: fn(a) -> a) -> Stream(a) {
   datastream.unfold(from: seed, with: fn(state) {
     Next(element: state, state: next(state))
+  })
+}
+
+/// Lift an `Option(a)` to a stream: `Some(x)` becomes a one-element
+/// stream, `None` becomes the empty stream.
+pub fn from_option(option: Option(a)) -> Stream(a) {
+  case option {
+    Some(value) -> once(value)
+    None -> empty()
+  }
+}
+
+/// Lift a `Result(a, e)` to a one-element `Stream(Result(a, e))`.
+///
+/// The `Error(e)` case is preserved as a single element rather than
+/// collapsed to the empty stream so the failure information survives
+/// through the pipeline. Callers that want to drop the error can chain
+/// a later `filter_map` or `collect_result`.
+pub fn from_result(result: Result(a, e)) -> Stream(Result(a, e)) {
+  once(result)
+}
+
+/// Yield each `#(key, value)` entry of a `Dict` exactly once.
+///
+/// Iteration order is not specified — it follows whatever order
+/// `dict.to_list` returns for the underlying target. Callers that need
+/// a deterministic order should funnel through `dict.to_list` and sort
+/// before constructing the stream.
+pub fn from_dict(d: Dict(k, v)) -> Stream(#(k, v)) {
+  d |> dict.to_list |> from_list
+}
+
+/// Yield each byte of a `BitArray` in order as an `Int` in `0..255`.
+///
+/// An empty `BitArray` produces the empty stream. This is the natural
+/// shape for the upcoming `binary` and `text.utf8_decode` work.
+pub fn from_bit_array(bytes: BitArray) -> Stream(Int) {
+  unfold(from: bytes, with: fn(remaining) {
+    case remaining {
+      <<byte:size(8), rest:bits>> -> Next(element: byte, state: rest)
+      _ -> Done
+    }
   })
 }
 

--- a/test/datastream/source_test.gleam
+++ b/test/datastream/source_test.gleam
@@ -2,6 +2,10 @@ import datastream.{Done, Next}
 import datastream/fold
 import datastream/source
 import datastream/stream
+import gleam/dict
+import gleam/list
+import gleam/option.{None, Some}
+import gleam/string
 import gleeunit
 import gleeunit/should
 
@@ -115,4 +119,67 @@ pub fn unfold_is_repeatable_test() {
     })
   fold.to_list(s) |> should.equal([0, 1])
   fold.to_list(s) |> should.equal([0, 1])
+}
+
+pub fn from_option_some_yields_one_element_test() {
+  source.from_option(Some(5)) |> fold.to_list |> should.equal([5])
+}
+
+pub fn from_option_none_yields_empty_test() {
+  source.from_option(None) |> fold.to_list |> should.equal([])
+}
+
+pub fn from_result_ok_yields_one_ok_test() {
+  source.from_result(Ok(7)) |> fold.to_list |> should.equal([Ok(7)])
+}
+
+pub fn from_result_error_yields_one_error_test() {
+  source.from_result(Error("nope"))
+  |> fold.to_list
+  |> should.equal([Error("nope")])
+}
+
+pub fn from_dict_empty_yields_empty_test() {
+  source.from_dict(dict.from_list([])) |> fold.to_list |> should.equal([])
+}
+
+pub fn from_dict_yields_each_entry_once_test() {
+  source.from_dict(dict.from_list([#("a", 1), #("b", 2)]))
+  |> fold.to_list
+  |> list.sort(by: fn(left, right) { string.compare(left.0, right.0) })
+  |> should.equal([#("a", 1), #("b", 2)])
+}
+
+pub fn from_bit_array_empty_yields_empty_test() {
+  source.from_bit_array(<<>>) |> fold.to_list |> should.equal([])
+}
+
+pub fn from_bit_array_yields_each_byte_test() {
+  source.from_bit_array(<<1, 2, 255>>)
+  |> fold.to_list
+  |> should.equal([1, 2, 255])
+}
+
+pub fn from_bit_array_preserves_zero_bytes_test() {
+  source.from_bit_array(<<0, 0, 0>>)
+  |> fold.to_list
+  |> should.equal([0, 0, 0])
+}
+
+pub fn from_option_is_repeatable_test() {
+  let s = source.from_option(Some(42))
+  fold.to_list(s) |> should.equal([42])
+  fold.to_list(s) |> should.equal([42])
+}
+
+pub fn from_result_is_repeatable_test() {
+  let s = source.from_result(Ok("v"))
+  fold.to_list(s) |> should.equal([Ok("v")])
+  fold.to_list(s) |> should.equal([Ok("v")])
+}
+
+pub fn from_bit_array_is_repeatable_test() {
+  let s = source.from_bit_array(<<10, 20>>)
+  fold.to_list(s) |> should.equal([10, 20])
+  fold.to_list(s) |> should.equal([10, 20])
 }


### PR DESCRIPTION
## Summary

Phase 2 starts with the remaining `from_*` adapters in `datastream/source` so callers can lift common stdlib values into a stream without writing `unfold` by hand. Adds `from_option`, `from_result`, `from_dict`, `from_bit_array`.

## Design decisions

- **`from_result` keeps `Error(e)` as a one-element stream** rather than collapsing it to empty. This preserves failure information at the source layer; callers that want to drop errors can chain `filter_map` / `collect_result` later.
- **`from_dict` does not promise iteration order.** Documented in the doc comment; the test sorts before asserting equality. Callers needing a deterministic order should funnel through `dict.to_list` and sort themselves.
- **`from_bit_array` uses bit pattern matching** (`<<byte:size(8), rest:bits>>`) so the per-pull step is a single match — works on both Erlang and JavaScript targets and matches the `binary` / `text.utf8_decode` callers that come in Phase 5.
- **No new internal substrate.** `from_option` / `from_result` reuse `once` and `empty`; `from_dict` reuses `from_list`; `from_bit_array` reuses `unfold`. Keeps the new surface as four thin adapters.

## Tests

`just all` is green on Erlang and JavaScript (76 total: 64 prior + 12 new):

- the full Issue #6 case table for each constructor
- a re-execution test per constructor (`from_option` / `from_result` / `from_bit_array`) confirming repeatability
- `from_dict_yields_each_entry_once` sorts before comparing because order is unspecified

Closes #6.