### PR TITLE
feat: add chunks_of and group_adjacent to stream

### DIFF
--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -15,6 +15,8 @@
 //// on infinite sources.
 
 import datastream.{type Stream, Done, Next}
+import datastream/chunk.{type Chunk}
+import gleam/list
 import gleam/option.{type Option, None, Some}
 
 /// Apply `f` to every element. Cardinality and order are preserved.
@@ -421,6 +423,155 @@ fn dedupe_step(
         Some(prev) if prev == element -> dedupe_step(#(Some(prev), rest))
         _ -> Next(element: element, state: #(Some(element), rest))
       }
+  }
+}
+
+/// Group adjacent elements into fixed-size chunks.
+///
+/// Each emitted chunk holds at most `size` elements, in source order.
+/// The trailing chunk MAY be smaller than `size` when the source length
+/// is not divisible — callers do not lose data when `length % size != 0`.
+/// `size < 1` is normalised to `1`, matching `gleam/list`'s behaviour
+/// for size-bounded splits.
+///
+/// Lazy: a chunk is only built when the downstream pulls.
+pub fn chunks_of(over stream: Stream(a), into size: Int) -> Stream(Chunk(a)) {
+  let normalised = case size < 1 {
+    True -> 1
+    False -> size
+  }
+  datastream.unfold(
+    from: ChunksActive(buffer: [], count: 0, source: stream),
+    with: fn(state) { chunks_of_step(state, normalised) },
+  )
+}
+
+type ChunksOf(a) {
+  ChunksActive(buffer: List(a), count: Int, source: Stream(a))
+  ChunksDrained
+}
+
+fn chunks_of_step(state: ChunksOf(a), size: Int) -> Step(Chunk(a), ChunksOf(a)) {
+  case state {
+    ChunksDrained -> Done
+    ChunksActive(buffer, count, source) ->
+      case datastream.pull(source) {
+        Done ->
+          case buffer {
+            [] -> Done
+            _ ->
+              Next(
+                element: chunk.from_list(list.reverse(buffer)),
+                state: ChunksDrained,
+              )
+          }
+        Next(element, rest) -> {
+          let new_count = count + 1
+          let new_buffer = [element, ..buffer]
+          case new_count >= size {
+            True ->
+              Next(
+                element: chunk.from_list(list.reverse(new_buffer)),
+                state: ChunksActive(buffer: [], count: 0, source: rest),
+              )
+            False ->
+              chunks_of_step(
+                ChunksActive(buffer: new_buffer, count: new_count, source: rest),
+                size,
+              )
+          }
+        }
+      }
+  }
+}
+
+/// Group consecutive elements that share `key(element)`.
+///
+/// Each emitted `#(k, chunk)` is one maximal run of adjacent elements
+/// with the same key, in source order. Non-adjacent occurrences of the
+/// same key are NOT merged: doing so would require unbounded state.
+///
+/// Lazy: a group is only built when the downstream pulls.
+pub fn group_adjacent(
+  over stream: Stream(a),
+  by key: fn(a) -> k,
+) -> Stream(#(k, Chunk(a))) {
+  datastream.unfold(
+    from: GroupActive(current_key: None, buffer: [], source: stream),
+    with: fn(state) { group_adjacent_step(state, key) },
+  )
+}
+
+type GroupAdjacent(a, k) {
+  GroupActive(current_key: Option(k), buffer: List(a), source: Stream(a))
+  GroupDrained
+}
+
+fn group_adjacent_step(
+  state: GroupAdjacent(a, k),
+  key: fn(a) -> k,
+) -> Step(#(k, Chunk(a)), GroupAdjacent(a, k)) {
+  case state {
+    GroupDrained -> Done
+    GroupActive(current_key, buffer, source) ->
+      case datastream.pull(source) {
+        Done -> group_adjacent_flush(current_key, buffer)
+        Next(element, rest) ->
+          group_adjacent_advance(current_key, buffer, element, rest, key)
+      }
+  }
+}
+
+fn group_adjacent_flush(
+  current_key: Option(k),
+  buffer: List(a),
+) -> Step(#(k, Chunk(a)), GroupAdjacent(a, k)) {
+  case current_key {
+    None -> Done
+    Some(k) ->
+      Next(
+        element: #(k, chunk.from_list(list.reverse(buffer))),
+        state: GroupDrained,
+      )
+  }
+}
+
+fn group_adjacent_advance(
+  current_key: Option(k),
+  buffer: List(a),
+  element: a,
+  rest: Stream(a),
+  key: fn(a) -> k,
+) -> Step(#(k, Chunk(a)), GroupAdjacent(a, k)) {
+  let element_key = key(element)
+  case current_key {
+    None ->
+      group_adjacent_step(
+        GroupActive(
+          current_key: Some(element_key),
+          buffer: [element],
+          source: rest,
+        ),
+        key,
+      )
+    Some(prev_key) if prev_key == element_key ->
+      group_adjacent_step(
+        GroupActive(
+          current_key: Some(element_key),
+          buffer: [element, ..buffer],
+          source: rest,
+        ),
+        key,
+      )
+    Some(prev_key) ->
+      Next(
+        element: #(prev_key, chunk.from_list(list.reverse(buffer))),
+        state: GroupActive(
+          current_key: Some(element_key),
+          buffer: [element],
+          source: rest,
+        ),
+      )
   }
 }
 

