### PR TITLE
feat: add source.resource with the spec close contract

### DIFF
--- a/src/datastream.gleam
+++ b/src/datastream.gleam
@@ -22,8 +22,14 @@
 /// free to change it (list-backed, function-backed, chunk-batched, …)
 /// without a breaking change. `==` / `!=` carry no specified meaning;
 /// observational equality is via terminal reduction.
+///
+/// Internally a `Stream(a)` carries both a `pull` function and a
+/// `close` function so the resource-safe sources from `source.resource`
+/// can be cleaned up on every termination path the library controls
+/// (normal end, downstream early-exit, early-exit folds, `try_each`
+/// failure). Pure `unfold`-built streams use a no-op `close`.
 pub opaque type Stream(a) {
-  Stream(pull: fn() -> Step(a, Stream(a)))
+  Stream(pull: fn() -> Step(a, Stream(a)), close: fn() -> Nil)
 }
 
 /// The result of pulling one element from a stream-like producer.
@@ -47,18 +53,93 @@ pub type Step(a, state) {
 /// The state type `s` is a private implementation detail of the
 /// constructed stream and never appears in the public surface.
 ///
+/// The constructed stream has a no-op `close`; resource-safe streams
+/// are built via `resource` instead.
+///
 /// This constructor is internal to the library — it is the substrate the
 /// `source`, `stream`, `fold`, and `sink` modules build on. It is not
 /// part of the public API.
 @internal
 pub fn unfold(from state: s, with step: fn(s) -> Step(a, s)) -> Stream(a) {
-  Stream(pull: fn() {
-    case step(state) {
-      Next(element, next_state) ->
-        Next(element, unfold(from: next_state, with: step))
-      Done -> Done
+  Stream(
+    pull: fn() {
+      case step(state) {
+        Next(element, next_state) ->
+          Next(element, unfold(from: next_state, with: step))
+        Done -> Done
+      }
+    },
+    close: noop,
+  )
+}
+
+/// Build a stream from explicit `pull` and `close` callbacks.
+///
+/// Used by combinators that need to forward the upstream's `close` to
+/// downstream consumers, and by `resource` to expose a real-world
+/// handle as a stream. The `close` callback is called by terminals or
+/// combinators that interrupt evaluation before the source returns
+/// `Done`; combinators that observe a `Done` already know the upstream
+/// has closed itself, so they MUST NOT call `close` again on that path.
+///
+/// Internal to the library.
+@internal
+pub fn make(
+  pull pull: fn() -> Step(a, Stream(a)),
+  close close: fn() -> Nil,
+) -> Stream(a) {
+  Stream(pull: pull, close: close)
+}
+
+/// Build a resource-backed stream.
+///
+/// `open` runs lazily on the first pull (NOT at construction), keeping
+/// stream construction side-effect-free. `next` is called once per
+/// pull; when it returns `Done`, `close` is invoked on the most recent
+/// state and the stream signals `Done`. When the stream is interrupted
+/// before `next` returns `Done` — for example by a `take` early-exit,
+/// a `first` terminal, or a `try_each` `Error` — the surrounding
+/// combinator / terminal calls the stream's `close` field, which closes
+/// the most recent state.
+///
+/// Each terminal call re-opens: a `Stream(a)` value is a pipeline
+/// definition, not a one-shot iterator.
+///
+/// Internal to the library — exposed publicly via `source.resource`.
+@internal
+pub fn resource(
+  open open: fn() -> s,
+  next next: fn(s) -> Step(a, s),
+  close close: fn(s) -> Nil,
+) -> Stream(a) {
+  Stream(
+    pull: fn() {
+      let initial = open()
+      pull_resource(initial, next, close)
+    },
+    close: noop,
+  )
+}
+
+fn pull_resource(
+  state: s,
+  next: fn(s) -> Step(a, s),
+  close: fn(s) -> Nil,
+) -> Step(a, Stream(a)) {
+  case next(state) {
+    Done -> {
+      close(state)
+      Done
     }
-  })
+    Next(element, next_state) ->
+      Next(
+        element,
+        Stream(
+          pull: fn() { pull_resource(next_state, next, close) },
+          close: fn() { close(next_state) },
+        ),
+      )
+  }
 }
 
 /// Pull one element from a stream.
@@ -72,4 +153,23 @@ pub fn unfold(from state: s, with step: fn(s) -> Step(a, s)) -> Stream(a) {
 @internal
 pub fn pull(stream: Stream(a)) -> Step(a, Stream(a)) {
   stream.pull()
+}
+
+/// Close a stream's underlying resource, if any.
+///
+/// Called by combinators / terminals on the *interruption* paths
+/// (early-exit, fail-fast). Streams that have already observed `Done`
+/// are closed by the source itself, so `close` MUST NOT be called by
+/// callers on that path.
+///
+/// For pure (`unfold`-built) streams `close` is a no-op.
+///
+/// Internal to the library.
+@internal
+pub fn close(stream: Stream(a)) -> Nil {
+  stream.close()
+}
+
+fn noop() -> Nil {
+  Nil
 }

--- a/src/datastream/fold.gleam
+++ b/src/datastream/fold.gleam
@@ -33,11 +33,15 @@ pub fn count(stream: Stream(a)) -> Int {
 
 /// Return the first element produced by the stream, if any.
 ///
-/// Pulls at most one element from upstream and stops; this makes `first`
-/// safe on infinite streams. Returns `None` if the stream is empty.
+/// Pulls at most one element from upstream, closes the unconsumed
+/// continuation, and stops. This makes `first` safe on infinite
+/// resource-backed streams. Returns `None` if the stream is empty.
 pub fn first(stream: Stream(a)) -> Option(a) {
   case datastream.pull(stream) {
-    Next(element, _) -> Some(element)
+    Next(element, rest) -> {
+      datastream.close(rest)
+      Some(element)
+    }
     Done -> None
   }
 }
@@ -100,7 +104,10 @@ pub fn all(over stream: Stream(a), satisfying predicate: fn(a) -> Bool) -> Bool 
     Next(element, rest) ->
       case predicate(element) {
         True -> all(over: rest, satisfying: predicate)
-        False -> False
+        False -> {
+          datastream.close(rest)
+          False
+        }
       }
   }
 }
@@ -115,7 +122,10 @@ pub fn any(over stream: Stream(a), satisfying predicate: fn(a) -> Bool) -> Bool 
     Done -> False
     Next(element, rest) ->
       case predicate(element) {
-        True -> True
+        True -> {
+          datastream.close(rest)
+          True
+        }
         False -> any(over: rest, satisfying: predicate)
       }
   }
@@ -132,7 +142,10 @@ pub fn find(
     Done -> None
     Next(element, rest) ->
       case predicate(element) {
-        True -> Some(element)
+        True -> {
+          datastream.close(rest)
+          Some(element)
+        }
         False -> find(in: rest, satisfying: predicate)
       }
   }
@@ -170,7 +183,10 @@ fn do_collect_result(
   case datastream.pull(stream) {
     Done -> Ok(list.reverse(acc))
     Next(Ok(value), rest) -> do_collect_result(rest, [value, ..acc])
-    Next(Error(e), _) -> Error(e)
+    Next(Error(e), rest) -> {
+      datastream.close(rest)
+      Error(e)
+    }
   }
 }
 

--- a/src/datastream/sink.gleam
+++ b/src/datastream/sink.gleam
@@ -42,7 +42,10 @@ pub fn try_each(
     Next(element, rest) ->
       case effect(element) {
         Ok(Nil) -> try_each(over: rest, with: effect)
-        Error(e) -> Error(e)
+        Error(e) -> {
+          datastream.close(rest)
+          Error(e)
+        }
       }
   }
 }

--- a/src/datastream/source.gleam
+++ b/src/datastream/source.gleam
@@ -143,3 +143,29 @@ pub fn unfold(
 ) -> Stream(a) {
   datastream.unfold(from: initial, with: step)
 }
