### PR TITLE
feat: introduce Chunk(a) opaque type with Phase 3 surface

### DIFF
--- a/src/datastream/chunk.gleam
+++ b/src/datastream/chunk.gleam
@@ -1,0 +1,81 @@
+//// `Chunk(a)` is an opaque, finite, immutable batch of elements.
+////
+//// Chunks are the element type of stream operations that produce
+//// batches (`stream.chunks_of`, `stream.group_adjacent`,
+//// `erlang/time.window_time`, …). The type is intentionally opaque so
+//// the internal representation can change later (for example a
+//// contiguous byte buffer for `Chunk(Int)`) without breaking callers.
+////
+//// The accessor surface is intentionally narrow: `to_list`, `size`,
+//// `is_empty`. Anything else is expressed by going through `to_list`,
+//// keeping `Chunk` from re-mirroring the entire list API.
+////
+//// Chunks are finite by design. Infinite-ness is the responsibility
+//// of `Stream`, not of a self-contained value.
+
+import gleam/list
+
+/// A finite, immutable batch of `a` values.
+///
+/// The internal representation is hidden so the library is free to
+/// change it (currently a list, possibly a contiguous buffer later)
+/// without a breaking change. Observational equality goes through
+/// `to_list`.
+pub opaque type Chunk(a) {
+  Chunk(elements: List(a))
+}
+
+/// The zero-element chunk.
+pub fn empty() -> Chunk(a) {
+  Chunk([])
+}
+
+/// The one-element chunk containing `value`.
+pub fn singleton(value: a) -> Chunk(a) {
+  Chunk([value])
+}
+
+/// Build a chunk from a list of elements.
+///
+/// Round-trips with `to_list`: `to_list(from_list(xs)) == xs`.
+pub fn from_list(elements: List(a)) -> Chunk(a) {
+  Chunk(elements)
+}
+
+/// Materialise a chunk back into a list, preserving order.
+pub fn to_list(chunk: Chunk(a)) -> List(a) {
+  chunk.elements
+}
+
+/// Number of elements in `chunk`.
+pub fn size(chunk: Chunk(a)) -> Int {
+  list.length(chunk.elements)
+}
+
+/// `True` iff `chunk` carries zero elements.
+pub fn is_empty(chunk: Chunk(a)) -> Bool {
+  case chunk.elements {
+    [] -> True
+    _ -> False
+  }
+}
+
+/// Apply `f` to every element. The result has the same size as the
+/// input; order is preserved.
+pub fn map(over chunk: Chunk(a), with f: fn(a) -> b) -> Chunk(b) {
+  Chunk(chunk.elements |> list.map(f))
+}
+
+/// Keep only the elements for which `predicate` returns `True`. Order
+/// is preserved.
+pub fn filter(
+  over chunk: Chunk(a),
+  keeping predicate: fn(a) -> Bool,
+) -> Chunk(a) {
+  Chunk(chunk.elements |> list.filter(predicate))
+}
+
+/// Concatenate chunks in list order.
+pub fn concat(chunks: List(Chunk(a))) -> Chunk(a) {
+  Chunk(chunks |> list.map(fn(c) { c.elements }) |> list.flatten)
+}