--- a/test/datastream/stream_test.gleam
+++ b/test/datastream/stream_test.gleam
@@ -1,8 +1,11 @@
-import datastream.{Done, Next}
+import datastream.{type Stream, Done, Next}
+import datastream/chunk.{type Chunk}
 import datastream/fold
 import datastream/source
 import datastream/stream
+import gleam/list
 import gleam/option.{None, Some}
+import gleam/string
 import gleeunit
 import gleeunit/should
 
@@ -342,4 +345,110 @@ pub fn dedupe_adjacent_keeps_non_adjacent_duplicates_test() {
   |> stream.dedupe_adjacent
   |> fold.to_list
   |> should.equal([1, 2, 1, 2, 1])
+}
+
+fn chunks_to_lists(stream_of_chunks) {
+  stream_of_chunks
+  |> fold.to_list
+  |> list.map(chunk.to_list)
+}
+
+fn groups_to_pairs(
+  stream_of_groups: Stream(#(k, Chunk(a))),
+) -> List(#(k, List(a))) {
+  stream_of_groups
+  |> fold.to_list
+  |> list.map(fn(pair) {
+    let #(key, c) = pair
+    #(key, chunk.to_list(c))
+  })
+}
+
+pub fn chunks_of_emits_full_size_then_remainder_test() {
+  from_list([1, 2, 3, 4, 5])
+  |> stream.chunks_of(into: 2)
+  |> chunks_to_lists
+  |> should.equal([[1, 2], [3, 4], [5]])
+}
+
+pub fn chunks_of_evenly_divisible_test() {
+  from_list([1, 2, 3, 4])
+  |> stream.chunks_of(into: 2)
+  |> chunks_to_lists
+  |> should.equal([[1, 2], [3, 4]])
+}
+
+pub fn chunks_of_on_empty_yields_no_chunks_test() {
+  from_list([])
+  |> stream.chunks_of(into: 3)
+  |> chunks_to_lists
+  |> should.equal([])
+}
+
+pub fn chunks_of_size_larger_than_source_test() {
+  from_list([1, 2, 3])
+  |> stream.chunks_of(into: 99)
+  |> chunks_to_lists
+  |> should.equal([[1, 2, 3]])
+}
+
+pub fn chunks_of_zero_normalises_to_one_test() {
+  from_list([1, 2, 3])
+  |> stream.chunks_of(into: 0)
+  |> chunks_to_lists
+  |> should.equal([[1], [2], [3]])
+}
+
+pub fn chunks_of_negative_normalises_to_one_test() {
+  from_list([1, 2, 3])
+  |> stream.chunks_of(into: -5)
+  |> chunks_to_lists
+  |> should.equal([[1], [2], [3]])
+}
+
+pub fn chunks_of_terminates_on_infinite_source_test() {
+  source.repeat(1)
+  |> stream.chunks_of(into: 2)
+  |> stream.take(up_to: 3)
+  |> chunks_to_lists
+  |> should.equal([[1, 1], [1, 1], [1, 1]])
+}
+
+pub fn group_adjacent_groups_runs_of_equal_test() {
+  from_list([1, 1, 2, 3, 3, 3])
+  |> stream.group_adjacent(by: fn(x) { x })
+  |> groups_to_pairs
+  |> should.equal([#(1, [1, 1]), #(2, [2]), #(3, [3, 3, 3])])
+}
+
+pub fn group_adjacent_by_key_function_test() {
+  let first_char = fn(s: String) -> String {
+    case string.first(s) {
+      Ok(c) -> c
+      Error(_) -> ""
+    }
+  }
+
+  from_list(["apple", "ant", "banana", "bee", "cat"])
+  |> stream.group_adjacent(by: first_char)
+  |> groups_to_pairs
+  |> should.equal([
+    #("a", ["apple", "ant"]),
+    #("b", ["banana", "bee"]),
+    #("c", ["cat"]),
+  ])
+}
+
+pub fn group_adjacent_on_empty_yields_no_groups_test() {
+  from_list([])
+  |> stream.group_adjacent(by: fn(x) { x })
+  |> groups_to_pairs
+  |> should.equal([])
+}
+
+pub fn group_adjacent_does_not_merge_non_adjacent_duplicates_test() {
+  from_list([1, 2, 1])
+  |> stream.group_adjacent(by: fn(x) { x })
+  |> groups_to_pairs
+  |> should.equal([#(1, [1]), #(2, [2]), #(1, [1])])
 }


### PR DESCRIPTION
## Summary

Phase 3 closes with the two chunk-producing combinators in `datastream/stream`. Both return `Stream(Chunk(a))` rather than `Stream(List(a))` so callers cannot couple themselves to the underlying list representation — `Chunk(a)` (#10) keeps the door open for a contiguous representation later.

## Design decisions

- **`chunks_of` flushes the trailing partial chunk via state transition.** Internal `ChunksOf` sum type carries `Active(buffer, count, source)` and a terminal `Drained`. On source `Done` with a non-empty buffer, the buffer becomes the last `Next` and the state transitions to `Drained`; subsequent pulls return `Done`. Callers do not lose data when `length % size != 0`.
- **`size < 1` normalises to `1` rather than panicking.** Matches `gleam/list`'s behaviour for size-bounded splits and keeps `chunks_of(0)` from being a footgun.
- **`group_adjacent` carries `Option(k)` for the running key** so the first element naturally seeds the run. Key transitions emit the completed run and start a new one in a single step. The decision logic was split into `group_adjacent_flush` (source done) and `group_adjacent_advance` (next element) helpers to keep nesting under glinter's `deep_nesting` threshold.
- **No look-back across the whole stream.** `group_adjacent` only merges *consecutive* elements with the same key; non-adjacent occurrences are emitted as separate groups. Full grouping would require unbounded state, which the pull-based core does not maintain.
- **Both are lazy.** A chunk is only built when the downstream pulls; the infinite-source termination test (`repeat(1) |> chunks_of(2) |> take(3)`) verifies the pipeline terminates as expected.

## Tests

`just all` is green on Erlang and JavaScript (156 total: 145 prior + 11 new):

- the full Issue #11 case table for both combinators
- the infinite-source termination test
- a key-function test using `string.first` to group strings by their first character

Closes #11.