### PR TITLE
feat: add text.utf8_decode and text.utf8_encode

### DIFF
--- a/src/datastream/text.gleam
+++ b/src/datastream/text.gleam
@@ -11,6 +11,7 @@
 //// `text.utf8_decode` (separate issue) so the cost lives in one place.
 
 import datastream.{type Step, type Stream, Done, Next}
+import gleam/bit_array
 import gleam/option.{type Option, None, Some}
 import gleam/string
 
@@ -198,4 +199,196 @@ fn graphemes_pull(
           }
       }
   }
+}
+
+// --- UTF-8 decode / encode ------------------------------------------------
+
+/// Decode a stream of UTF-8 byte chunks into a stream of decoded
+/// strings, reassembling multi-byte codepoints split across chunks.
+///
+/// Each successfully decoded codepoint surfaces as `Ok(string)`. An
+/// invalid byte (lead byte that is not a valid UTF-8 start, or a
+/// missing/invalid continuation) emits exactly one `Error(Nil)` and
+/// decoding resumes from the next byte. An incomplete trailing
+/// sequence at end-of-stream emits a final `Error(Nil)` before halting.
+///
+/// The decoder holds a small internal buffer for partial multi-byte
+/// codepoints; it never materialises the full input.
+pub fn utf8_decode(over stream: Stream(BitArray)) -> Stream(Result(String, Nil)) {
+  utf8_decode_active(stream, <<>>, False)
+}
+
+fn utf8_decode_active(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  source_drained: Bool,
+) -> Stream(Result(String, Nil)) {
+  datastream.make(
+    pull: fn() { utf8_decode_pull(source, buffer, source_drained) },
+    close: fn() {
+      case source_drained {
+        True -> Nil
+        False -> datastream.close(source)
+      }
+    },
+  )
+}
+
+fn utf8_decode_pull(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  source_drained: Bool,
+) -> Step(Result(String, Nil), Stream(Result(String, Nil))) {
+  case extract_run(buffer, source_drained) {
+    RunOkAccum(bytes, remaining) ->
+      case bit_array.to_string(bytes) {
+        Ok(s) ->
+          Next(Ok(s), utf8_decode_active(source, remaining, source_drained))
+        Error(_) ->
+          Next(
+            Error(Nil),
+            utf8_decode_active(source, remaining, source_drained),
+          )
+      }
+    RunInvalid(remaining) ->
+      Next(Error(Nil), utf8_decode_active(source, remaining, source_drained))
+    RunNeedMore ->
+      case datastream.pull(source) {
+        Next(chunk, source_rest) ->
+          utf8_decode_pull(source_rest, bit_array.append(buffer, chunk), False)
+        Done -> utf8_decode_pull(source, buffer, True)
+      }
+    RunDone -> Done
+  }
+}
+
+type Run {
+  RunOkAccum(bytes: BitArray, remaining: BitArray)
+  RunInvalid(remaining: BitArray)
+  RunNeedMore
+  RunDone
+}
+
+fn extract_run(buffer: BitArray, source_drained: Bool) -> Run {
+  do_extract_run(buffer, <<>>, source_drained)
+}
+
+fn do_extract_run(
+  buffer: BitArray,
+  accumulated: BitArray,
+  source_drained: Bool,
+) -> Run {
+  case extract_codepoint(buffer, source_drained) {
+    DecodeOk(bytes, rest) ->
+      do_extract_run(rest, bit_array.append(accumulated, bytes), source_drained)
+    DecodeInvalid(rest) ->
+      case bit_array.byte_size(accumulated) {
+        0 -> RunInvalid(rest)
+        _ -> RunOkAccum(accumulated, buffer)
+      }
+    DecodeNeedMore ->
+      case bit_array.byte_size(accumulated) {
+        0 -> RunNeedMore
+        _ -> RunOkAccum(accumulated, buffer)
+      }
+    DecodeDone ->
+      case bit_array.byte_size(accumulated) {
+        0 -> RunDone
+        _ -> RunOkAccum(accumulated, <<>>)
+      }
+  }
+}
+
+type Decoded {
+  DecodeOk(bytes: BitArray, rest: BitArray)
+  DecodeInvalid(rest: BitArray)
+  DecodeNeedMore
+  DecodeDone
+}
+
+fn extract_codepoint(buffer: BitArray, source_drained: Bool) -> Decoded {
+  case buffer {
+    <<>> ->
+      case source_drained {
+        True -> DecodeDone
+        False -> DecodeNeedMore
+      }
+    <<lead:size(8), rest:bits>> ->
+      classify_and_extract(lead, rest, source_drained)
+    _ -> DecodeInvalid(<<>>)
+  }
+}
+
+fn classify_and_extract(
+  lead: Int,
+  rest: BitArray,
+  source_drained: Bool,
+) -> Decoded {
+  case lead {
+    l if l < 0x80 -> DecodeOk(<<l>>, rest)
+    l if l < 0xC2 -> DecodeInvalid(rest)
+    l if l < 0xE0 -> collect_continuation(lead, <<>>, rest, 1, source_drained)
+    l if l < 0xF0 -> collect_continuation(lead, <<>>, rest, 2, source_drained)
+    l if l < 0xF5 -> collect_continuation(lead, <<>>, rest, 3, source_drained)
+    _ -> DecodeInvalid(rest)
+  }
+}
+
+fn collect_continuation(
+  lead: Int,
+  collected: BitArray,
+  rest: BitArray,
+  need: Int,
+  source_drained: Bool,
+) -> Decoded {
+  case need {
+    0 -> DecodeOk(bit_array.append(<<lead>>, collected), rest)
+    _ -> consume_continuation(lead, collected, rest, need, source_drained)
+  }
+}
+
+fn consume_continuation(
+  lead: Int,
+  collected: BitArray,
+  rest: BitArray,
+  need: Int,
+  source_drained: Bool,
+) -> Decoded {
+  case rest {
+    <<>> ->
+      case source_drained {
+        True -> DecodeInvalid(<<>>)
+        False -> DecodeNeedMore
+      }
+    <<b:size(8), more:bits>> ->
+      case b >= 0x80 && b < 0xC0 {
+        True ->
+          collect_continuation(
+            lead,
+            bit_array.append(collected, <<b>>),
+            more,
+            need - 1,
+            source_drained,
+          )
+        False -> DecodeInvalid(rest)
+      }
+    _ -> DecodeInvalid(rest)
+  }
+}
+
+/// Encode a stream of strings as UTF-8 byte chunks.
+///
+/// Each input string maps to its UTF-8 encoding as a single
+/// `BitArray` element; an empty input string maps to the empty
+/// `BitArray`.
+pub fn utf8_encode(over stream: Stream(String)) -> Stream(BitArray) {
+  datastream.make(
+    pull: fn() {
+      case datastream.pull(stream) {
+        Next(s, rest) -> Next(bit_array.from_string(s), utf8_encode(over: rest))
+        Done -> Done
+      }
+    },
+    close: fn() { datastream.close(stream) },
+  )
 }