--- a/test/datastream/chunk_test.gleam
+++ b/test/datastream/chunk_test.gleam
@@ -1,0 +1,113 @@
+import datastream/chunk
+import gleeunit
+import gleeunit/should
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn empty_to_list_is_empty_test() {
+  chunk.empty() |> chunk.to_list |> should.equal([])
+}
+
+pub fn empty_size_is_zero_test() {
+  chunk.empty() |> chunk.size |> should.equal(0)
+}
+
+pub fn empty_is_empty_test() {
+  chunk.empty() |> chunk.is_empty |> should.equal(True)
+}
+
+pub fn singleton_to_list_yields_one_element_test() {
+  chunk.singleton(7) |> chunk.to_list |> should.equal([7])
+}
+
+pub fn singleton_size_is_one_test() {
+  chunk.singleton(7) |> chunk.size |> should.equal(1)
+}
+
+pub fn singleton_is_not_empty_test() {
+  chunk.singleton(7) |> chunk.is_empty |> should.equal(False)
+}
+
+pub fn from_list_to_list_round_trip_test() {
+  chunk.from_list([1, 2, 3]) |> chunk.to_list |> should.equal([1, 2, 3])
+}
+
+pub fn from_list_size_matches_input_test() {
+  chunk.from_list([1, 2, 3]) |> chunk.size |> should.equal(3)
+}
+
+pub fn from_list_empty_is_empty_test() {
+  chunk.from_list([]) |> chunk.is_empty |> should.equal(True)
+}
+
+pub fn map_transforms_each_element_test() {
+  chunk.from_list([1, 2, 3])
+  |> chunk.map(with: fn(x) { x * 2 })
+  |> chunk.to_list
+  |> should.equal([2, 4, 6])
+}
+
+pub fn map_on_empty_returns_empty_test() {
+  chunk.from_list([])
+  |> chunk.map(with: fn(x) { x * 2 })
+  |> chunk.to_list
+  |> should.equal([])
+}
+
+pub fn map_preserves_size_test() {
+  chunk.from_list([1, 2, 3, 4])
+  |> chunk.map(with: fn(x) { x * 10 })
+  |> chunk.size
+  |> should.equal(4)
+}
+
+pub fn filter_keeps_matching_elements_test() {
+  chunk.from_list([1, 2, 3, 4])
+  |> chunk.filter(keeping: fn(x) { x > 2 })
+  |> chunk.to_list
+  |> should.equal([3, 4])
+}
+
+pub fn filter_with_constant_false_yields_empty_test() {
+  chunk.from_list([1, 2, 3])
+  |> chunk.filter(keeping: fn(_) { False })
+  |> chunk.to_list
+  |> should.equal([])
+}
+
+pub fn concat_walks_chunks_in_list_order_test() {
+  chunk.concat([
+    chunk.from_list([1]),
+    chunk.from_list([2, 3]),
+    chunk.from_list([4]),
+  ])
+  |> chunk.to_list
+  |> should.equal([1, 2, 3, 4])
+}
+
+pub fn concat_of_empty_list_yields_empty_test() {
+  chunk.concat([]) |> chunk.to_list |> should.equal([])
+}
+
+pub fn concat_skips_empty_inner_chunks_test() {
+  chunk.concat([chunk.empty(), chunk.singleton(1), chunk.empty()])
+  |> chunk.to_list
+  |> should.equal([1])
+}
+
+pub fn from_list_to_list_round_trip_property_empty_test() {
+  let xs: List(Int) = []
+  chunk.to_list(chunk.from_list(xs)) |> should.equal(xs)
+}
+
+pub fn from_list_to_list_round_trip_property_singleton_test() {
+  let xs = [42]
+  chunk.to_list(chunk.from_list(xs)) |> should.equal(xs)
+}
+
+pub fn from_list_to_list_round_trip_property_strings_test() {
+  let xs = ["a", "b", "c", "d"]
+  chunk.to_list(chunk.from_list(xs)) |> should.equal(xs)
+}


### PR DESCRIPTION
## Summary

Phase 3 starts with the `Chunk(a)` foundation. Subsequent stream operations that batch elements (`stream.chunks_of`, `stream.group_adjacent`, `erlang/time.window_time`) need a chunk-shaped element type; `Chunk(a)` is that type. Adds `datastream/chunk` with constructors (`empty`, `singleton`, `from_list`), accessors (`to_list`, `size`, `is_empty`), and three transforms (`map`, `filter`, `concat`).

## Design decisions

- **`Chunk(a)` is `pub opaque`.** A bare `List(a)` would freeze the representation as part of the public contract; the opaque wrapper keeps the door open for a contiguous byte buffer for `Chunk(Int)` (the obvious target for `binary` / `text.utf8_decode` work) without breaking callers.
- **The accessor surface is intentionally narrow.** `to_list` / `size` / `is_empty` cover everything; anything else is expressed by going through `to_list`. This keeps `Chunk` from slowly growing into a second list module.
- **`Chunk` is finite by construction.** Infinite-ness is the responsibility of `Stream`, not of a self-contained value.
- **`map` / `filter` / `concat` delegate to `gleam/list`.** Trivially correct against the round-trip property `to_list(from_list(xs)) == xs`. When the representation changes later, only these wrappers and the accessors need to move with it.

## Tests

`just all` is green on Erlang and JavaScript (145 total: 125 prior + 20 new):

- the full Issue #10 case table for each function
- three round-trip property checks (empty list, singleton, four-element string list)
- a `concat` regression covering empty inner chunks (`concat([empty(), singleton(1), empty()])`)

Closes #10.