### PR TITLE
feat: extend stream with composition combinators

### DIFF
--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -15,6 +15,7 @@
 //// on infinite sources.
 
 import datastream.{type Stream, Done, Next}
+import gleam/option.{type Option, None, Some}
 
 /// Apply `f` to every element. Cardinality and order are preserved.
 pub fn map(over stream: Stream(a), with f: fn(a) -> b) -> Stream(b) {
@@ -174,6 +175,251 @@ fn append_step(state: Append(a)) -> Step(a, Append(a)) {
         Next(element, rest) ->
           Next(element: element, state: AppendInSecond(rest))
         Done -> Done
+      }
+  }
+}
+
+/// Apply `f` to each element and keep only the `Some(x)` results.
+///
+/// Use this rather than `filter` followed by `map` when the predicate
+/// and the transform are the same decision: returning `None` discards
+/// the element, `Some(x)` emits `x`. Errors should be carried as
+/// element-shaped values, not as the discarded path.
+pub fn filter_map(
+  over stream: Stream(a),
+  with f: fn(a) -> Option(b),
+) -> Stream(b) {
+  datastream.unfold(from: stream, with: fn(current) {
+    do_filter_map(current, f)
+  })
+}
+
+fn do_filter_map(stream: Stream(a), f: fn(a) -> Option(b)) -> Step(b, Stream(a)) {
+  case datastream.pull(stream) {
+    Next(element, rest) ->
+      case f(element) {
+        Some(value) -> Next(element: value, state: rest)
+        None -> do_filter_map(rest, f)
+      }
+    Done -> Done
+  }
+}
+
+/// Apply `f` to each element and concatenate the inner streams it
+/// produces.
+///
+/// Observationally equivalent to `map(f) |> flatten`. Pulls one inner
+/// stream at a time; the next inner stream is not constructed until the
+/// previous one is exhausted.
+pub fn flat_map(over stream: Stream(a), with f: fn(a) -> Stream(b)) -> Stream(b) {
+  datastream.unfold(from: FlatMapPullingOuter(stream), with: fn(state) {
+    flat_map_step(state, f)
+  })
+}
+
+type FlatMap(a, b) {
+  FlatMapPullingOuter(outer: Stream(a))
+  FlatMapPullingInner(inner: Stream(b), outer: Stream(a))
+}
+
+fn flat_map_step(
+  state: FlatMap(a, b),
+  f: fn(a) -> Stream(b),
+) -> Step(b, FlatMap(a, b)) {
+  case state {
+    FlatMapPullingOuter(outer) ->
+      case datastream.pull(outer) {
+        Next(element, outer_rest) ->
+          flat_map_step(FlatMapPullingInner(f(element), outer_rest), f)
+        Done -> Done
+      }
+    FlatMapPullingInner(inner, outer) ->
+      case datastream.pull(inner) {
+        Next(element, inner_rest) ->
+          Next(element: element, state: FlatMapPullingInner(inner_rest, outer))
+        Done -> flat_map_step(FlatMapPullingOuter(outer), f)
+      }
+  }
+}
+
+/// Flatten a stream of streams into a single stream.
+///
+/// `flatten(s)` is observationally equal to `flat_map(s, fn(x) { x })`.
+pub fn flatten(streams: Stream(Stream(a))) -> Stream(a) {
+  flat_map(over: streams, with: fn(inner) { inner })
+}
+
+/// Walk a `List(Stream(a))` in list order, yielding every element of
+/// every stream exactly once.
+///
+/// Prefer this over a long left-associative `append` chain: pull-based
+/// `append` chains can drift toward quadratic cost, while `concat`
+/// walks the list once and pulls each stream lazily.
+pub fn concat(streams: List(Stream(a))) -> Stream(a) {
+  datastream.unfold(from: streams, with: concat_step)
+}
+
+fn concat_step(remaining: List(Stream(a))) -> Step(a, List(Stream(a))) {
+  case remaining {
+    [] -> Done
+    [first, ..rest] ->
+      case datastream.pull(first) {
+        Next(element, first_rest) ->
+          Next(element: element, state: [first_rest, ..rest])
+        Done -> concat_step(rest)
+      }
+  }
+}
+
+/// Left-fold the stream, emitting one output per input.
+///
+/// The seed itself is NOT emitted, so `scan`'s output cardinality
+/// equals its input cardinality. On `[x1, x2, x3]` with seed `s0` and
+/// step `f`, the output is `[f(s0,x1), f(f(s0,x1),x2), f(f(f(s0,x1),x2),x3)]`.
+/// On empty input the output is empty.
+pub fn scan(
+  over stream: Stream(a),
+  from initial: b,
+  with step: fn(b, a) -> b,
+) -> Stream(b) {
+  datastream.unfold(from: #(initial, stream), with: fn(state) {
+    let #(acc, current) = state
+    case datastream.pull(current) {
+      Next(element, rest) -> {
+        let new_acc = step(acc, element)
+        Next(element: new_acc, state: #(new_acc, rest))
+      }
+      Done -> Done
+    }
+  })
+}
+
+/// Thread a state through the stream while emitting elements of a
+/// possibly different type.
+///
+/// `step(acc, x)` returns `#(new_acc, output)`; `new_acc` becomes the
+/// state for the next pull and `output` is emitted.
+pub fn map_accum(
+  over stream: Stream(a),
+  from initial: state,
+  with step: fn(state, a) -> #(state, b),
+) -> Stream(b) {
+  datastream.unfold(from: #(initial, stream), with: fn(s) {
+    let #(acc, current) = s
+    case datastream.pull(current) {
+      Next(element, rest) -> {
+        let #(new_acc, output) = step(acc, element)
+        Next(element: output, state: #(new_acc, rest))
+      }
+      Done -> Done
+    }
+  })
+}
+
+/// Pair-wise zip two streams; halts the moment either source halts.
+pub fn zip(left: Stream(a), right: Stream(b)) -> Stream(#(a, b)) {
+  zip_with(left, right, with: fn(l, r) { #(l, r) })
+}
+
+/// Combine two streams element-wise with `combiner`; halts the moment
+/// either source halts.
+pub fn zip_with(
+  left: Stream(a),
+  right: Stream(b),
+  with combiner: fn(a, b) -> c,
+) -> Stream(c) {
+  datastream.unfold(from: #(left, right), with: fn(state) {
+    let #(l, r) = state
+    case datastream.pull(l) {
+      Done -> Done
+      Next(left_element, left_rest) ->
+        case datastream.pull(r) {
+          Done -> Done
+          Next(right_element, right_rest) ->
+            Next(element: combiner(left_element, right_element), state: #(
+              left_rest,
+              right_rest,
+            ))
+        }
+    }
+  })
+}
+
+/// Insert `separator` between adjacent elements.
+///
+/// Empty and single-element streams are unchanged: `separator` is only
+/// emitted between two real elements, never at the start, end, or
+/// around an absent neighbour.
+pub fn intersperse(over stream: Stream(a), with separator: a) -> Stream(a) {
+  datastream.unfold(from: IntersperseInitial(stream), with: fn(state) {
+    intersperse_step(state, separator)
+  })
+}
+
+type Intersperse(a) {
+  IntersperseInitial(stream: Stream(a))
+  IntersperseAwaitingSep(stream: Stream(a))
+  IntersperseHasPending(pending: a, stream: Stream(a))
+}
+
+fn intersperse_step(
+  state: Intersperse(a),
+  separator: a,
+) -> Step(a, Intersperse(a)) {
+  case state {
+    IntersperseInitial(stream) ->
+      case datastream.pull(stream) {
+        Done -> Done
+        Next(first, rest) ->
+          Next(element: first, state: IntersperseAwaitingSep(rest))
+      }
+    IntersperseAwaitingSep(stream) ->
+      case datastream.pull(stream) {
+        Done -> Done
+        Next(next, rest) ->
+          Next(element: separator, state: IntersperseHasPending(next, rest))
+      }
+    IntersperseHasPending(pending, stream) ->
+      Next(element: pending, state: IntersperseAwaitingSep(stream))
+  }
+}
+
+/// Call `effect` once per element and re-emit the element unchanged.
+///
+/// Observation only: the element sequence is not altered. Allowed to
+/// perform effects (logging, counters, debug breakpoints), but pure
+/// pipelines should keep `tap` out of production paths.
+pub fn tap(over stream: Stream(a), with effect: fn(a) -> Nil) -> Stream(a) {
+  datastream.unfold(from: stream, with: fn(current) {
+    case datastream.pull(current) {
+      Next(element, rest) -> {
+        effect(element)
+        Next(element: element, state: rest)
+      }
+      Done -> Done
+    }
+  })
+}
+
+/// Collapse runs of `==`-equal adjacent values to a single occurrence.
+///
+/// Local only: values that appear far apart are kept. Full
+/// deduplication would require unbounded state, which the pull-based
+/// core does not maintain.
+pub fn dedupe_adjacent(stream: Stream(a)) -> Stream(a) {
+  datastream.unfold(from: #(None, stream), with: dedupe_step)
+}
+
+fn dedupe_step(
+  state: #(Option(a), Stream(a)),
+) -> Step(a, #(Option(a), Stream(a))) {
+  let #(last, current) = state
+  case datastream.pull(current) {
+    Done -> Done
+    Next(element, rest) ->
+      case last {
+        Some(prev) if prev == element -> dedupe_step(#(Some(prev), rest))
+        _ -> Next(element: element, state: #(Some(element), rest))
       }
   }
 }

--- a/test/datastream/stream_test.gleam
+++ b/test/datastream/stream_test.gleam
@@ -1,6 +1,8 @@
 import datastream.{Done, Next}
 import datastream/fold
+import datastream/source
 import datastream/stream
+import gleam/option.{None, Some}
 import gleeunit
 import gleeunit/should
 
@@ -185,4 +187,159 @@ pub fn map_invokes_callback_once_per_element_on_terminal_test() {
     |> stream.map(with: fn(x) { x + 100 })
 
   pipeline |> fold.to_list |> should.equal([101, 102, 103])
+}
+
+pub fn filter_map_keeps_some_drops_none_test() {
+  from_list([1, 2, 3])
+  |> stream.filter_map(with: fn(x) {
+    case x > 1 {
+      True -> Some(x * 10)
+      False -> None
+    }
+  })
+  |> fold.to_list
+  |> should.equal([20, 30])
+}
+
+pub fn filter_map_on_empty_yields_empty_test() {
+  from_list([])
+  |> stream.filter_map(with: fn(x) { Some(x) })
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn flat_map_concatenates_inner_streams_test() {
+  from_list([1, 2, 3])
+  |> stream.flat_map(with: fn(x) { from_list([x, x]) })
+  |> fold.to_list
+  |> should.equal([1, 1, 2, 2, 3, 3])
+}
+
+pub fn flat_map_with_all_empty_inners_yields_empty_test() {
+  from_list([1, 2])
+  |> stream.flat_map(with: fn(_) { source.empty() })
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn flatten_concatenates_inner_streams_test() {
+  from_list([from_list([1]), from_list([2, 3])])
+  |> stream.flatten
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+}
+
+pub fn flatten_is_observationally_flat_map_identity_test() {
+  let direct =
+    from_list([from_list([1, 2]), from_list([]), from_list([3])])
+    |> stream.flatten
+    |> fold.to_list
+  let via_flat_map =
+    from_list([from_list([1, 2]), from_list([]), from_list([3])])
+    |> stream.flat_map(with: fn(s) { s })
+    |> fold.to_list
+  direct |> should.equal(via_flat_map)
+}
+
+pub fn concat_walks_streams_in_list_order_test() {
+  stream.concat([from_list([1]), from_list([2, 3]), from_list([4])])
+  |> fold.to_list
+  |> should.equal([1, 2, 3, 4])
+}
+
+pub fn concat_of_empty_list_yields_empty_test() {
+  stream.concat([]) |> fold.to_list |> should.equal([])
+}
+
+pub fn scan_emits_running_accumulator_test() {
+  from_list([1, 2, 3, 4])
+  |> stream.scan(from: 0, with: fn(acc, x) { acc + x })
+  |> fold.to_list
+  |> should.equal([1, 3, 6, 10])
+}
+
+pub fn scan_does_not_emit_seed_on_empty_input_test() {
+  from_list([])
+  |> stream.scan(from: 0, with: fn(acc, x) { acc + x })
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn map_accum_threads_state_and_emits_output_test() {
+  from_list([10, 20, 30])
+  |> stream.map_accum(from: 0, with: fn(acc, x) {
+    let s = acc + x
+    #(s, s)
+  })
+  |> fold.to_list
+  |> should.equal([10, 30, 60])
+}
+
+pub fn zip_pairs_until_either_halts_test() {
+  stream.zip(from_list([1, 2, 3]), from_list(["a", "b"]))
+  |> fold.to_list
+  |> should.equal([#(1, "a"), #(2, "b")])
+}
+
+pub fn zip_with_empty_left_yields_empty_test() {
+  stream.zip(from_list([]), from_list([1, 2]))
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn zip_with_combiner_test() {
+  stream.zip_with(from_list([1, 2, 3]), from_list([10, 20, 30]), with: fn(a, b) {
+    a + b
+  })
+  |> fold.to_list
+  |> should.equal([11, 22, 33])
+}
+
+pub fn intersperse_inserts_separator_between_elements_test() {
+  from_list([1, 2, 3])
+  |> stream.intersperse(with: 0)
+  |> fold.to_list
+  |> should.equal([1, 0, 2, 0, 3])
+}
+
+pub fn intersperse_on_empty_yields_empty_test() {
+  from_list([])
+  |> stream.intersperse(with: 0)
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn intersperse_on_singleton_unchanged_test() {
+  from_list([1])
+  |> stream.intersperse(with: 0)
+  |> fold.to_list
+  |> should.equal([1])
+}
+
+pub fn tap_re_emits_elements_unchanged_test() {
+  from_list([1, 2, 3])
+  |> stream.tap(with: fn(_) { Nil })
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+}
+
+pub fn dedupe_adjacent_collapses_runs_test() {
+  from_list([1, 1, 2, 2, 2, 3, 1])
+  |> stream.dedupe_adjacent
+  |> fold.to_list
+  |> should.equal([1, 2, 3, 1])
+}
+
+pub fn dedupe_adjacent_on_empty_yields_empty_test() {
+  from_list([])
+  |> stream.dedupe_adjacent
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn dedupe_adjacent_keeps_non_adjacent_duplicates_test() {
+  from_list([1, 2, 1, 2, 1])
+  |> stream.dedupe_adjacent
+  |> fold.to_list
+  |> should.equal([1, 2, 1, 2, 1])
 }


### PR DESCRIPTION
## Summary

Phase 2 composition layer: add the eleven composition combinators in scope for #7 to `datastream/stream`. With this PR `stream` covers the full Phase 2 surface — single-stream transforms (#4), nesting (`flat_map`, `flatten`), multi-source joining (`concat`, `zip`, `zip_with`), state-carrying transforms (`scan`, `map_accum`), and the small utilities (`filter_map`, `intersperse`, `tap`, `dedupe_adjacent`).

## Design decisions

- **`flat_map` and `flatten` share semantics by construction.** `flatten` is defined as `flat_map(identity)`, so any future change to one applies to both. `flat_map` itself carries a private `FlatMap(a, b)` sum type to switch between pulling the outer stream and draining the current inner stream without constructing the next inner stream eagerly.
- **`concat` walks the list lazily.** State is `List(Stream(a))`; the head stream is stepped until `Done`, then the list advances. This avoids the quadratic cost a long left-associative `append` chain would incur in the pull-based core.
- **`scan` does NOT emit the seed.** Output cardinality equals input cardinality. Empty input → empty output. This matches the convention used by libraries that distinguish `scan` from `fold`.
- **`map_accum` separates state's type from the emitted element's type.** Right shape for prefix-sum-shaped problems where the accumulator and the output diverge.
- **`zip` is implemented in terms of `zip_with`.** The halt-when-either-source-halts logic lives in one place.
- **`intersperse` is a three-state machine** (`Initial` → `AwaitingSep` → `HasPending`) so the separator is emitted strictly between two real elements — never at the start, end, or around an absent neighbour. Empty and singleton streams are unchanged.
- **`tap` is observation only.** Re-emits the element unchanged after invoking the side-effect callback. The element sequence cannot diverge from the upstream.
- **`dedupe_adjacent` keeps `Option(a)` of the most recent emit.** Bounded state — non-adjacent duplicates are preserved by design (full deduplication would need unbounded state).

## Tests

`just all` is green on Erlang and JavaScript (97 total: 76 prior + 21 new):

- the full Issue #7 case table for each combinator
- a `flatten ≡ flat_map(identity)` equivalence test
- a `dedupe_adjacent` test confirming non-adjacent duplicates survive

`tap`'s side-effect assertion (recording call order via mutable state) is omitted: a portable cross-target way to record callbacks is non-trivial in Gleam, and the `to_list` equivalence already pins the element-sequence invariant. Happy to add a `@target(erlang)` process-dictionary-based test if desired.

Closes #7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 11 new stream operators for transforming, filtering, combining, and deduplicating data streams, including filter_map, flat_map, flatten, concat, scan, map_accum, zip, zip_with, intersperse, tap, and dedupe_adjacent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->