### PR TITLE
feat: extend fold with arithmetic and result helpers

### DIFF
--- a/src/datastream/fold.gleam
+++ b/src/datastream/fold.gleam
@@ -88,3 +88,126 @@ pub fn drain(stream: Stream(a)) -> Nil {
     Done -> Nil
   }
 }
+
+/// Return `True` only when `predicate` holds for every element.
+///
+/// Returns `True` on an empty stream and short-circuits on the first
+/// `False`, so `all` terminates on infinite sources whose first failure
+/// is reachable.
+pub fn all(over stream: Stream(a), satisfying predicate: fn(a) -> Bool) -> Bool {
+  case datastream.pull(stream) {
+    Done -> True
+    Next(element, rest) ->
+      case predicate(element) {
+        True -> all(over: rest, satisfying: predicate)
+        False -> False
+      }
+  }
+}
+
+/// Return `True` as soon as `predicate` holds for some element.
+///
+/// Returns `False` on an empty stream and short-circuits on the first
+/// `True`, so `any` terminates on infinite sources whose first match is
+/// reachable.
+pub fn any(over stream: Stream(a), satisfying predicate: fn(a) -> Bool) -> Bool {
+  case datastream.pull(stream) {
+    Done -> False
+    Next(element, rest) ->
+      case predicate(element) {
+        True -> True
+        False -> any(over: rest, satisfying: predicate)
+      }
+  }
+}
+
+/// Return the first element satisfying `predicate`, or `None`.
+///
+/// Stops pulling upstream the moment a match is observed.
+pub fn find(
+  in stream: Stream(a),
+  satisfying predicate: fn(a) -> Bool,
+) -> Option(a) {
+  case datastream.pull(stream) {
+    Done -> None
+    Next(element, rest) ->
+      case predicate(element) {
+        True -> Some(element)
+        False -> find(in: rest, satisfying: predicate)
+      }
+  }
+}
+
+/// Sum a stream of `Int`s. Returns `0` on the empty stream.
+pub fn sum_int(stream: Stream(Int)) -> Int {
+  fold(over: stream, from: 0, with: fn(acc, x) { acc + x })
+}
+
+/// Sum a stream of `Float`s. Returns `0.0` on the empty stream.
+pub fn sum_float(stream: Stream(Float)) -> Float {
+  fold(over: stream, from: 0.0, with: fn(acc, x) { acc +. x })
+}
+
+/// Multiply a stream of `Int`s. Returns `1` on the empty stream.
+pub fn product_int(stream: Stream(Int)) -> Int {
+  fold(over: stream, from: 1, with: fn(acc, x) { acc * x })
+}
+
+/// Walk a `Stream(Result(a, e))`, returning `Ok(values)` if every
+/// element is `Ok`, or short-circuiting with the first `Error(e)`.
+///
+/// Order is preserved: `Ok` values land in the returned list in source
+/// order. Pulling stops the moment the first `Error` is seen, so this
+/// is safe to use on infinite streams whose first failure is reachable.
+pub fn collect_result(stream: Stream(Result(a, e))) -> Result(List(a), e) {
+  do_collect_result(stream, [])
+}
+
+fn do_collect_result(
+  stream: Stream(Result(a, e)),
+  acc: List(a),
+) -> Result(List(a), e) {
+  case datastream.pull(stream) {
+    Done -> Ok(list.reverse(acc))
+    Next(Ok(value), rest) -> do_collect_result(rest, [value, ..acc])
+    Next(Error(e), _) -> Error(e)
+  }
+}
+
+/// Split a `Stream(Result(a, e))` into `#(oks, errors)`, both in
+/// source order.
+///
+/// Drives the stream to completion: this is a full-traversal reducer,
+/// not a short-circuiting one. Use `collect_result` when you want to
+/// stop on the first failure.
+pub fn partition_result(stream: Stream(Result(a, e))) -> #(List(a), List(e)) {
+  let #(oks, errs) =
+    fold(over: stream, from: #([], []), with: fn(acc, value) {
+      let #(oks, errs) = acc
+      case value {
+        Ok(ok) -> #([ok, ..oks], errs)
+        Error(err) -> #(oks, [err, ..errs])
+      }
+    })
+  #(list.reverse(oks), list.reverse(errs))
+}
+
+/// Route each element through `split` and accumulate the two outputs
+/// separately, both in source order.
+///
+/// `Ok(left)` lands in the first list, `Error(right)` in the second.
+/// Drives the stream to completion.
+pub fn partition_map(
+  over stream: Stream(a),
+  with split: fn(a) -> Result(b, c),
+) -> #(List(b), List(c)) {
+  let #(lefts, rights) =
+    fold(over: stream, from: #([], []), with: fn(acc, element) {
+      let #(lefts, rights) = acc
+      case split(element) {
+        Ok(left) -> #([left, ..lefts], rights)
+        Error(right) -> #(lefts, [right, ..rights])
+      }
+    })
+  #(list.reverse(lefts), list.reverse(rights))
+}

