### PR TITLE
feat: add datastream/sink with effectful terminal consumers

### DIFF
--- a/src/datastream/sink.gleam
+++ b/src/datastream/sink.gleam
@@ -1,0 +1,57 @@
+//// Side-effecting terminal consumers over `Stream(a)`.
+////
+//// `sink` is the effectful half of the terminal layer; pure reductions
+//// live in `fold`. The split is intentional: a reader can tell from
+//// the import whether a function is pure (`fold`) or effectful (`sink`).
+////
+//// `fold.drain` already covers the "evaluate and discard" case, so a
+//// `sink.drain` synonym is intentionally omitted.
+
+import datastream.{type Stream, Done, Next}
+import gleam/io
+
+/// Drive the stream to completion, calling `effect` once per element
+/// in source order. Returns `Nil`.
+///
+/// Use this when the work the consumer does is infallible. For
+/// fallible consumers use `try_each`.
+pub fn each(over stream: Stream(a), with effect: fn(a) -> Nil) -> Nil {
+  case datastream.pull(stream) {
+    Done -> Nil
+    Next(element, rest) -> {
+      effect(element)
+      each(over: rest, with: effect)
+    }
+  }
+}
+
+/// Drive the stream while `effect` returns `Ok(Nil)`, halting on the
+/// first `Error(e)` and returning that error.
+///
+/// On all-`Ok` returns `Ok(Nil)`. On the first `Error(e)`, no further
+/// element is pulled from upstream — this also satisfies the
+/// resource-close contract for resource-backed sources (introduced in
+/// a later phase): an upstream that holds a handle will see its `Done`
+/// branch reached when the unconsumed continuation is dropped.
+pub fn try_each(
+  over stream: Stream(a),
+  with effect: fn(a) -> Result(Nil, e),
+) -> Result(Nil, e) {
+  case datastream.pull(stream) {
+    Done -> Ok(Nil)
+    Next(element, rest) ->
+      case effect(element) {
+        Ok(Nil) -> try_each(over: rest, with: effect)
+        Error(e) -> Error(e)
+      }
+  }
+}
+
+/// Print every element of `stream` followed by a newline to standard
+/// output, in source order.
+///
+/// Cross-target convenience over `gleam/io.println`. Target-aware
+/// sinks (file, socket, …) belong outside the cross-target core.
+pub fn println(stream: Stream(String)) -> Nil {
+  each(over: stream, with: io.println)
+}

--- a/test/datastream/sink_test.gleam
+++ b/test/datastream/sink_test.gleam
@@ -1,0 +1,91 @@
+import datastream.{Done, Next}
+import datastream/sink
+import datastream/source
+import gleeunit
+import gleeunit/should
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+fn from_list(list) {
+  datastream.unfold(from: list, with: fn(xs) {
+    case xs {
+      [] -> Done
+      [head, ..tail] -> Next(element: head, state: tail)
+    }
+  })
+}
+
+pub fn each_returns_nil_test() {
+  from_list([1, 2, 3])
+  |> sink.each(with: fn(_) { Nil })
+  |> should.equal(Nil)
+}
+
+pub fn each_on_empty_returns_nil_test() {
+  source.empty()
+  |> sink.each(with: fn(_) { Nil })
+  |> should.equal(Nil)
+}
+
+pub fn each_pulls_every_element_test() {
+  let stream =
+    datastream.unfold(from: 1, with: fn(s) {
+      case s <= 3 {
+        True -> Next(element: s, state: s + 1)
+        False -> Done
+      }
+    })
+
+  stream
+  |> sink.each(with: fn(_) { Nil })
+  |> should.equal(Nil)
+}
+
+pub fn try_each_all_ok_returns_ok_nil_test() {
+  from_list([1, 2, 3, 4])
+  |> sink.try_each(with: fn(_) { Ok(Nil) })
+  |> should.equal(Ok(Nil))
+}
+
+pub fn try_each_on_empty_returns_ok_nil_test() {
+  source.empty()
+  |> sink.try_each(with: fn(_) { Ok(Nil) })
+  |> should.equal(Ok(Nil))
+}
+
+pub fn try_each_short_circuits_on_first_error_test() {
+  from_list([1, 2, 3, 4])
+  |> sink.try_each(with: fn(x) {
+    case x < 3 {
+      True -> Ok(Nil)
+      False -> Error(x)
+    }
+  })
+  |> should.equal(Error(3))
+}
+
+pub fn try_each_does_not_visit_elements_after_error_test() {
+  let stream =
+    datastream.unfold(from: 1, with: fn(s) {
+      case s <= 4 {
+        True -> Next(element: s, state: s + 1)
+        False -> Done
+      }
+    })
+
+  stream
+  |> sink.try_each(with: fn(x) {
+    case x {
+      3 -> Error("stop")
+      4 -> panic as "try_each must not visit elements after the first Error"
+      _ -> Ok(Nil)
+    }
+  })
+  |> should.equal(Error("stop"))
+}
+
+pub fn println_runs_to_completion_on_empty_test() {
+  source.empty() |> sink.println |> should.equal(Nil)
+}


### PR DESCRIPTION
## Summary

Phase 2 wraps up with the effectful terminal layer: introduce `datastream/sink` so callers can drive a stream's elements into side effects without abusing `tap`. With this PR the Phase 2 core surface (#6, #7, #8, #9) is feature-complete.

## Design decisions

- **`sink` is separate from `fold`.** A reader can tell from the import whether a function is pure (`fold.foo`) or effectful (`sink.foo`). Mixing them in one module would lose that signal.
- **`try_each` honours the resource-close contract by construction.** When `effect` returns `Error(e)`, `try_each` simply returns; the unconsumed continuation goes out of scope. Resource-backed sources (introduced in Phase 4) will see their close branch via that drop, so `try_each` does not need to know about resources directly.
- **`println` is a one-liner over `gleam/io.println`.** Cross-target convenience only — target-aware sinks (file, socket, …) belong outside the cross-target core.
- **`sink.drain` is intentionally omitted** because `fold.drain` already covers "evaluate and discard". A synonym would split one operation across two modules.

## Tests

`just all` is green on Erlang and JavaScript (125 total: 117 prior + 8 new):

- `each` returns `Nil` on empty / non-empty / `unfold`-built streams
- `try_each` returns `Ok(Nil)` on all-`Ok` and on empty input
- `try_each` short-circuits on the first `Error`, with two angles: (a) the returned error value pins where the stop happened, and (b) a follow-up element installs `panic` and the test only passes because `try_each` never pulled it
- `println` smoke-tested on the empty stream so test output stays clean

The Issue's mutable-cell-based assertion of call order (`calls.push(x)`) is omitted — a portable cross-target way to record callbacks is non-trivial in Gleam, and the panic-after-error test pins the same short-circuit invariant. Happy to add a `@target(erlang)` process-dictionary-based test if the explicit recorded sequence is wanted.

Closes #9.