--- a/test/datastream/text_test.gleam
+++ b/test/datastream/text_test.gleam
@@ -144,3 +144,108 @@ pub fn split_empty_delimiter_handles_multibyte_grapheme_test() {
   |> fold.to_list
   |> should.equal(["a", "👍", "b"])
 }
+
+// --- utf8_decode ----------------------------------------------------------
+
+pub fn utf8_decode_simple_ascii_test() {
+  from_list([<<104, 105>>])
+  |> text.utf8_decode
+  |> fold.to_list
+  |> should.equal([Ok("hi")])
+}
+
+pub fn utf8_decode_empty_chunk_yields_no_elements_test() {
+  from_list([<<>>]) |> text.utf8_decode |> fold.to_list |> should.equal([])
+}
+
+pub fn utf8_decode_empty_source_yields_empty_test() {
+  from_list([]) |> text.utf8_decode |> fold.to_list |> should.equal([])
+}
+
+pub fn utf8_decode_four_byte_codepoint_in_one_chunk_test() {
+  from_list([<<240, 159, 145, 141>>])
+  |> text.utf8_decode
+  |> fold.to_list
+  |> should.equal([Ok("👍")])
+}
+
+pub fn utf8_decode_codepoint_split_across_chunks_2_2_test() {
+  from_list([<<240, 159>>, <<145, 141>>])
+  |> text.utf8_decode
+  |> fold.to_list
+  |> should.equal([Ok("👍")])
+}
+
+pub fn utf8_decode_codepoint_split_across_chunks_3_1_test() {
+  from_list([<<240, 159, 145>>, <<141>>])
+  |> text.utf8_decode
+  |> fold.to_list
+  |> should.equal([Ok("👍")])
+}
+
+pub fn utf8_decode_per_chunk_decode_test() {
+  from_list([<<104>>, <<105>>])
+  |> text.utf8_decode
+  |> fold.to_list
+  |> should.equal([Ok("h"), Ok("i")])
+}
+
+pub fn utf8_decode_invalid_lead_byte_test() {
+  from_list([<<255>>])
+  |> text.utf8_decode
+  |> fold.to_list
+  |> should.equal([Error(Nil)])
+}
+
+pub fn utf8_decode_resumes_after_error_test() {
+  from_list([<<104, 255, 105>>])
+  |> text.utf8_decode
+  |> fold.to_list
+  |> should.equal([Ok("h"), Error(Nil), Ok("i")])
+}
+
+pub fn utf8_decode_incomplete_trailing_sequence_at_eof_test() {
+  from_list([<<240, 159>>])
+  |> text.utf8_decode
+  |> fold.to_list
+  |> should.equal([Error(Nil)])
+}
+
+// --- utf8_encode ----------------------------------------------------------
+
+pub fn utf8_encode_ascii_test() {
+  from_list(["hi"])
+  |> text.utf8_encode
+  |> fold.to_list
+  |> should.equal([<<104, 105>>])
+}
+
+pub fn utf8_encode_empty_string_yields_empty_bit_array_test() {
+  from_list([""]) |> text.utf8_encode |> fold.to_list |> should.equal([<<>>])
+}
+
+pub fn utf8_encode_multibyte_codepoint_test() {
+  from_list(["👍"])
+  |> text.utf8_encode
+  |> fold.to_list
+  |> should.equal([<<240, 159, 145, 141>>])
+}
+
+pub fn utf8_encode_per_chunk_test() {
+  from_list(["a", "b", "c"])
+  |> text.utf8_encode
+  |> fold.to_list
+  |> should.equal([<<97>>, <<98>>, <<99>>])
+}
+
+pub fn utf8_encode_empty_source_yields_empty_test() {
+  from_list([]) |> text.utf8_encode |> fold.to_list |> should.equal([])
+}
+
+pub fn utf8_encode_then_decode_round_trip_ascii_test() {
+  from_list(["hello"])
+  |> text.utf8_encode
+  |> text.utf8_decode
+  |> fold.collect_result
+  |> should.equal(Ok(["hello"]))
+}