--- a/test/datastream/fold_test.gleam
+++ b/test/datastream/fold_test.gleam
@@ -112,3 +112,116 @@ pub fn reduce_on_empty_returns_none_test() {
 pub fn drain_returns_nil_test() {
   from_list([1, 2, 3]) |> fold.drain |> should.equal(Nil)
 }
+
+pub fn all_true_when_predicate_holds_for_every_element_test() {
+  from_list([1, 2, 3])
+  |> fold.all(satisfying: fn(x) { x > 0 })
+  |> should.equal(True)
+}
+
+pub fn all_false_on_first_failing_element_test() {
+  from_list([1, -2, 3])
+  |> fold.all(satisfying: fn(x) { x > 0 })
+  |> should.equal(False)
+}
+
+pub fn all_true_on_empty_test() {
+  from_list([])
+  |> fold.all(satisfying: fn(x) { x > 0 })
+  |> should.equal(True)
+}
+
+pub fn all_terminates_on_infinite_source_when_predicate_fails_test() {
+  repeat(0)
+  |> fold.all(satisfying: fn(x) { x > 0 })
+  |> should.equal(False)
+}
+
+pub fn any_true_when_some_element_matches_test() {
+  from_list([0, 0, 1])
+  |> fold.any(satisfying: fn(x) { x > 0 })
+  |> should.equal(True)
+}
+
+pub fn any_false_on_empty_test() {
+  from_list([])
+  |> fold.any(satisfying: fn(x) { x > 0 })
+  |> should.equal(False)
+}
+
+pub fn any_terminates_on_infinite_source_when_predicate_matches_test() {
+  repeat(1)
+  |> fold.any(satisfying: fn(x) { x > 0 })
+  |> should.equal(True)
+}
+
+pub fn find_returns_first_match_test() {
+  from_list([1, 2, 3])
+  |> fold.find(satisfying: fn(x) { x > 1 })
+  |> should.equal(Some(2))
+}
+
+pub fn find_returns_none_when_nothing_matches_test() {
+  from_list([1, 2, 3])
+  |> fold.find(satisfying: fn(x) { x > 99 })
+  |> should.equal(None)
+}
+
+pub fn sum_int_sums_elements_test() {
+  from_list([1, 2, 3]) |> fold.sum_int |> should.equal(6)
+}
+
+pub fn sum_int_on_empty_returns_zero_test() {
+  from_list([]) |> fold.sum_int |> should.equal(0)
+}
+
+pub fn sum_float_sums_elements_test() {
+  from_list([1.5, 2.5]) |> fold.sum_float |> should.equal(4.0)
+}
+
+pub fn sum_float_on_empty_returns_zero_point_zero_test() {
+  from_list([]) |> fold.sum_float |> should.equal(0.0)
+}
+
+pub fn product_int_multiplies_elements_test() {
+  from_list([1, 2, 3]) |> fold.product_int |> should.equal(6)
+}
+
+pub fn product_int_on_empty_returns_one_test() {
+  from_list([]) |> fold.product_int |> should.equal(1)
+}
+
+pub fn collect_result_all_ok_returns_ok_list_test() {
+  from_list([Ok(1), Ok(2), Ok(3)])
+  |> fold.collect_result
+  |> should.equal(Ok([1, 2, 3]))
+}
+
+pub fn collect_result_short_circuits_on_first_error_test() {
+  from_list([Ok(1), Error("x"), Ok(2)])
+  |> fold.collect_result
+  |> should.equal(Error("x"))
+}
+
+pub fn collect_result_on_empty_returns_ok_empty_test() {
+  from_list([])
+  |> fold.collect_result
+  |> should.equal(Ok([]))
+}
+
+pub fn partition_result_splits_oks_and_errors_in_order_test() {
+  from_list([Ok(1), Error("a"), Ok(2), Error("b")])
+  |> fold.partition_result
+  |> should.equal(#([1, 2], ["a", "b"]))
+}
+
+pub fn partition_map_routes_via_split_test() {
+  from_list([1, 2, 3, 4])
+  |> fold.partition_map(with: fn(x) {
+    case x % 2 == 0 {
+      True -> Ok(x)
+      False -> Error(x)
+    }
+  })
+  |> should.equal(#([2, 4], [1, 3]))
+}


### PR DESCRIPTION
## Summary

Phase 2 fold extension: add the nine remaining terminal reducers in scope for #8 — predicate checks (`all`, `any`, `find`), arithmetic shortcuts (`sum_int`, `sum_float`, `product_int`), and `Result`-aware shape converters (`collect_result`, `partition_result`, `partition_map`).

## Design decisions

- **`all` / `any` / `find` short-circuit by direct recursion.** Each function pulls one element, decides whether to commit, and recurses only when it must. `all([1, -2, 3], fn(x) { x > 0 })` halts on `-2`; `any([0, 0, 1], fn(x) { x > 0 })` halts on `1`. This is what makes them safe on infinite streams whose first deciding element is reachable.
- **Arithmetic helpers wrap `fold` with the identity element as seed.** `sum_int` → `fold(0, +)`, `sum_float` → `fold(0.0, +.)`, `product_int` → `fold(1, *)`. Empty input returns the identity, matching the natural mathematical convention.
- **`collect_result` short-circuits on the first `Error`.** A separate `do_collect_result(stream, acc)` keeps the recursion tail-call-shaped; on `Done` the accumulator is reversed once.
- **`partition_result` and `partition_map` are full-traversal reducers.** Splitting a stream into two lists requires consuming everything, so they live on the fold side rather than as middle combinators. Both accumulate via `fold` over a `#(list, list)` seed and reverse both lists once at the end.

## Tests

`just all` is green on Erlang and JavaScript (117 total: 97 prior + 20 new):

- the full Issue #8 case table for each function
- short-circuit termination tests for `all` / `any` against `repeat(...)` infinite sources

The Issue's pull-counting short-circuit assertion (using `tap` to record the number of pulls) is omitted — a portable cross-target way to record the call count without mutable cells is non-trivial. The `repeat` termination tests pin the same invariant: if `all` / `any` did not short-circuit, neither test would terminate. Happy to add a `@target(erlang)` process-dictionary-based test if the explicit pull count assertion is wanted.

Closes #8.