### PR TITLE
feat: add source.try_resource and ResourceError

### DIFF
--- a/src/datastream/source.gleam
+++ b/src/datastream/source.gleam
@@ -144,6 +144,17 @@ pub fn unfold(
   datastream.unfold(from: initial, with: step)
 }
 
+/// Unified failure shape for `try_resource`.
+///
+/// `OpenError(e)` carries the error returned by `open`; the stream
+/// emits exactly one of these and halts. `NextError(e)` wraps a
+/// per-element read error returned by `next`; the stream continues
+/// after one of these unless the caller stops it.
+pub type ResourceError(open_error, next_error) {
+  OpenError(open_error)
+  NextError(next_error)
+}
+
 /// Build a resource-backed stream that opens lazily and closes
 /// deterministically.
 ///
@@ -168,4 +179,83 @@ pub fn resource(
   close close: fn(state) -> Nil,
 ) -> Stream(a) {
   datastream.resource(open: open, next: next, close: close)
+}
+
+/// Build a resource-backed stream whose `open` and per-element `next`
+/// can both fail.
+///
+/// The two failure shapes are unified into the element type via
+/// `ResourceError`:
+///
+/// - When `open` returns `Error(e)`, the stream emits exactly one
+///   element `Error(OpenError(e))` and halts. `close` is NOT called
+///   (there is no opened state to close).
+/// - When `open` returns `Ok(state)`, behaviour follows the contract
+///   of `resource`. `next` returning `Next(Ok(x), state')` yields
+///   element `Ok(x)`; `Next(Error(e), state')` yields
+///   `Error(NextError(e))` and continues; `Done` halts and triggers
+///   `close(state)`.
+///
+/// Lazy: `open` runs on the first pull, NOT at construction. Each
+/// terminal call re-attempts `open`.
+///
+/// Downstream sees a single `Stream(Result(a, ResourceError(o, n)))`,
+/// so `fold.collect_result` and `fold.partition_result` work without
+/// further adaptation.
+pub fn try_resource(
+  open open: fn() -> Result(state, open_error),
+  next next: fn(state) -> Step(Result(a, next_error), state),
+  close close: fn(state) -> Nil,
+) -> Stream(Result(a, ResourceError(open_error, next_error))) {
+  datastream.make(
+    pull: fn() { try_resource_first_pull(open, next, close) },
+    close: fn() { Nil },
+  )
+}
+
+fn try_resource_first_pull(
+  open: fn() -> Result(state, open_error),
+  next: fn(state) -> Step(Result(a, next_error), state),
+  close: fn(state) -> Nil,
+) -> Step(
+  Result(a, ResourceError(open_error, next_error)),
+  Stream(Result(a, ResourceError(open_error, next_error))),
+) {
+  case open() {
+    Error(e) ->
+      Next(
+        element: Error(OpenError(e)),
+        state: datastream.make(pull: fn() { Done }, close: fn() { Nil }),
+      )
+    Ok(state) -> try_resource_pull(state, next, close)
+  }
+}
+
+fn try_resource_pull(
+  state: state,
+  next: fn(state) -> Step(Result(a, next_error), state),
+  close: fn(state) -> Nil,
+) -> Step(
+  Result(a, ResourceError(open_error, next_error)),
+  Stream(Result(a, ResourceError(open_error, next_error))),
+) {
+  case next(state) {
+    Done -> {
+      close(state)
+      Done
+    }
+    Next(element, next_state) -> {
+      let lifted = case element {
+        Ok(value) -> Ok(value)
+        Error(e) -> Error(NextError(e))
+      }
+      Next(
+        element: lifted,
+        state: datastream.make(
+          pull: fn() { try_resource_pull(next_state, next, close) },
+          close: fn() { close(next_state) },
+        ),
+      )
+    }
+  }
 }