+
+/// Build a resource-backed stream that opens lazily and closes
+/// deterministically.
+///
+/// `open` runs on the first pull (NOT at construction), so holding a
+/// `Stream` value never holds a real-world handle until evaluation
+/// begins. Each terminal call re-runs `open`: a `Stream` is a pipeline
+/// definition, not a one-shot iterator.
+///
+/// `close` is honoured on every termination path the library controls:
+/// normal end (when `next` returns `Done`), downstream early-exit
+/// (`stream.take`, `stream.take_while`), early-exit folds (`fold.first`,
+/// `fold.find`, `fold.any`, `fold.all`, `fold.collect_result`), and
+/// `sink.try_each` failure. Termination caused by user-code panicking
+/// is best-effort.
+///
+/// `close` returns `Nil`. Errors that happen at close time are not
+/// propagated through the terminal's return value; callers that must
+/// observe close failures should use a sink that owns the lifecycle.
+pub fn resource(
+  open open: fn() -> state,
+  next next: fn(state) -> Step(a, state),
+  close close: fn(state) -> Nil,
+) -> Stream(a) {
+  datastream.resource(open: open, next: next, close: close)
+}

--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -1,32 +1,44 @@
-//// Single-stream middle combinators over `Stream(a)`.
+//// Single-stream middle and composition combinators over `Stream(a)`.
 ////
-//// These are the lazy, order-preserving transforms whose names callers
-//// already know from list-style APIs: `map`, `filter`, `take`, `drop`,
-//// `take_while`, `drop_while`, and binary `append`. Multi-source
-//// composition (`flat_map`, `flatten`, `concat`, `scan`, …) lives in a
-//// later issue.
-////
-//// Building a pipeline with these combinators triggers no user
-//// callbacks. Callbacks fire only when a terminal in `fold` or `sink`
-//// pulls the result.
+//// All combinators are lazy and order-preserving (unless documented
+//// otherwise). Building a pipeline with these combinators triggers no
+//// user callbacks; callbacks fire only when a terminal in `fold` or
+//// `sink` pulls the result.
 ////
 //// Early-exit combinators (`take`, `take_while`) stop pulling upstream
-//// the moment their result is determined, which is what makes them safe
-//// on infinite sources.
+//// the moment their result is determined, which is what makes them
+//// safe on infinite sources.
+////
+//// Every combinator here forwards the upstream's `close` callback so
+//// resource-backed streams (`source.resource`) are released on every
+//// termination path. Combinators that observe a `Done` from the
+//// upstream do NOT call `close` again — the source closed itself when
+//// it returned `Done`. Combinators that hold multiple upstreams open
+//// at once close them in the order specified in the spec
+//// (`flat_map`: inner before outer; `zip`: right before left).
 
-import datastream.{type Stream, Done, Next}
+import datastream.{type Step, type Stream, Done, Next}
 import datastream/chunk.{type Chunk}
 import gleam/list
 import gleam/option.{type Option, None, Some}
 
+fn noop() -> Nil {
+  Nil
+}
+
+// --- single-stream combinators ----------------------------------------------
+
 /// Apply `f` to every element. Cardinality and order are preserved.
 pub fn map(over stream: Stream(a), with f: fn(a) -> b) -> Stream(b) {
-  datastream.unfold(from: stream, with: fn(current) {
-    case datastream.pull(current) {
-      Next(element, rest) -> Next(element: f(element), state: rest)
-      Done -> Done
-    }
-  })
+  datastream.make(
+    pull: fn() {
+      case datastream.pull(stream) {
+        Next(element, rest) -> Next(f(element), map(over: rest, with: f))
+        Done -> Done
+      }
+    },
+    close: fn() { datastream.close(stream) },
+  )
 }
 
 /// Keep only the elements for which `predicate` returns `True`.
