### PR TITLE
feat: add text.lines and text.split

### DIFF
--- a/src/datastream/text.gleam
+++ b/src/datastream/text.gleam
@@ -1,0 +1,201 @@
+//// Chunk-boundary-aware text stream operations on `Stream(String)`.
+////
+//// Real text inputs arrive in arbitrary chunks (file reads, network
+//// reads). A naïve `string.split` per chunk is wrong because line
+//// terminators and delimiters land on chunk boundaries. The functions
+//// here absorb that with a small, bounded amount of internal buffering
+//// — they never materialise the full input.
+////
+//// Both functions consume `Stream(String)` rather than
+//// `Stream(BitArray)`. The byte → string boundary is owned by
+//// `text.utf8_decode` (separate issue) so the cost lives in one place.
+
+import datastream.{type Step, type Stream, Done, Next}
+import gleam/option.{type Option, None, Some}
+import gleam/string
+
+/// Split a stream of strings into a stream of lines, treating both
+/// `\n` and `\r\n` as terminators.
+///
+/// The terminator is NOT included in emitted lines. A trailing partial
+/// line (input that does not end with a terminator) is emitted as a
+/// final element so callers do not silently drop the last record.
+///
+/// Chunk-boundary handling: when a `\r` lands at the end of one chunk
+/// and the next chunk starts with `\n`, the pair is treated as a
+/// single `\r\n` boundary. A lone `\r` with no following `\n` (either
+/// because the next chunk does not start with `\n`, or because the
+/// stream ended) is treated as a line terminator.
+pub fn lines(over stream: Stream(String)) -> Stream(String) {
+  lines_active(stream, "", False)
+}
+
+fn lines_active(
+  source: Stream(String),
+  buffer: String,
+  source_drained: Bool,
+) -> Stream(String) {
+  datastream.make(
+    pull: fn() { lines_pull(source, buffer, source_drained) },
+    close: fn() {
+      case source_drained {
+        True -> Nil
+        False -> datastream.close(source)
+      }
+    },
+  )
+}
+
+fn lines_pull(
+  source: Stream(String),
+  buffer: String,
+  source_drained: Bool,
+) -> Step(String, Stream(String)) {
+  case extract_line(buffer, "", source_drained) {
+    Some(#(line, rest)) ->
+      Next(line, lines_active(source, rest, source_drained))
+    None ->
+      case source_drained {
+        True ->
+          case buffer {
+            "" -> Done
+            _ -> Next(buffer, lines_active(source, "", True))
+          }
+        False ->
+          case datastream.pull(source) {
+            Next(chunk, source_rest) ->
+              lines_pull(source_rest, buffer <> chunk, False)
+            Done -> lines_pull(source, buffer, True)
+          }
+      }
+  }
+}
+
+fn extract_line(
+  remaining: String,
+  acc: String,
+  source_drained: Bool,
+) -> Option(#(String, String)) {
+  case string.pop_grapheme(remaining) {
+    Error(_) -> None
+    Ok(#(g, rest)) ->
+      case g {
+        "\n" -> Some(#(acc, rest))
+        "\r\n" -> Some(#(acc, rest))
+        "\r" -> handle_cr(rest, acc, source_drained)
+        _ -> extract_line(rest, acc <> g, source_drained)
+      }
+  }
+}
+
+fn handle_cr(
+  rest: String,
+  acc: String,
+  source_drained: Bool,
+) -> Option(#(String, String)) {
+  case string.pop_grapheme(rest) {
+    Ok(#("\n", rest_after)) -> Some(#(acc, rest_after))
+    Ok(_) -> Some(#(acc, rest))
+    Error(_) ->
+      case source_drained {
+        True -> Some(#(acc, ""))
+        False -> None
+      }
+  }
+}
+
+/// Split a stream of strings on `delimiter`, emitting every separated
+/// piece including the empty pieces between consecutive delimiters and
+/// at the start / end of the input.
+///
+/// `delimiter == ""` triggers the grapheme-cluster splitter: each
+/// emitted element is exactly one Unicode grapheme cluster of the
+/// input, in source order.
+///
+/// Chunk-boundary handling: pieces that span a chunk boundary are
+/// joined; the trailing in-flight piece is held in a small buffer and
+/// emitted only when a delimiter or end-of-stream is reached.
+pub fn split(
+  over stream: Stream(String),
+  on delimiter: String,
+) -> Stream(String) {
+  case delimiter {
+    "" -> graphemes_active(stream, [], False)
+    _ -> split_active(stream, "", delimiter, False)
+  }
+}
+
+fn split_active(
+  source: Stream(String),
+  buffer: String,
+  delimiter: String,
+  has_seen_input: Bool,
+) -> Stream(String) {
+  datastream.make(
+    pull: fn() { split_pull(source, buffer, delimiter, has_seen_input) },
+    close: fn() { datastream.close(source) },
+  )
+}
+
+fn split_pull(
+  source: Stream(String),
+  buffer: String,
+  delimiter: String,
+  has_seen_input: Bool,
+) -> Step(String, Stream(String)) {
+  case string.split_once(buffer, on: delimiter) {
+    Ok(#(before, after)) ->
+      Next(before, split_active(source, after, delimiter, True))
+    Error(_) ->
+      case datastream.pull(source) {
+        Next(chunk, source_rest) ->
+          split_pull(source_rest, buffer <> chunk, delimiter, True)
+        Done ->
+          case has_seen_input {
+            True -> Next(buffer, split_drained())
+            False -> Done
+          }
+      }
+  }
+}
+
+fn split_drained() -> Stream(String) {
+  datastream.make(pull: fn() { Done }, close: fn() { Nil })
+}
+
+fn graphemes_active(
+  source: Stream(String),
+  pending: List(String),
+  source_drained: Bool,
+) -> Stream(String) {
+  datastream.make(
+    pull: fn() { graphemes_pull(source, pending, source_drained) },
+    close: fn() {
+      case source_drained {
+        True -> Nil
+        False -> datastream.close(source)
+      }
+    },
+  )
+}
+
+fn graphemes_pull(
+  source: Stream(String),
+  pending: List(String),
+  source_drained: Bool,
+) -> Step(String, Stream(String)) {
+  case pending {
+    [grapheme, ..rest] ->
+      Next(grapheme, graphemes_active(source, rest, source_drained))
+    [] ->
+      case source_drained {
+        True -> Done
+        False ->
+          case datastream.pull(source) {
+            Done -> Done
+            Next(chunk, source_rest) ->
+              graphemes_pull(source_rest, string.to_graphemes(chunk), False)
+          }
+      }
+  }
+}

--- a/test/datastream/text_test.gleam
+++ b/test/datastream/text_test.gleam
@@ -1,0 +1,146 @@
+import datastream.{Done, Next}
+import datastream/fold
+import datastream/text
+import gleeunit
+import gleeunit/should
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+fn from_list(list) {
+  datastream.unfold(from: list, with: fn(xs) {
+    case xs {
+      [] -> Done
+      [head, ..tail] -> Next(element: head, state: tail)
+    }
+  })
+}
+
+// --- lines -----------------------------------------------------------------
+
+pub fn lines_terminated_by_lf_test() {
+  from_list(["hello\nworld\n"])
+  |> text.lines
+  |> fold.to_list
+  |> should.equal(["hello", "world"])
+}
+
+pub fn lines_partial_trailing_line_emitted_test() {
+  from_list(["hello\nworld"])
+  |> text.lines
+  |> fold.to_list
+  |> should.equal(["hello", "world"])
+}
+
+pub fn lines_empty_chunk_yields_no_lines_test() {
+  from_list([""]) |> text.lines |> fold.to_list |> should.equal([])
+}
+
+pub fn lines_two_consecutive_terminators_yield_two_empty_lines_test() {
+  from_list(["\n\n"]) |> text.lines |> fold.to_list |> should.equal(["", ""])
+}
+
+pub fn lines_crlf_terminator_test() {
+  from_list(["a\r\nb\r\n"])
+  |> text.lines
+  |> fold.to_list
+  |> should.equal(["a", "b"])
+}
+
+pub fn lines_split_across_chunks_test() {
+  from_list(["hel", "lo\nwor", "ld"])
+  |> text.lines
+  |> fold.to_list
+  |> should.equal(["hello", "world"])
+}
+
+pub fn lines_crlf_split_across_chunks_test() {
+  from_list(["a\r", "\nb"])
+  |> text.lines
+  |> fold.to_list
+  |> should.equal(["a", "b"])
+}
+
+pub fn lines_lone_cr_at_chunk_end_treated_as_terminator_test() {
+  from_list(["a\r", "b"])
+  |> text.lines
+  |> fold.to_list
+  |> should.equal(["a", "b"])
+}
+
+pub fn lines_on_truly_empty_source_yields_no_lines_test() {
+  from_list([]) |> text.lines |> fold.to_list |> should.equal([])
+}
+
+// --- split -----------------------------------------------------------------
+
+pub fn split_on_comma_yields_pieces_test() {
+  from_list(["a,b,c"])
+  |> text.split(on: ",")
+  |> fold.to_list
+  |> should.equal(["a", "b", "c"])
+}
+
+pub fn split_preserves_empty_between_consecutive_delimiters_test() {
+  from_list(["a,,b"])
+  |> text.split(on: ",")
+  |> fold.to_list
+  |> should.equal(["a", "", "b"])
+}
+
+pub fn split_preserves_trailing_empty_test() {
+  from_list(["a,b,"])
+  |> text.split(on: ",")
+  |> fold.to_list
+  |> should.equal(["a", "b", ""])
+}
+
+pub fn split_preserves_leading_empty_test() {
+  from_list([",a,b"])
+  |> text.split(on: ",")
+  |> fold.to_list
+  |> should.equal(["", "a", "b"])
+}
+
+pub fn split_empty_input_yields_one_empty_test() {
+  from_list([""])
+  |> text.split(on: ",")
+  |> fold.to_list
+  |> should.equal([""])
+}
+
+pub fn split_truly_empty_source_yields_empty_test() {
+  from_list([])
+  |> text.split(on: ",")
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn split_delimiter_across_chunk_boundary_test() {
+  from_list(["a,b", ",c"])
+  |> text.split(on: ",")
+  |> fold.to_list
+  |> should.equal(["a", "b", "c"])
+}
+
+pub fn split_non_delimiter_join_across_chunks_test() {
+  from_list(["a,b", "c,d"])
+  |> text.split(on: ",")
+  |> fold.to_list
+  |> should.equal(["a", "bc", "d"])
+}
+
+pub fn split_empty_delimiter_emits_each_grapheme_test() {
+  from_list(["abc"])
+  |> text.split(on: "")
+  |> fold.to_list
+  |> should.equal(["a", "b", "c"])
+}
+
+pub fn split_empty_delimiter_handles_multibyte_grapheme_test() {
+  from_list(["a👍b"])
+  |> text.split(on: "")
+  |> fold.to_list
+  |> should.equal(["a", "👍", "b"])
+}


### PR DESCRIPTION
## Summary

Phase 5 starts with `datastream/text`: chunk-boundary-aware line splitting (`lines`) and arbitrary-delimiter splitting (`split`) for `Stream(String)`. Both absorb the chunk boundaries that real text inputs (file reads, network reads) sit on, with bounded internal buffering.

## Design decisions

- **`lines` recognises `\n`, `\r\n`, and lone `\r` as terminators.** Within a single chunk, Gleam's grapheme cluster rules return `\r\n` as one cluster, so the `pop_grapheme` scan picks it up directly. The explicit `"\r"` case handles the chunk-split lookahead: a `\r` at the buffer tail is held until the next chunk arrives, then either combined with a leading `\n` as `\r\n` or treated as a lone-`\r` terminator (also if the source has drained).
- **`lines` emits the trailing partial line.** Inputs that omit a final terminator do not silently lose their last record.
- **`split` joins across chunk boundaries via the buffer.** `string.split_once` finds the first delimiter in the joined buffer; what comes after stays as the next buffer. Pieces split across two chunks naturally merge (e.g. `["a,b", "c,d"]` → `["a", "bc", "d"]`).
- **`split` distinguishes empty source from a single empty element.** A `has_seen_input` flag ensures `from_list([])` → `[]` (no elements) while `from_list([""])` → `[""]` (one empty element).
- **`split("")` is the grapheme-cluster splitter.** Implemented via `string.to_graphemes` per chunk; emits one element per Unicode grapheme cluster. Bounded state.
- **Both consume `Stream(String)`, not `Stream(BitArray)`.** The byte → string boundary is owned by `text.utf8_decode` (#15) so the cost lives in one place.

## Tests

`just all` is green: Erlang 212 / JS 191 (Erlang-only counter tests from prior PRs don't run under JS).

- `lines`: 9 cases — LF terminator, partial trailing line, empty chunk, two consecutive terminators, CRLF, chunks split mid-line, CRLF split across chunks, lone CR at chunk end, truly empty source.
- `split`: 10 cases — single chunk, consecutive / leading / trailing empty pieces, empty input → `[""]`, truly empty source → `[]`, delimiter and non-delimiter splits across chunk boundaries, grapheme splitter on ASCII and on a multibyte emoji.

Closes #14.