--- a/test/datastream/try_resource_test.gleam
+++ b/test/datastream/try_resource_test.gleam
@@ -1,0 +1,261 @@
+//// Tests for `source.try_resource` and `ResourceError`.
+////
+//// Cross-target tests pin the element shape and the OpenError /
+//// NextError lifting. Erlang-only tests use the process dictionary as
+//// counters to confirm `close` is called once on success and zero
+//// times on `Error(OpenError)`.
+
+import datastream.{Done, Next}
+import datastream/fold
+import datastream/source.{NextError, OpenError}
+import datastream/stream
+import gleam/option
+import gleeunit/should
+
+// --- cross-target ---------------------------------------------------------
+
+fn ok_resource(elements: List(a)) {
+  source.try_resource(
+    open: fn() { Ok(elements) },
+    next: fn(state) {
+      case state {
+        [] -> Done
+        [head, ..tail] -> Next(element: Ok(head), state: tail)
+      }
+    },
+    close: fn(_) { Nil },
+  )
+}
+
+pub fn try_resource_open_ok_yields_ok_elements_test() {
+  ok_resource([1, 2])
+  |> fold.to_list
+  |> should.equal([Ok(1), Ok(2)])
+}
+
+pub fn try_resource_open_error_yields_one_open_error_test() {
+  source.try_resource(
+    open: fn() -> Result(Nil, String) { Error("oops") },
+    next: fn(_) -> datastream.Step(Result(Int, String), Nil) { Done },
+    close: fn(_) { Nil },
+  )
+  |> fold.to_list
+  |> should.equal([Error(OpenError("oops"))])
+}
+
+pub fn try_resource_next_error_is_lifted_to_next_error_test() {
+  let s =
+    source.try_resource(
+      open: fn() { Ok(0) },
+      next: fn(state) {
+        case state {
+          0 -> Next(element: Ok(1), state: 1)
+          1 -> Next(element: Error("bad"), state: 2)
+          2 -> Next(element: Ok(3), state: 3)
+          _ -> Done
+        }
+      },
+      close: fn(_) { Nil },
+    )
+
+  s
+  |> fold.to_list
+  |> should.equal([Ok(1), Error(NextError("bad")), Ok(3)])
+}
+
+pub fn try_resource_re_runs_open_per_terminal_test() {
+  let s = ok_resource([1, 2])
+  fold.to_list(s) |> should.equal([Ok(1), Ok(2)])
+  fold.to_list(s) |> should.equal([Ok(1), Ok(2)])
+}
+
+pub fn try_resource_first_returns_open_error_test() {
+  source.try_resource(
+    open: fn() -> Result(Nil, String) { Error("oops") },
+    next: fn(_) -> datastream.Step(Result(Int, String), Nil) { Done },
+    close: fn(_) { Nil },
+  )
+  |> fold.first
+  |> should.equal(option.Some(Error(OpenError("oops"))))
+}
+
+pub fn try_resource_with_take_one_yields_first_element_test() {
+  ok_resource([1, 2, 3])
+  |> stream.take(up_to: 1)
+  |> fold.to_list
+  |> should.equal([Ok(1)])
+}
+
+pub fn try_resource_collect_result_on_all_ok_test() {
+  ok_resource([1, 2])
+  |> fold.collect_result
+  |> should.equal(Ok([1, 2]))
+}
+
+pub fn try_resource_collect_result_short_circuits_on_open_error_test() {
+  source.try_resource(
+    open: fn() -> Result(Nil, String) { Error("oops") },
+    next: fn(_) -> datastream.Step(Result(Int, String), Nil) { Done },
+    close: fn(_) { Nil },
+  )
+  |> fold.collect_result
+  |> should.equal(Error(OpenError("oops")))
+}
+
+// --- Erlang-only counter assertions --------------------------------------
+
+@target(erlang)
+@external(erlang, "erlang", "put")
+fn put_dict(key: String, value: Int) -> Int
+
+@target(erlang)
+@external(erlang, "erlang", "get")
+fn get_dict(key: String) -> Int
+
+@target(erlang)
+fn reset(key: String) -> Nil {
+  let _previous = put_dict(key, 0)
+  Nil
+}
+
+@target(erlang)
+fn bump(key: String) -> Nil {
+  let current = get_dict(key)
+  let _previous = put_dict(key, current + 1)
+  Nil
+}
+
+@target(erlang)
+pub fn try_resource_open_ok_closes_once_on_normal_end_test() {
+  reset("c13_open_a")
+  reset("c13_close_a")
+
+  source.try_resource(
+    open: fn() {
+      bump("c13_open_a")
+      Ok([1, 2])
+    },
+    next: fn(state) {
+      case state {
+        [] -> Done
+        [head, ..tail] -> Next(element: Ok(head), state: tail)
+      }
+    },
+    close: fn(_) {
+      bump("c13_close_a")
+      Nil
+    },
+  )
+  |> fold.to_list
+  |> should.equal([Ok(1), Ok(2)])
+
+  get_dict("c13_open_a") |> should.equal(1)
+  get_dict("c13_close_a") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn try_resource_open_error_does_not_call_close_test() {
+  reset("c13_open_b")
+  reset("c13_close_b")
+
+  source.try_resource(
+    open: fn() -> Result(Nil, String) {
+      bump("c13_open_b")
+      Error("oops")
+    },
+    next: fn(_) -> datastream.Step(Result(Int, String), Nil) { Done },
+    close: fn(_) {
+      bump("c13_close_b")
+      Nil
+    },
+  )
+  |> fold.to_list
+  |> should.equal([Error(OpenError("oops"))])
+
+  get_dict("c13_open_b") |> should.equal(1)
+  get_dict("c13_close_b") |> should.equal(0)
+}
+
+@target(erlang)
+pub fn try_resource_next_error_does_not_close_until_done_test() {
+  reset("c13_open_c")
+  reset("c13_close_c")
+
+  source.try_resource(
+    open: fn() {
+      bump("c13_open_c")
+      Ok(0)
+    },
+    next: fn(state) {
+      case state {
+        0 -> Next(element: Ok(1), state: 1)
+        1 -> Next(element: Error("bad"), state: 2)
+        2 -> Next(element: Ok(3), state: 3)
+        _ -> Done
+      }
+    },
+    close: fn(_) {
+      bump("c13_close_c")
+      Nil
+    },
+  )
+  |> fold.to_list
+  |> should.equal([Ok(1), Error(NextError("bad")), Ok(3)])
+
+  get_dict("c13_open_c") |> should.equal(1)
+  get_dict("c13_close_c") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn try_resource_re_run_re_attempts_open_test() {
+  reset("c13_open_d")
+  reset("c13_close_d")
+
+  let s =
+    source.try_resource(
+      open: fn() -> Result(Nil, String) {
+        bump("c13_open_d")
+        Error("oops")
+      },
+      next: fn(_) -> datastream.Step(Result(Int, String), Nil) { Done },
+      close: fn(_) {
+        bump("c13_close_d")
+        Nil
+      },
+    )
+
+  fold.to_list(s) |> should.equal([Error(OpenError("oops"))])
+  fold.to_list(s) |> should.equal([Error(OpenError("oops"))])
+
+  get_dict("c13_open_d") |> should.equal(2)
+  get_dict("c13_close_d") |> should.equal(0)
+}
+
+@target(erlang)
+pub fn try_resource_take_closes_once_on_early_exit_test() {
+  reset("c13_open_e")
+  reset("c13_close_e")
+
+  source.try_resource(
+    open: fn() {
+      bump("c13_open_e")
+      Ok([1, 2, 3])
+    },
+    next: fn(state) {
+      case state {
+        [] -> Done
+        [head, ..tail] -> Next(element: Ok(head), state: tail)
+      }
+    },
+    close: fn(_) {
+      bump("c13_close_e")
+      Nil
+    },
+  )
+  |> stream.take(up_to: 1)
+  |> fold.to_list
+  |> should.equal([Ok(1)])
+
+  get_dict("c13_open_e") |> should.equal(1)
+  get_dict("c13_close_e") |> should.equal(1)
+}


### PR DESCRIPTION
## Summary

Phase 4 closes with the fallible variant of `source.resource`. Real-world `open` calls fail (file missing, permission denied, socket refused) and per-element reads fail; this PR adds the constructor that surfaces both as a single, unified element type.

## Public API

```gleam
pub type ResourceError(open_error, next_error) {
  OpenError(open_error)
  NextError(next_error)
}

pub fn try_resource(
  open: fn() -> Result(state, open_error),
  next: fn(state) -> Step(Result(a, next_error), state),
  close: fn(state) -> Nil,
) -> Stream(Result(a, ResourceError(open_error, next_error)))
```

## Design decisions

- **Lazy `open`.** `open` runs on the first pull, NOT at construction, so a stream value never holds an open handle (or an open error). Each terminal call re-attempts `open`.
- **`OpenError` halts; `close` is NOT called.** When `open` returns `Error(e)`, the stream emits exactly one `Error(OpenError(e))` and halts. There is no opened state to close, so `close` is intentionally skipped.
- **`NextError` is recoverable.** `Next(Error(e), state')` yields `Error(NextError(e))` and continues; the caller decides whether to stop (via `take_while`, `try_each`, etc.).
- **Reuses #12's close wiring.** Each continuation built by `try_resource` carries `close: fn() { close_fn(latest_state) }`, so the close-contract logic already in `stream` / `fold` / `sink` picks it up without further changes — `take`, `first`, `try_each`, etc. all close the resource on early-exit.
- **Unified element type for downstream composition.** `fold.collect_result` and `fold.partition_result` work directly against `Stream(Result(a, ResourceError(...)))`; no extra adapter is needed.

## Tests

`just all` is green: Erlang 193 / JS 172 (Erlang-only counter tests don't run under JS).

- **Cross-target** (8 tests): the full Issue case table for `try_resource` plus `collect_result` composition (all-Ok and OpenError-short-circuit).
- **Erlang-only** (5 tests, process-dictionary counters): close-once-on-normal-end, close-zero-on-OpenError, close-once-after-NextError-then-Done, re-run re-attempts open (counter shows 2), and `take(1)` early-exit closes once.

Closes #13.