### PR DESCRIPTION
## Summary

Phase 5 continues with the byte ↔ string bridge. With this PR, every text combinator above this layer can assume `Stream(String)` while callers wrapping byte sources (file reads, socket reads) get a deterministic UTF-8 boundary that absorbs split multi-byte codepoints.

## Design decisions

- **Codepoint walker, run-accumulator emit shape.** A small UTF-8 lead-byte classifier (1 / 2 / 3 / 4 byte sequences) extracts one codepoint at a time. Consecutive valid codepoints accumulate into a single `Ok(string)` emit so `[<<104, 105>>]` → `[Ok(\"hi\")]` while `[<<104>>, <<105>>]` → `[Ok(\"h\"), Ok(\"i\")]` — chunk boundary, not codepoint boundary, drives `Ok` emits. Invalid bytes and end-of-stream interrupt the run and force the accumulator to flush before they emit their own `Error(Nil)`.
- **Bounded internal buffer.** Multi-byte sequences split across chunk boundaries (2+2, 3+1) are held in the internal buffer until the next chunk arrives; the implementation never materialises the full input.
- **Errors are in-band.** Invalid lead byte (`< 0xC2`, or `>= 0xF5`), invalid / missing continuation byte (`!= 10xxxxxx`), and incomplete trailing sequence at EOF all surface as exactly one `Error(Nil)` element. Decoding resumes from the next byte after the error. Matches the project-wide policy of carrying errors as elements.
- **`utf8_encode` is a one-line `bit_array.from_string` wrapper.** Empty input string maps to empty `BitArray`. The encoder cannot fail because every Gleam `String` is well-formed UTF-8.

## Tests

`just all` is green: Erlang 228 / JS 207.

- `utf8_decode`: 10 cases — ASCII single chunk, empty chunk, empty source, 4-byte codepoint single chunk, 2+2 split, 3+1 split, per-chunk decode, invalid lead byte, decode resumes after error in mid-chunk, incomplete trailing sequence at EOF.
- `utf8_encode`: 5 cases — ASCII, empty string → empty BitArray, multibyte codepoint, per-chunk, empty source.
- Round-trip: `utf8_encode |> utf8_decode |> collect_result == Ok([s])` for ASCII.

Closes #15.