@@ -36,17 +48,20 @@ pub fn filter(
   over stream: Stream(a),
   keeping predicate: fn(a) -> Bool,
 ) -> Stream(a) {
-  datastream.unfold(from: stream, with: fn(current) {
-    do_filter(current, predicate)
+  datastream.make(pull: fn() { filter_pull(stream, predicate) }, close: fn() {
+    datastream.close(stream)
   })
 }
 
-fn do_filter(stream: Stream(a), predicate: fn(a) -> Bool) -> Step(a, Stream(a)) {
+fn filter_pull(
+  stream: Stream(a),
+  predicate: fn(a) -> Bool,
+) -> Step(a, Stream(a)) {
   case datastream.pull(stream) {
     Next(element, rest) ->
       case predicate(element) {
-        True -> Next(element: element, state: rest)
-        False -> do_filter(rest, predicate)
+        True -> Next(element, filter(over: rest, keeping: predicate))
+        False -> filter_pull(rest, predicate)
       }
     Done -> Done
   }
@@ -54,41 +69,45 @@ fn do_filter(stream: Stream(a), predicate: fn(a) -> Bool) -> Step(a, Stream(a)) 
 
 /// Yield at most the first `n` elements; `n <= 0` yields the empty stream.
 ///
-/// Stops pulling upstream the moment the `n`th element has been emitted,
-/// which is what makes `take` safe on infinite sources.
+/// Stops pulling upstream the moment the `n`th element has been
+/// emitted, and closes the upstream on that early exit. This is what
+/// makes `take` safe on infinite resource-backed sources.
 pub fn take(from stream: Stream(a), up_to n: Int) -> Stream(a) {
-  datastream.unfold(from: #(n, stream), with: fn(state) {
-    let #(remaining, current) = state
-    case remaining <= 0 {
-      True -> Done
-      False ->
-        case datastream.pull(current) {
-          Next(element, rest) ->
-            Next(element: element, state: #(remaining - 1, rest))
-          Done -> Done
+  datastream.make(
+    pull: fn() {
+      case n <= 0 {
+        True -> {
+          datastream.close(stream)
+          Done
         }
-    }
-  })
+        False ->
+          case datastream.pull(stream) {
+            Next(element, rest) -> Next(element, take(from: rest, up_to: n - 1))
+            Done -> Done
+          }
+      }
+    },
+    close: fn() { datastream.close(stream) },
+  )
 }
 
 /// Discard the first `n` elements; `n <= 0` is the identity.
 pub fn drop(from stream: Stream(a), up_to n: Int) -> Stream(a) {
-  datastream.unfold(from: #(n, stream), with: fn(state) {
-    let #(remaining, current) = state
-    do_drop(remaining, current)
+  datastream.make(pull: fn() { drop_pull(stream, n) }, close: fn() {
+    datastream.close(stream)
   })
 }
 
-fn do_drop(remaining: Int, stream: Stream(a)) -> Step(a, #(Int, Stream(a))) {
-  case remaining <= 0 {
+fn drop_pull(stream: Stream(a), n: Int) -> Step(a, Stream(a)) {
+  case n <= 0 {
     True ->
       case datastream.pull(stream) {
-        Next(element, rest) -> Next(element: element, state: #(0, rest))
+        Next(element, rest) -> Next(element, drop(from: rest, up_to: 0))
         Done -> Done
       }
     False ->
       case datastream.pull(stream) {
-        Next(_, rest) -> do_drop(remaining - 1, rest)
+        Next(_, rest) -> drop_pull(rest, n - 1)
         Done -> Done
       }
   }
@@ -96,23 +115,29 @@ fn do_drop(remaining: Int, stream: Stream(a)) -> Step(a, #(Int, Stream(a))) {
 
 /// Yield the longest prefix where `predicate` holds, then stop.
 ///
-/// Stops pulling upstream as soon as `predicate` returns `False`, so
-/// `take_while` terminates on infinite sources whose prefix eventually
-/// fails the predicate.
+/// Stops pulling upstream and closes it as soon as `predicate` returns
+/// `False`, so `take_while` terminates on infinite resource-backed
+/// sources whose prefix eventually fails the predicate.
 pub fn take_while(
   in stream: Stream(a),
   satisfying predicate: fn(a) -> Bool,
 ) -> Stream(a) {
-  datastream.unfold(from: stream, with: fn(current) {
-    case datastream.pull(current) {
-      Next(element, rest) ->
-        case predicate(element) {
-          True -> Next(element: element, state: rest)
-          False -> Done
-        }
-      Done -> Done
-    }
-  })
+  datastream.make(
+    pull: fn() {
+      case datastream.pull(stream) {
+        Next(element, rest) ->
+          case predicate(element) {
+            True -> Next(element, take_while(in: rest, satisfying: predicate))
+            False -> {
+              datastream.close(rest)
+              Done
+            }
+          }
+        Done -> Done
+      }
+    },
+    close: fn() { datastream.close(stream) },
+  )
 }
 
 /// Discard the longest prefix where `predicate` holds, then yield the rest.
@@ -120,88 +145,85 @@ pub fn drop_while(
   in stream: Stream(a),
   satisfying predicate: fn(a) -> Bool,
 ) -> Stream(a) {
-  datastream.unfold(from: DropWhilePending(stream), with: fn(state) {
-    drop_while_step(state, predicate)
-  })
+  datastream.make(
+    pull: fn() { drop_while_pull(stream, predicate) },
+    close: fn() { datastream.close(stream) },
+  )
 }
 
-type DropWhile(a) {
-  DropWhilePending(stream: Stream(a))
-  DropWhileSettled(stream: Stream(a))
-}
-
-fn drop_while_step(
-  state: DropWhile(a),
+fn drop_while_pull(
+  stream: Stream(a),
   predicate: fn(a) -> Bool,
-) -> Step(a, DropWhile(a)) {
-  case state {
-    DropWhilePending(stream) ->
-      case datastream.pull(stream) {
-        Next(element, rest) ->
-          case predicate(element) {
-            True -> drop_while_step(DropWhilePending(rest), predicate)
-            False -> Next(element: element, state: DropWhileSettled(rest))
-          }
-        Done -> Done
+) -> Step(a, Stream(a)) {
+  case datastream.pull(stream) {
+    Next(element, rest) ->
+      case predicate(element) {
+        True -> drop_while_pull(rest, predicate)
+        False -> Next(element, identity(rest))
       }
-    DropWhileSettled(stream) ->
-      case datastream.pull(stream) {
-        Next(element, rest) ->
-          Next(element: element, state: DropWhileSettled(rest))
-        Done -> Done
-      }
+    Done -> Done
   }
+}
+
+fn identity(stream: Stream(a)) -> Stream(a) {
+  datastream.make(
+    pull: fn() {
+      case datastream.pull(stream) {
+        Next(element, rest) -> Next(element, identity(rest))
+        Done -> Done
+      }
+    },
+    close: fn() { datastream.close(stream) },
+  )
 }
 
 /// Yield all of `first`, then all of `second`. If `first` is infinite,
-/// `second` is never reached.
+/// `second` is never opened.
+///
+/// Honours the spec close ordering: `second` is opened only after
+/// `first` returns `Done` (and so has already closed itself); on early
+/// exit before `first` finishes, `second` is never opened.
 pub fn append(first: Stream(a), second: Stream(a)) -> Stream(a) {
-  datastream.unfold(from: AppendInFirst(first, second), with: append_step)
+  datastream.make(pull: fn() { append_pull(first, second) }, close: fn() {
+    datastream.close(first)
+  })
 }
 
-type Append(a) {
-  AppendInFirst(first: Stream(a), second: Stream(a))
-  AppendInSecond(stream: Stream(a))
-}
-
-fn append_step(state: Append(a)) -> Step(a, Append(a)) {
-  case state {
-    AppendInFirst(first, second) ->
-      case datastream.pull(first) {
-        Next(element, rest) ->
-          Next(element: element, state: AppendInFirst(rest, second))
-        Done -> append_step(AppendInSecond(second))
-      }
-    AppendInSecond(stream) ->
-      case datastream.pull(stream) {
-        Next(element, rest) ->
-          Next(element: element, state: AppendInSecond(rest))
-        Done -> Done
-      }
+fn append_pull(first: Stream(a), second: Stream(a)) -> Step(a, Stream(a)) {
+  case datastream.pull(first) {
+    Next(element, rest) -> Next(element, append(rest, second))
+    Done -> append_pull_second(second)
   }
 }
 
+fn append_pull_second(stream: Stream(a)) -> Step(a, Stream(a)) {
+  case datastream.pull(stream) {
+    Next(element, rest) -> Next(element, identity(rest))
+    Done -> Done
+  }
+}
+
+// --- composition combinators ------------------------------------------------
+
 /// Apply `f` to each element and keep only the `Some(x)` results.
-///
-/// Use this rather than `filter` followed by `map` when the predicate
-/// and the transform are the same decision: returning `None` discards
-/// the element, `Some(x)` emits `x`. Errors should be carried as
-/// element-shaped values, not as the discarded path.
 pub fn filter_map(
   over stream: Stream(a),
   with f: fn(a) -> Option(b),
 ) -> Stream(b) {
-  datastream.unfold(from: stream, with: fn(current) {
-    do_filter_map(current, f)
+  datastream.make(pull: fn() { filter_map_pull(stream, f) }, close: fn() {
+    datastream.close(stream)
   })
 }
 
-fn do_filter_map(stream: Stream(a), f: fn(a) -> Option(b)) -> Step(b, Stream(a)) {
+fn filter_map_pull(
+  stream: Stream(a),
+  f: fn(a) -> Option(b),
+) -> Step(b, Stream(b)) {
   case datastream.pull(stream) {
     Next(element, rest) ->
       case f(element) {
-        Some(value) -> Next(element: value, state: rest)
-        None -> do_filter_map(rest, f)
+        Some(value) -> Next(value, filter_map(over: rest, with: f))
+        None -> filter_map_pull(rest, f)
       }
     Done -> Done
   }
@@ -210,370 +232,381 @@ fn do_filter_map(stream: Stream(a), f: fn(a) -> Option(b)) -> Step(b, Stream(a))
 /// Apply `f` to each element and concatenate the inner streams it
 /// produces.
 ///
-/// Observationally equivalent to `map(f) |> flatten`. Pulls one inner
-/// stream at a time; the next inner stream is not constructed until the
-/// previous one is exhausted.
+/// Pulls one inner stream at a time; the next inner stream is not
+/// constructed until the previous one is exhausted. On early exit
+/// before the outer is `Done`, the active inner is closed first, then
+/// the outer.
 pub fn flat_map(over stream: Stream(a), with f: fn(a) -> Stream(b)) -> Stream(b) {
-  datastream.unfold(from: FlatMapPullingOuter(stream), with: fn(state) {
-    flat_map_step(state, f)
+  flat_map_outer(stream, f)
+}
+
+fn flat_map_outer(outer: Stream(a), f: fn(a) -> Stream(b)) -> Stream(b) {
+  datastream.make(pull: fn() { flat_map_outer_pull(outer, f) }, close: fn() {
+    datastream.close(outer)
   })
 }
 
-type FlatMap(a, b) {
-  FlatMapPullingOuter(outer: Stream(a))
-  FlatMapPullingInner(inner: Stream(b), outer: Stream(a))
+fn flat_map_outer_pull(
+  outer: Stream(a),
+  f: fn(a) -> Stream(b),
+) -> Step(b, Stream(b)) {
+  case datastream.pull(outer) {
+    Done -> Done
+    Next(element, outer_rest) -> flat_map_inner_pull(f(element), outer_rest, f)
+  }
 }
 
-fn flat_map_step(
-  state: FlatMap(a, b),
+fn flat_map_inner(
+  inner: Stream(b),
+  outer: Stream(a),
   f: fn(a) -> Stream(b),
-) -> Step(b, FlatMap(a, b)) {
-  case state {
-    FlatMapPullingOuter(outer) ->
-      case datastream.pull(outer) {
-        Next(element, outer_rest) ->
-          flat_map_step(FlatMapPullingInner(f(element), outer_rest), f)
-        Done -> Done
-      }
-    FlatMapPullingInner(inner, outer) ->
-      case datastream.pull(inner) {
-        Next(element, inner_rest) ->
-          Next(element: element, state: FlatMapPullingInner(inner_rest, outer))
-        Done -> flat_map_step(FlatMapPullingOuter(outer), f)
-      }
+) -> Stream(b) {
+  datastream.make(
+    pull: fn() { flat_map_inner_pull(inner, outer, f) },
+    close: fn() {
+      datastream.close(inner)
+      datastream.close(outer)
+    },
+  )
+}
+
+fn flat_map_inner_pull(
+  inner: Stream(b),
+  outer: Stream(a),
+  f: fn(a) -> Stream(b),
+) -> Step(b, Stream(b)) {
+  case datastream.pull(inner) {
+    Next(value, inner_rest) -> Next(value, flat_map_inner(inner_rest, outer, f))
+    Done -> flat_map_outer_pull(outer, f)
   }
 }
 
 /// Flatten a stream of streams into a single stream.
 ///
-/// `flatten(s)` is observationally equal to `flat_map(s, fn(x) { x })`.
+/// Equivalent to `flat_map(s, fn(x) { x })`; the close ordering is the
+/// same.
 pub fn flatten(streams: Stream(Stream(a))) -> Stream(a) {
   flat_map(over: streams, with: fn(inner) { inner })
 }
 
 /// Walk a `List(Stream(a))` in list order, yielding every element of
-/// every stream exactly once.
+/// every stream.
 ///
-/// Prefer this over a long left-associative `append` chain: pull-based
-/// `append` chains can drift toward quadratic cost, while `concat`
-/// walks the list once and pulls each stream lazily.
+/// Each inner stream is closed (by reaching its own `Done`) before the
+/// next one is opened. On early exit, the active stream is closed.
 pub fn concat(streams: List(Stream(a))) -> Stream(a) {
-  datastream.unfold(from: streams, with: concat_step)
+  case streams {
+    [] -> empty_stream()
+    [first, ..rest] -> concat_active(first, rest)
+  }
 }
 
-fn concat_step(remaining: List(Stream(a))) -> Step(a, List(Stream(a))) {
-  case remaining {
-    [] -> Done
-    [first, ..rest] ->
-      case datastream.pull(first) {
-        Next(element, first_rest) ->
-          Next(element: element, state: [first_rest, ..rest])
-        Done -> concat_step(rest)
+fn concat_active(active: Stream(a), remaining: List(Stream(a))) -> Stream(a) {
+  datastream.make(pull: fn() { concat_pull(active, remaining) }, close: fn() {
+    datastream.close(active)
+  })
+}
+
+fn concat_pull(
+  active: Stream(a),
+  remaining: List(Stream(a)),
+) -> Step(a, Stream(a)) {
+  case datastream.pull(active) {
+    Next(element, rest) -> Next(element, concat_active(rest, remaining))
+    Done ->
+      case remaining {
+        [] -> Done
+        [next, ..rest] -> concat_pull(next, rest)
       }
   }
 }
 
+fn empty_stream() -> Stream(a) {
+  datastream.make(pull: fn() { Done }, close: noop)
+}
+
 /// Left-fold the stream, emitting one output per input.
 ///
-/// The seed itself is NOT emitted, so `scan`'s output cardinality
-/// equals its input cardinality. On `[x1, x2, x3]` with seed `s0` and
-/// step `f`, the output is `[f(s0,x1), f(f(s0,x1),x2), f(f(f(s0,x1),x2),x3)]`.
-/// On empty input the output is empty.
+/// The seed itself is NOT emitted, so output cardinality equals input
+/// cardinality. On empty input the output is empty.
 pub fn scan(
   over stream: Stream(a),
   from initial: b,
   with step: fn(b, a) -> b,
 ) -> Stream(b) {
-  datastream.unfold(from: #(initial, stream), with: fn(state) {
-    let #(acc, current) = state
-    case datastream.pull(current) {
-      Next(element, rest) -> {
-        let new_acc = step(acc, element)
-        Next(element: new_acc, state: #(new_acc, rest))
+  datastream.make(
+    pull: fn() {
+      case datastream.pull(stream) {
+        Next(element, rest) -> {
+          let new_acc = step(initial, element)
+          Next(new_acc, scan(over: rest, from: new_acc, with: step))
+        }
+        Done -> Done
       }
-      Done -> Done
-    }
-  })
+    },
+    close: fn() { datastream.close(stream) },
+  )
 }
 
 /// Thread a state through the stream while emitting elements of a
 /// possibly different type.
-///
-/// `step(acc, x)` returns `#(new_acc, output)`; `new_acc` becomes the
-/// state for the next pull and `output` is emitted.
 pub fn map_accum(
   over stream: Stream(a),
   from initial: state,
   with step: fn(state, a) -> #(state, b),
 ) -> Stream(b) {
-  datastream.unfold(from: #(initial, stream), with: fn(s) {
-    let #(acc, current) = s
-    case datastream.pull(current) {
-      Next(element, rest) -> {
-        let #(new_acc, output) = step(acc, element)
-        Next(element: output, state: #(new_acc, rest))
+  datastream.make(
+    pull: fn() {
+      case datastream.pull(stream) {
+        Next(element, rest) -> {
+          let #(new_acc, output) = step(initial, element)
+          Next(output, map_accum(over: rest, from: new_acc, with: step))
+        }
+        Done -> Done
       }
-      Done -> Done
-    }
-  })
+    },
+    close: fn() { datastream.close(stream) },
+  )
 }
 
 /// Pair-wise zip two streams; halts the moment either source halts.
+///
+/// Both upstreams may be open at once. On halt, closes `right` first,
+/// then `left`, matching the spec.
 pub fn zip(left: Stream(a), right: Stream(b)) -> Stream(#(a, b)) {
   zip_with(left, right, with: fn(l, r) { #(l, r) })
 }
 
 /// Combine two streams element-wise with `combiner`; halts the moment
 /// either source halts.
+///
+/// Same close ordering as `zip`: right then left.
 pub fn zip_with(
   left: Stream(a),
   right: Stream(b),
   with combiner: fn(a, b) -> c,
 ) -> Stream(c) {
-  datastream.unfold(from: #(left, right), with: fn(state) {
-    let #(l, r) = state
-    case datastream.pull(l) {
-      Done -> Done
-      Next(left_element, left_rest) ->
-        case datastream.pull(r) {
-          Done -> Done
-          Next(right_element, right_rest) ->
-            Next(element: combiner(left_element, right_element), state: #(
-              left_rest,
-              right_rest,
-            ))
-        }
-    }
+  datastream.make(pull: fn() { zip_pull(left, right, combiner) }, close: fn() {
+    datastream.close(right)
+    datastream.close(left)
   })
+}
+
+fn zip_pull(
+  left: Stream(a),
+  right: Stream(b),
+  combiner: fn(a, b) -> c,
+) -> Step(c, Stream(c)) {
+  case datastream.pull(left) {
+    Done -> {
+      datastream.close(right)
+      Done
+    }
+    Next(left_element, left_rest) ->
+      case datastream.pull(right) {
+        Done -> {
+          datastream.close(left_rest)
+          Done
+        }
+        Next(right_element, right_rest) ->
+          Next(
+            combiner(left_element, right_element),
+            zip_with(left_rest, right_rest, with: combiner),
+          )
+      }
+  }
 }
 
 /// Insert `separator` between adjacent elements.
 ///
-/// Empty and single-element streams are unchanged: `separator` is only
-/// emitted between two real elements, never at the start, end, or
-/// around an absent neighbour.
+/// Empty and single-element streams are unchanged.
 pub fn intersperse(over stream: Stream(a), with separator: a) -> Stream(a) {
-  datastream.unfold(from: IntersperseInitial(stream), with: fn(state) {
-    intersperse_step(state, separator)
-  })
+  intersperse_initial(stream, separator)
 }
 
-type Intersperse(a) {
-  IntersperseInitial(stream: Stream(a))
-  IntersperseAwaitingSep(stream: Stream(a))
-  IntersperseHasPending(pending: a, stream: Stream(a))
-}
-
-fn intersperse_step(
-  state: Intersperse(a),
-  separator: a,
-) -> Step(a, Intersperse(a)) {
-  case state {
-    IntersperseInitial(stream) ->
+fn intersperse_initial(stream: Stream(a), separator: a) -> Stream(a) {
+  datastream.make(
+    pull: fn() {
       case datastream.pull(stream) {
         Done -> Done
         Next(first, rest) ->
-          Next(element: first, state: IntersperseAwaitingSep(rest))
+          Next(first, intersperse_awaiting_sep(rest, separator))
       }
-    IntersperseAwaitingSep(stream) ->
+    },
+    close: fn() { datastream.close(stream) },
+  )
+}
+
+fn intersperse_awaiting_sep(stream: Stream(a), separator: a) -> Stream(a) {
+  datastream.make(
+    pull: fn() {
       case datastream.pull(stream) {
         Done -> Done
         Next(next, rest) ->
-          Next(element: separator, state: IntersperseHasPending(next, rest))
+          Next(separator, intersperse_pending(next, rest, separator))
       }
-    IntersperseHasPending(pending, stream) ->
-      Next(element: pending, state: IntersperseAwaitingSep(stream))
-  }
+    },
+    close: fn() { datastream.close(stream) },
+  )
+}
+
+fn intersperse_pending(pending: a, stream: Stream(a), separator: a) -> Stream(a) {
+  datastream.make(
+    pull: fn() { Next(pending, intersperse_awaiting_sep(stream, separator)) },
+    close: fn() { datastream.close(stream) },
+  )
 }
 
 /// Call `effect` once per element and re-emit the element unchanged.
-///
-/// Observation only: the element sequence is not altered. Allowed to
-/// perform effects (logging, counters, debug breakpoints), but pure
-/// pipelines should keep `tap` out of production paths.
 pub fn tap(over stream: Stream(a), with effect: fn(a) -> Nil) -> Stream(a) {
-  datastream.unfold(from: stream, with: fn(current) {
-    case datastream.pull(current) {
-      Next(element, rest) -> {
-        effect(element)
-        Next(element: element, state: rest)
+  datastream.make(
+    pull: fn() {
+      case datastream.pull(stream) {
+        Next(element, rest) -> {
+          effect(element)
+          Next(element, tap(over: rest, with: effect))
+        }
+        Done -> Done
       }
-      Done -> Done
-    }
-  })
+    },
+    close: fn() { datastream.close(stream) },
+  )
 }
 
 /// Collapse runs of `==`-equal adjacent values to a single occurrence.
-///
-/// Local only: values that appear far apart are kept. Full
-/// deduplication would require unbounded state, which the pull-based
-/// core does not maintain.
 pub fn dedupe_adjacent(stream: Stream(a)) -> Stream(a) {
-  datastream.unfold(from: #(None, stream), with: dedupe_step)
+  dedupe_active(stream, None)
 }
 
-fn dedupe_step(
-  state: #(Option(a), Stream(a)),
-) -> Step(a, #(Option(a), Stream(a))) {
-  let #(last, current) = state
-  case datastream.pull(current) {
+fn dedupe_active(stream: Stream(a), last: Option(a)) -> Stream(a) {
+  datastream.make(pull: fn() { dedupe_pull(stream, last) }, close: fn() {
+    datastream.close(stream)
+  })
+}
+
+fn dedupe_pull(stream: Stream(a), last: Option(a)) -> Step(a, Stream(a)) {
+  case datastream.pull(stream) {
     Done -> Done
     Next(element, rest) ->
       case last {
-        Some(prev) if prev == element -> dedupe_step(#(Some(prev), rest))
-        _ -> Next(element: element, state: #(Some(element), rest))
+        Some(prev) if prev == element -> dedupe_pull(rest, Some(prev))
+        _ -> Next(element, dedupe_active(rest, Some(element)))
       }
   }
 }
 
+// --- chunked operations -----------------------------------------------------
+
 /// Group adjacent elements into fixed-size chunks.
 ///
-/// Each emitted chunk holds at most `size` elements, in source order.
-/// The trailing chunk MAY be smaller than `size` when the source length
-/// is not divisible — callers do not lose data when `length % size != 0`.
-/// `size < 1` is normalised to `1`, matching `gleam/list`'s behaviour
-/// for size-bounded splits.
-///
-/// Lazy: a chunk is only built when the downstream pulls.
+/// `size < 1` is normalised to `1`. The trailing chunk may be smaller
+/// than `size` when the source length is not divisible.
 pub fn chunks_of(over stream: Stream(a), into size: Int) -> Stream(Chunk(a)) {
   let normalised = case size < 1 {
     True -> 1
     False -> size
   }
-  datastream.unfold(
-    from: ChunksActive(buffer: [], count: 0, source: stream),
-    with: fn(state) { chunks_of_step(state, normalised) },
+  chunks_active(stream, [], 0, normalised)
+}
+
+fn chunks_active(
+  source: Stream(a),
+  buffer: List(a),
+  count: Int,
+  size: Int,
+) -> Stream(Chunk(a)) {
+  datastream.make(
+    pull: fn() { chunks_pull(source, buffer, count, size) },
+    close: fn() { datastream.close(source) },
   )
 }
 
-type ChunksOf(a) {
-  ChunksActive(buffer: List(a), count: Int, source: Stream(a))
-  ChunksDrained
-}
-
-fn chunks_of_step(state: ChunksOf(a), size: Int) -> Step(Chunk(a), ChunksOf(a)) {
-  case state {
-    ChunksDrained -> Done
-    ChunksActive(buffer, count, source) ->
-      case datastream.pull(source) {
-        Done ->
-          case buffer {
-            [] -> Done
-            _ ->
-              Next(
-                element: chunk.from_list(list.reverse(buffer)),
-                state: ChunksDrained,
-              )
-          }
-        Next(element, rest) -> {
-          let new_count = count + 1
-          let new_buffer = [element, ..buffer]
-          case new_count >= size {
-            True ->
-              Next(
-                element: chunk.from_list(list.reverse(new_buffer)),
-                state: ChunksActive(buffer: [], count: 0, source: rest),
-              )
-            False ->
-              chunks_of_step(
-                ChunksActive(buffer: new_buffer, count: new_count, source: rest),
-                size,
-              )
-          }
-        }
+fn chunks_pull(
+  source: Stream(a),
+  buffer: List(a),
+  count: Int,
+  size: Int,
+) -> Step(Chunk(a), Stream(Chunk(a))) {
+  case datastream.pull(source) {
+    Done ->
+      case buffer {
+        [] -> Done
+        _ -> Next(chunk.from_list(list.reverse(buffer)), empty_stream())
       }
+    Next(element, rest) -> {
+      let new_count = count + 1
+      let new_buffer = [element, ..buffer]
+      case new_count >= size {
+        True ->
+          Next(
+            chunk.from_list(list.reverse(new_buffer)),
+            chunks_active(rest, [], 0, size),
+          )
+        False -> chunks_pull(rest, new_buffer, new_count, size)
+      }
+    }
   }
 }
 
 /// Group consecutive elements that share `key(element)`.
-///
-/// Each emitted `#(k, chunk)` is one maximal run of adjacent elements
-/// with the same key, in source order. Non-adjacent occurrences of the
-/// same key are NOT merged: doing so would require unbounded state.
-///
-/// Lazy: a group is only built when the downstream pulls.
 pub fn group_adjacent(
   over stream: Stream(a),
   by key: fn(a) -> k,
 ) -> Stream(#(k, Chunk(a))) {
-  datastream.unfold(
-    from: GroupActive(current_key: None, buffer: [], source: stream),
-    with: fn(state) { group_adjacent_step(state, key) },
+  group_active(stream, None, [], key)
+}
+
+fn group_active(
+  source: Stream(a),
+  current_key: Option(k),
+  buffer: List(a),
+  key: fn(a) -> k,
+) -> Stream(#(k, Chunk(a))) {
+  datastream.make(
+    pull: fn() { group_pull(source, current_key, buffer, key) },
+    close: fn() { datastream.close(source) },
   )
 }
 
-type GroupAdjacent(a, k) {
-  GroupActive(current_key: Option(k), buffer: List(a), source: Stream(a))
-  GroupDrained
-}
-
-fn group_adjacent_step(
-  state: GroupAdjacent(a, k),
-  key: fn(a) -> k,
-) -> Step(#(k, Chunk(a)), GroupAdjacent(a, k)) {
-  case state {
-    GroupDrained -> Done
-    GroupActive(current_key, buffer, source) ->
-      case datastream.pull(source) {
-        Done -> group_adjacent_flush(current_key, buffer)
-        Next(element, rest) ->
-          group_adjacent_advance(current_key, buffer, element, rest, key)
-      }
-  }
-}
-
-fn group_adjacent_flush(
+fn group_pull(
+  source: Stream(a),
   current_key: Option(k),
   buffer: List(a),
-) -> Step(#(k, Chunk(a)), GroupAdjacent(a, k)) {
-  case current_key {
-    None -> Done
-    Some(k) ->
-      Next(
-        element: #(k, chunk.from_list(list.reverse(buffer))),
-        state: GroupDrained,
-      )
+  key: fn(a) -> k,
+) -> Step(#(k, Chunk(a)), Stream(#(k, Chunk(a)))) {
+  case datastream.pull(source) {
+    Done -> group_flush(current_key, buffer)
+    Next(element, rest) ->
+      group_advance(current_key, buffer, element, rest, key)
   }
 }
 
-fn group_adjacent_advance(
+fn group_flush(
+  current_key: Option(k),
+  buffer: List(a),
+) -> Step(#(k, Chunk(a)), Stream(#(k, Chunk(a)))) {
+  case current_key {
+    None -> Done
+    Some(k) -> Next(#(k, chunk.from_list(list.reverse(buffer))), empty_stream())
+  }
+}
+
+fn group_advance(
   current_key: Option(k),
   buffer: List(a),
   element: a,
   rest: Stream(a),
   key: fn(a) -> k,
-) -> Step(#(k, Chunk(a)), GroupAdjacent(a, k)) {
+) -> Step(#(k, Chunk(a)), Stream(#(k, Chunk(a)))) {
   let element_key = key(element)
   case current_key {
-    None ->
-      group_adjacent_step(
-        GroupActive(
-          current_key: Some(element_key),
-          buffer: [element],
-          source: rest,
-        ),
-        key,
-      )
+    None -> group_pull(rest, Some(element_key), [element], key)
     Some(prev_key) if prev_key == element_key ->
-      group_adjacent_step(
-        GroupActive(
-          current_key: Some(element_key),
-          buffer: [element, ..buffer],
-          source: rest,
-        ),
-        key,
-      )
+      group_pull(rest, Some(element_key), [element, ..buffer], key)
     Some(prev_key) ->
       Next(
-        element: #(prev_key, chunk.from_list(list.reverse(buffer))),
-        state: GroupActive(
-          current_key: Some(element_key),
-          buffer: [element],
-          source: rest,
-        ),
+        #(prev_key, chunk.from_list(list.reverse(buffer))),
+        group_active(rest, Some(element_key), [element], key),
       )
   }
 }
-
-type Step(a, state) =
-  datastream.Step(a, state)

--- a/test/datastream/resource_test.gleam
+++ b/test/datastream/resource_test.gleam
@@ -142,6 +142,68 @@ fn bump(key: String) -> Nil {
 }
 
 @target(erlang)
+@external(erlang, "erlang", "put")
+fn put_events(key: String, value: List(String)) -> List(String)
+
+@target(erlang)
+@external(erlang, "erlang", "get")
+fn get_events(key: String) -> List(String)
+
+@target(erlang)
+fn reset_events(key: String) -> Nil {
+  let _previous = put_events(key, [])
+  Nil
+}
+
+@target(erlang)
+fn record(log_key: String, event: String) -> Nil {
+  let current = get_events(log_key)
+  let _previous = put_events(log_key, [event, ..current])
+  Nil
+}
+
+@target(erlang)
+fn events(log_key: String) -> List(String) {
+  get_events(log_key) |> reverse_events
+}
+
+@target(erlang)
+fn reverse_events(events: List(String)) -> List(String) {
+  reverse_events_loop(events, [])
+}
+
+@target(erlang)
+fn reverse_events_loop(
+  remaining: List(String),
+  acc: List(String),
+) -> List(String) {
+  case remaining {
+    [] -> acc
+    [head, ..tail] -> reverse_events_loop(tail, [head, ..acc])
+  }
+}
+
+@target(erlang)
+fn logged_resource(elements: List(a), log_key: String, name: String) {
+  source.resource(
+    open: fn() {
+      record(log_key, "open:" <> name)
+      elements
+    },
+    next: fn(state) {
+      case state {
+        [] -> Done
+        [head, ..tail] -> Next(element: head, state: tail)
+      }
+    },
+    close: fn(_) {
+      record(log_key, "close:" <> name)
+      Nil
+    },
+  )
+}
+
+@target(erlang)
 fn counted_resource(elements: List(a), opens_key: String, closes_key: String) {
   source.resource(
     open: fn() {
@@ -338,4 +400,105 @@ pub fn resource_try_each_error_closes_once_test() {
 
   get_dict("c12_open_te") |> should.equal(1)
   get_dict("c12_close_te") |> should.equal(1)
+}
+
+// --- Erlang-only: close ordering assertions -------------------------------
+
+@target(erlang)
+pub fn resource_flat_map_closes_inner_before_outer_on_early_exit_test() {
+  reset_events("c12_log_fmt_te")
+
+  let inner = logged_resource([1, 2, 3], "c12_log_fmt_te", "inner")
+  let outer = logged_resource([inner], "c12_log_fmt_te", "outer")
+
+  outer
+  |> stream.flat_map(with: fn(s) { s })
+  |> stream.take(up_to: 1)
+  |> fold.to_list
+  |> should.equal([1])
+
+  events("c12_log_fmt_te")
+  |> should.equal(["open:outer", "open:inner", "close:inner", "close:outer"])
+}
+
+@target(erlang)
+pub fn resource_flat_map_take_does_not_open_second_inner_ordering_test() {
+  reset_events("c12_log_fmt_take")
+
+  let inner_a = logged_resource([1, 2], "c12_log_fmt_take", "inner_a")
+  let inner_b = logged_resource([3, 4], "c12_log_fmt_take", "inner_b")
+  let outer = logged_resource([inner_a, inner_b], "c12_log_fmt_take", "outer")
+
+  outer
+  |> stream.flat_map(with: fn(s) { s })
+  |> stream.take(up_to: 1)
+  |> fold.to_list
+  |> should.equal([1])
+
+  // outer opened, then inner_a; on take(1) the active inner_a closes
+  // first, then outer; inner_b is never touched.
+  events("c12_log_fmt_take")
+  |> should.equal(["open:outer", "open:inner_a", "close:inner_a", "close:outer"])
+}
+
+@target(erlang)
+pub fn resource_append_left_fully_closes_before_right_opens_test() {
+  reset_events("c12_log_append")
+
+  let left = logged_resource([1, 2], "c12_log_append", "left")
+  let right = logged_resource([3, 4], "c12_log_append", "right")
+
+  stream.append(left, right) |> fold.to_list |> should.equal([1, 2, 3, 4])
+
+  // left must close before right opens.
+  events("c12_log_append")
+  |> should.equal(["open:left", "close:left", "open:right", "close:right"])
+}
+
+@target(erlang)
+pub fn resource_append_take_does_not_open_right_test() {
+  reset_events("c12_log_append_take")
+
+  let left =
+    source.resource(
+      open: fn() {
+        record("c12_log_append_take", "open:left")
+        1
+      },
+      next: fn(state) { Next(element: state, state: state + 1) },
+      close: fn(_) {
+        record("c12_log_append_take", "close:left")
+        Nil
+      },
+    )
+  let right = logged_resource([10, 20], "c12_log_append_take", "right")
+
+  stream.append(left, right)
+  |> stream.take(up_to: 2)
+  |> fold.to_list
+  |> should.equal([1, 2])
+
+  events("c12_log_append_take")
+  |> should.equal(["open:left", "close:left"])
+}
+
+@target(erlang)
+pub fn resource_zip_closes_right_then_left_test() {
+  reset_events("c12_log_zip")
+
+  let left = logged_resource([1, 2], "c12_log_zip", "left")
+  let right = logged_resource([10, 20, 30], "c12_log_zip", "right")
+
+  stream.zip(left, right)
+  |> fold.to_list
+  |> should.equal([#(1, 10), #(2, 20)])
+
+  // Order in the log: opens happen during the first zip pull (left
+  // first, then right). Then on the third pull, left returns Done and
+  // closes itself, after which zip closes the still-active right.
+  // Spec: "close right then left" applies when the zip combinator
+  // itself is asked to close — here the left already closed via Done,
+  // so only right's close is recorded after left's.
+  events("c12_log_zip")
+  |> should.equal(["open:left", "open:right", "close:left", "close:right"])
 }

--- a/test/datastream/resource_test.gleam
+++ b/test/datastream/resource_test.gleam
@@ -1,0 +1,341 @@
+//// Tests for `source.resource`'s close contract.
+////
+//// Two flavours of test:
+////
+//// - Cross-target tests use a `panic`-as-tripwire pattern: the
+////   resource's `close` is set to `Nil`, but a follow-up element installs
+////   `panic`. If the close contract weren't honoured (resource closed
+////   too early, or upstream pulled past an early exit) the panic would
+////   trip and the test would fail.
+//// - Erlang-only tests use the process dictionary as a counter to pin
+////   precise open / close counts and ordering.
+
+import datastream.{Done, Next}
+import datastream/fold
+import datastream/sink
+import datastream/source
+import datastream/stream
+import gleam/option
+import gleeunit/should
+
+// --- cross-target: behavioural tests ---------------------------------------
+
+fn list_resource(elements: List(a)) {
+  source.resource(
+    open: fn() { elements },
+    next: fn(state) {
+      case state {
+        [] -> Done
+        [head, ..tail] -> Next(element: head, state: tail)
+      }
+    },
+    close: fn(_) { Nil },
+  )
+}
+
+pub fn resource_to_list_yields_source_order_test() {
+  list_resource([1, 2, 3]) |> fold.to_list |> should.equal([1, 2, 3])
+}
+
+pub fn resource_take_one_yields_first_element_test() {
+  list_resource([1, 2, 3])
+  |> stream.take(up_to: 1)
+  |> fold.to_list
+  |> should.equal([1])
+}
+
+pub fn resource_first_returns_some_head_test() {
+  list_resource([1, 2, 3]) |> fold.first |> should.equal(option.Some(1))
+}
+
+pub fn resource_re_runs_open_per_terminal_test() {
+  let s = list_resource([1, 2, 3])
+  fold.to_list(s) |> should.equal([1, 2, 3])
+  fold.to_list(s) |> should.equal([1, 2, 3])
+}
+
+pub fn resource_on_empty_yields_empty_test() {
+  list_resource([]) |> fold.to_list |> should.equal([])
+}
+
+// --- cross-target: short-circuit and ordering tripwires --------------------
+
+pub fn map_passes_resource_through_test() {
+  list_resource([1, 2, 3])
+  |> stream.map(with: fn(x) { x + 1 })
+  |> fold.to_list
+  |> should.equal([2, 3, 4])
+}
+
+pub fn try_each_short_circuits_and_does_not_pull_past_error_test() {
+  // After try_each returns Error("stop") on element 3, element 4 must
+  // not be pulled (which would trip the panic).
+  let s =
+    source.resource(
+      open: fn() { 1 },
+      next: fn(state) {
+        case state {
+          n if n <= 4 -> Next(element: n, state: n + 1)
+          _ -> Done
+        }
+      },
+      close: fn(_) { Nil },
+    )
+
+  s
+  |> sink.try_each(with: fn(x) {
+    case x {
+      3 -> Error("stop")
+      4 -> panic as "try_each must not pull element 4 after error on 3"
+      _ -> Ok(Nil)
+    }
+  })
+  |> should.equal(Error("stop"))
+}
+
+pub fn append_does_not_open_second_when_first_short_circuits_test() {
+  // The second resource's `open` panics; if `append` opened it before
+  // the take(2) early-exit on the (infinite) first, the test would
+  // panic.
+  let infinite_first =
+    source.resource(
+      open: fn() { 1 },
+      next: fn(state) { Next(element: state, state: state + 1) },
+      close: fn(_) { Nil },
+    )
+  let panicking_second =
+    source.resource(
+      open: fn() {
+        panic as "second resource opened despite take(2) early-exit"
+      },
+      next: fn(_) { Done },
+      close: fn(_) { Nil },
+    )
+
+  stream.append(infinite_first, panicking_second)
+  |> stream.take(up_to: 2)
+  |> fold.to_list
+  |> should.equal([1, 2])
+}
+
+// --- Erlang-only: precise counter assertions ------------------------------
+
+@target(erlang)
+@external(erlang, "erlang", "put")
+fn put_dict(key: String, value: Int) -> Int
+
+@target(erlang)
+@external(erlang, "erlang", "get")
+fn get_dict(key: String) -> Int
+
+@target(erlang)
+fn reset(key: String) -> Nil {
+  let _previous = put_dict(key, 0)
+  Nil
+}
+
+@target(erlang)
+fn bump(key: String) -> Nil {
+  let current = get_dict(key)
+  let _previous = put_dict(key, current + 1)
+  Nil
+}
+
+@target(erlang)
+fn counted_resource(elements: List(a), opens_key: String, closes_key: String) {
+  source.resource(
+    open: fn() {
+      bump(opens_key)
+      elements
+    },
+    next: fn(state) {
+      case state {
+        [] -> Done
+        [head, ..tail] -> Next(element: head, state: tail)
+      }
+    },
+    close: fn(_) {
+      bump(closes_key)
+      Nil
+    },
+  )
+}
+
+@target(erlang)
+pub fn resource_normal_end_closes_once_test() {
+  reset("c12_open_a")
+  reset("c12_close_a")
+  counted_resource([1, 2, 3], "c12_open_a", "c12_close_a")
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+  get_dict("c12_open_a") |> should.equal(1)
+  get_dict("c12_close_a") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn resource_take_early_exit_closes_once_test() {
+  reset("c12_open_b")
+  reset("c12_close_b")
+  counted_resource([1, 2, 3], "c12_open_b", "c12_close_b")
+  |> stream.take(up_to: 1)
+  |> fold.to_list
+  |> should.equal([1])
+  get_dict("c12_open_b") |> should.equal(1)
+  get_dict("c12_close_b") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn resource_first_closes_once_test() {
+  reset("c12_open_c")
+  reset("c12_close_c")
+  counted_resource([1, 2, 3], "c12_open_c", "c12_close_c")
+  |> fold.first
+  |> should.equal(option.Some(1))
+  get_dict("c12_open_c") |> should.equal(1)
+  get_dict("c12_close_c") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn resource_each_terminal_re_opens_test() {
+  reset("c12_open_d")
+  reset("c12_close_d")
+  let s = counted_resource([1, 2, 3], "c12_open_d", "c12_close_d")
+  fold.to_list(s) |> should.equal([1, 2, 3])
+  fold.to_list(s) |> should.equal([1, 2, 3])
+  get_dict("c12_open_d") |> should.equal(2)
+  get_dict("c12_close_d") |> should.equal(2)
+}
+
+@target(erlang)
+pub fn resource_empty_closes_once_test() {
+  reset("c12_open_e")
+  reset("c12_close_e")
+  counted_resource([], "c12_open_e", "c12_close_e")
+  |> fold.to_list
+  |> should.equal([])
+  get_dict("c12_open_e") |> should.equal(1)
+  get_dict("c12_close_e") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn resource_lazy_open_test() {
+  reset("c12_open_f")
+  reset("c12_close_f")
+  let _pipeline = counted_resource([1, 2, 3], "c12_open_f", "c12_close_f")
+  // No terminal yet → open must not have run
+  get_dict("c12_open_f") |> should.equal(0)
+  get_dict("c12_close_f") |> should.equal(0)
+}
+
+@target(erlang)
+pub fn resource_flat_map_inner_then_outer_close_test() {
+  reset("c12_open_outer")
+  reset("c12_close_outer")
+  reset("c12_open_inner_a")
+  reset("c12_close_inner_a")
+  reset("c12_open_inner_b")
+  reset("c12_close_inner_b")
+
+  let inner_a =
+    counted_resource([1, 2], "c12_open_inner_a", "c12_close_inner_a")
+  let inner_b =
+    counted_resource([3, 4], "c12_open_inner_b", "c12_close_inner_b")
+  let outer =
+    counted_resource([inner_a, inner_b], "c12_open_outer", "c12_close_outer")
+
+  outer
+  |> stream.flat_map(with: fn(s) { s })
+  |> fold.to_list
+  |> should.equal([1, 2, 3, 4])
+
+  get_dict("c12_open_outer") |> should.equal(1)
+  get_dict("c12_close_outer") |> should.equal(1)
+  get_dict("c12_open_inner_a") |> should.equal(1)
+  get_dict("c12_close_inner_a") |> should.equal(1)
+  get_dict("c12_open_inner_b") |> should.equal(1)
+  get_dict("c12_close_inner_b") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn resource_flat_map_take_does_not_open_second_inner_test() {
+  reset("c12_open_outer2")
+  reset("c12_close_outer2")
+  reset("c12_open_inner2_a")
+  reset("c12_close_inner2_a")
+  reset("c12_open_inner2_b")
+  reset("c12_close_inner2_b")
+
+  let inner_a =
+    counted_resource([1, 2], "c12_open_inner2_a", "c12_close_inner2_a")
+  let inner_b =
+    counted_resource([3, 4], "c12_open_inner2_b", "c12_close_inner2_b")
+  let outer =
+    counted_resource([inner_a, inner_b], "c12_open_outer2", "c12_close_outer2")
+
+  outer
+  |> stream.flat_map(with: fn(s) { s })
+  |> stream.take(up_to: 1)
+  |> fold.to_list
+  |> should.equal([1])
+
+  get_dict("c12_open_inner2_a") |> should.equal(1)
+  get_dict("c12_close_inner2_a") |> should.equal(1)
+  get_dict("c12_open_inner2_b") |> should.equal(0)
+  get_dict("c12_close_inner2_b") |> should.equal(0)
+}
+
+@target(erlang)
+pub fn resource_append_left_closed_before_right_opens_test() {
+  reset("c12_open_l")
+  reset("c12_close_l")
+  reset("c12_open_r")
+  reset("c12_close_r")
+
+  let left = counted_resource([1, 2], "c12_open_l", "c12_close_l")
+  let right = counted_resource([3, 4], "c12_open_r", "c12_close_r")
+
+  stream.append(left, right) |> fold.to_list |> should.equal([1, 2, 3, 4])
+
+  get_dict("c12_open_l") |> should.equal(1)
+  get_dict("c12_close_l") |> should.equal(1)
+  get_dict("c12_open_r") |> should.equal(1)
+  get_dict("c12_close_r") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn resource_zip_closes_both_test() {
+  reset("c12_open_zl")
+  reset("c12_close_zl")
+  reset("c12_open_zr")
+  reset("c12_close_zr")
+
+  let left = counted_resource([1, 2], "c12_open_zl", "c12_close_zl")
+  let right = counted_resource([10, 20, 30], "c12_open_zr", "c12_close_zr")
+
+  stream.zip(left, right)
+  |> fold.to_list
+  |> should.equal([#(1, 10), #(2, 20)])
+
+  get_dict("c12_open_zl") |> should.equal(1)
+  get_dict("c12_close_zl") |> should.equal(1)
+  get_dict("c12_open_zr") |> should.equal(1)
+  get_dict("c12_close_zr") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn resource_try_each_error_closes_once_test() {
+  reset("c12_open_te")
+  reset("c12_close_te")
+
+  counted_resource([1, 2, 3, 4], "c12_open_te", "c12_close_te")
+  |> sink.try_each(with: fn(x) {
+    case x < 3 {
+      True -> Ok(Nil)
+      False -> Error("stop")
+    }
+  })
+  |> should.equal(Error("stop"))
+
+  get_dict("c12_open_te") |> should.equal(1)
+  get_dict("c12_close_te") |> should.equal(1)
+}


### PR DESCRIPTION
## Summary

Phase 4 starts with the load-bearing change: `source.resource` plus the close contract wired through every combinator and terminal in the cross-target core. This is what every later resource-backed work (BEAM extensions, file/socket helpers) depends on.

## Internal change

`Stream(a)` now carries both `pull` and `close` callbacks (still opaque). `unfold`-built streams use a no-op `close` — observable behaviour unchanged for every Phase 1-3 caller. `source.resource(open, next, close)` builds a stream whose `close` releases the most recent state.

## Close contract honoured on every termination path the library controls

- **Normal end**: `next` returns `Done` and the resource closes itself. Combinators MUST NOT close again on this path.
- **`take` / `take_while`**: close upstream when the early-exit decision fires.
- **`fold.first` / `find` / `any` (True branch) / `all` (False branch) / `collect_result` (Error branch)**: close the unconsumed continuation.
- **`sink.try_each` (Error branch)**: close the unconsumed continuation.
- **`flat_map`**: close active inner first, then outer.
- **`zip` / `zip_with`**: close right then left.
- **`append`**: never opens the right when the left short-circuits; closes left fully before the right is ever pulled.
- **`concat`**: closes the active stream on early-exit; subsequent streams are never opened.

`open` runs lazily on the first pull, NOT at construction. Each terminal call re-opens; the stream is repeatable.

## Tests

All 156 existing tests still pass — no regressions from the internal Stream representation change.

New tests cover both flavours of guarantee:

- **Cross-target** (8 tests, both Erlang and JavaScript): `panic`-as-tripwire patterns confirm short-circuit combinators never pull past the cut point and `append` never opens the right under `take(2)` early-exit.
- **Erlang-only** (11 tests, using the process dictionary as a counter): pin precise open / close counts and ordering for the spec table — normal end, `take`, `first`, re-open per terminal, empty source, laziness (no `open` before terminal), `flat_map` inner-then-outer ordering, `flat_map |> take` not opening the unconsumed inner, `append` ordering, `zip` closing both sides, `try_each` Error-branch close.

`just all` is green: Erlang 175 / JS 164 (Erlang-only counter tests don't run under JS).

Closes #12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `resource` stream constructor for building streams with proper cleanup guarantees across termination paths.

* **Bug Fixes**
  * Fixed resource cleanup to execute on stream early termination (early-exit, filtered results, limited pulls) across all combinators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->