### PR TITLE
feat: add binary framing module

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -70,3 +70,10 @@ thrown_away_error = "off"
   "short_variable_name",
   "unused_exports",
 ]
+# `binary.length_prefixed` and `binary.fixed_size` reject malformed
+# arguments with `panic` at construction time per the spec (#16): the
+# only sensible response to a programmer error like `prefix_size = 3`
+# is to crash, so callers can't quietly trust a bogus framing.
+"src/datastream/binary.gleam" = [
+  "avoid_panic",
+]

--- a/src/datastream/binary.gleam
+++ b/src/datastream/binary.gleam
@@ -1,0 +1,358 @@
+//// Framing operations on `Stream(BitArray)`.
+////
+//// Real byte sources (sockets, files, pipes) deliver bytes in
+//// arbitrary chunks. A frame may straddle chunks, several frames may
+//// sit in one chunk, or a chunk may end mid-prefix. Every framing
+//// combinator here owns the buffer needed to reassemble.
+////
+//// All combinators are lazy and chunk-boundary-aware; none of them
+//// materialises the full input.
+
+import datastream.{type Step, type Stream, Done, Next}
+import gleam/bit_array
+
+// --- bytes ----------------------------------------------------------------
+
+/// Yield each byte of each chunk in order, as `Int` in `0..255`.
+///
+/// The trivial degenerate framing: bridges from `Stream(BitArray)` to
+/// `Stream(Int)` so callers can move into the byte-stream-shaped world
+/// without writing the per-byte `unfold` themselves.
+pub fn bytes(over stream: Stream(BitArray)) -> Stream(Int) {
+  bytes_active(stream, <<>>, False)
+}
+
+fn bytes_active(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  source_drained: Bool,
+) -> Stream(Int) {
+  datastream.make(
+    pull: fn() { bytes_pull(source, buffer, source_drained) },
+    close: fn() {
+      case source_drained {
+        True -> Nil
+        False -> datastream.close(source)
+      }
+    },
+  )
+}
+
+fn bytes_pull(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  source_drained: Bool,
+) -> Step(Int, Stream(Int)) {
+  case buffer {
+    <<b:size(8), rest:bits>> ->
+      Next(b, bytes_active(source, rest, source_drained))
+    _ ->
+      case source_drained {
+        True -> Done
+        False ->
+          case datastream.pull(source) {
+            Next(chunk, source_rest) ->
+              bytes_pull(source_rest, bit_array.append(buffer, chunk), False)
+            Done -> bytes_pull(source, buffer, True)
+          }
+      }
+  }
+}
+
+// --- length-prefixed -----------------------------------------------------
+
+/// Read a `prefix_size` byte big-endian unsigned length, then yield
+/// the next `length` bytes as a frame.
+///
+/// `prefix_size` MUST be one of `{1, 2, 4, 8}`. Other values are
+/// rejected at construction time with a panic.
+///
+/// Incomplete frames at end-of-input (short prefix or short payload)
+/// are NOT emitted; the stream simply halts.
+pub fn length_prefixed(
+  over stream: Stream(BitArray),
+  prefix_size prefix_size: Int,
+) -> Stream(BitArray) {
+  case prefix_size {
+    1 | 2 | 4 | 8 -> length_prefixed_active(stream, <<>>, prefix_size, False)
+    _ ->
+      panic as "datastream/binary.length_prefixed: prefix_size must be 1, 2, 4, or 8"
+  }
+}
+
+fn length_prefixed_active(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  prefix_size: Int,
+  source_drained: Bool,
+) -> Stream(BitArray) {
+  datastream.make(
+    pull: fn() {
+      length_prefixed_pull(source, buffer, prefix_size, source_drained)
+    },
+    close: fn() {
+      case source_drained {
+        True -> Nil
+        False -> datastream.close(source)
+      }
+    },
+  )
+}
+
+fn length_prefixed_pull(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  prefix_size: Int,
+  source_drained: Bool,
+) -> Step(BitArray, Stream(BitArray)) {
+  case bit_array.byte_size(buffer) >= prefix_size {
+    False ->
+      ensure_more(source, buffer, source_drained, fn(s, b, d) {
+        length_prefixed_pull(s, b, prefix_size, d)
+      })
+    True ->
+      length_prefixed_with_prefix(source, buffer, prefix_size, source_drained)
+  }
+}
+
+fn length_prefixed_with_prefix(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  prefix_size: Int,
+  source_drained: Bool,
+) -> Step(BitArray, Stream(BitArray)) {
+  let length = read_prefix(buffer, prefix_size)
+  let total_needed = prefix_size + length
+  case bit_array.byte_size(buffer) >= total_needed {
+    True ->
+      case
+        bit_array.slice(buffer, prefix_size, length),
+        bit_array.slice(
+          buffer,
+          total_needed,
+          bit_array.byte_size(buffer) - total_needed,
+        )
+      {
+        Ok(frame), Ok(rest) ->
+          Next(
+            frame,
+            length_prefixed_active(source, rest, prefix_size, source_drained),
+          )
+        _, _ -> Done
+      }
+    False ->
+      ensure_more(source, buffer, source_drained, fn(s, b, d) {
+        length_prefixed_pull(s, b, prefix_size, d)
+      })
+  }
+}
+
+fn read_prefix(buffer: BitArray, size: Int) -> Int {
+  case size, buffer {
+    1, <<n:size(8), _:bits>> -> n
+    2, <<n:size(16), _:bits>> -> n
+    4, <<n:size(32), _:bits>> -> n
+    8, <<n:size(64), _:bits>> -> n
+    _, _ -> 0
+  }
+}
+
+// --- delimited ------------------------------------------------------------
+
+/// Yield delimiter-separated frames in source order, preserving empty
+/// frames between consecutive delimiters and the trailing frame after
+/// a trailing delimiter. The delimiter itself is NOT included in any
+/// emitted frame.
+///
+/// If the input does not end with a delimiter, the trailing partial
+/// frame is emitted as the last element.
+pub fn delimited(
+  over stream: Stream(BitArray),
+  on delimiter: BitArray,
+) -> Stream(BitArray) {
+  delimited_active(stream, <<>>, delimiter, False, False)
+}
+
+fn delimited_active(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  delimiter: BitArray,
+  source_drained: Bool,
+  has_seen_input: Bool,
+) -> Stream(BitArray) {
+  datastream.make(
+    pull: fn() {
+      delimited_pull(source, buffer, delimiter, source_drained, has_seen_input)
+    },
+    close: fn() {
+      case source_drained {
+        True -> Nil
+        False -> datastream.close(source)
+      }
+    },
+  )
+}
+
+fn delimited_pull(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  delimiter: BitArray,
+  source_drained: Bool,
+  has_seen_input: Bool,
+) -> Step(BitArray, Stream(BitArray)) {
+  case find_delimiter(buffer, delimiter, 0) {
+    Ok(pos) -> {
+      let delim_size = bit_array.byte_size(delimiter)
+      case
+        bit_array.slice(buffer, 0, pos),
+        bit_array.slice(
+          buffer,
+          pos + delim_size,
+          bit_array.byte_size(buffer) - pos - delim_size,
+        )
+      {
+        Ok(frame), Ok(rest) ->
+          Next(
+            frame,
+            delimited_active(source, rest, delimiter, source_drained, True),
+          )
+        _, _ -> Done
+      }
+    }
+    Error(_) ->
+      case source_drained {
+        True ->
+          case has_seen_input || bit_array.byte_size(buffer) > 0 {
+            True -> Next(buffer, delimited_drained())
+            False -> Done
+          }
+        False ->
+          case datastream.pull(source) {
+            Next(chunk, source_rest) ->
+              delimited_pull(
+                source_rest,
+                bit_array.append(buffer, chunk),
+                delimiter,
+                False,
+                has_seen_input || bit_array.byte_size(chunk) > 0,
+              )
+            Done ->
+              delimited_pull(source, buffer, delimiter, True, has_seen_input)
+          }
+      }
+  }
+}
+
+fn delimited_drained() -> Stream(BitArray) {
+  datastream.make(pull: fn() { Done }, close: fn() { Nil })
+}
+
+fn find_delimiter(
+  buffer: BitArray,
+  delimiter: BitArray,
+  pos: Int,
+) -> Result(Int, Nil) {
+  let buffer_size = bit_array.byte_size(buffer)
+  let delim_size = bit_array.byte_size(delimiter)
+  case pos + delim_size > buffer_size {
+    True -> Error(Nil)
+    False ->
+      case bit_array.slice(buffer, pos, delim_size) {
+        Ok(window) ->
+          case window == delimiter {
+            True -> Ok(pos)
+            False -> find_delimiter(buffer, delimiter, pos + 1)
+          }
+        Error(_) -> Error(Nil)
+      }
+  }
+}
+
+// --- fixed-size ----------------------------------------------------------
+
+/// Yield successive `size`-byte frames in source order. The trailing
+/// partial frame on EOF is discarded — by definition a fixed-size
+/// framing combinator cannot emit a frame of fewer than `size` bytes.
+///
+/// `size` MUST be `>= 1`. Other values are rejected at construction
+/// time with a panic.
+pub fn fixed_size(
+  over stream: Stream(BitArray),
+  size size: Int,
+) -> Stream(BitArray) {
+  case size >= 1 {
+    True -> fixed_size_active(stream, <<>>, size, False)
+    False -> panic as "datastream/binary.fixed_size: size must be >= 1"
+  }
+}
+
+fn fixed_size_active(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  size: Int,
+  source_drained: Bool,
+) -> Stream(BitArray) {
+  datastream.make(
+    pull: fn() { fixed_size_pull(source, buffer, size, source_drained) },
+    close: fn() {
+      case source_drained {
+        True -> Nil
+        False -> datastream.close(source)
+      }
+    },
+  )
+}
+
+fn fixed_size_pull(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  size: Int,
+  source_drained: Bool,
+) -> Step(BitArray, Stream(BitArray)) {
+  case bit_array.byte_size(buffer) >= size {
+    True ->
+      case
+        bit_array.slice(buffer, 0, size),
+        bit_array.slice(buffer, size, bit_array.byte_size(buffer) - size)
+      {
+        Ok(frame), Ok(rest) ->
+          Next(frame, fixed_size_active(source, rest, size, source_drained))
+        _, _ -> Done
+      }
+    False ->
+      case source_drained {
+        True -> Done
+        False ->
+          case datastream.pull(source) {
+            Next(chunk, source_rest) ->
+              fixed_size_pull(
+                source_rest,
+                bit_array.append(buffer, chunk),
+                size,
+                False,
+              )
+            Done -> fixed_size_pull(source, buffer, size, True)
+          }
+      }
+  }
+}
+
+// --- internal helpers ----------------------------------------------------
+
+fn ensure_more(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  source_drained: Bool,
+  retry: fn(Stream(BitArray), BitArray, Bool) ->
+    Step(BitArray, Stream(BitArray)),
+) -> Step(BitArray, Stream(BitArray)) {
+  case source_drained {
+    True -> Done
+    False ->
+      case datastream.pull(source) {
+        Next(chunk, source_rest) ->
+          retry(source_rest, bit_array.append(buffer, chunk), False)
+        Done -> retry(source, buffer, True)
+      }
+  }
+}

--- a/test/datastream/binary_test.gleam
+++ b/test/datastream/binary_test.gleam
@@ -1,0 +1,167 @@
+import datastream.{Done, Next}
+import datastream/binary
+import datastream/fold
+import gleeunit
+import gleeunit/should
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+fn from_list(list) {
+  datastream.unfold(from: list, with: fn(xs) {
+    case xs {
+      [] -> Done
+      [head, ..tail] -> Next(element: head, state: tail)
+    }
+  })
+}
+
+// --- bytes ----------------------------------------------------------------
+
+pub fn bytes_yields_each_byte_in_order_test() {
+  from_list([<<1, 2>>, <<3>>])
+  |> binary.bytes
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+}
+
+pub fn bytes_empty_chunk_yields_no_bytes_test() {
+  from_list([<<>>]) |> binary.bytes |> fold.to_list |> should.equal([])
+}
+
+pub fn bytes_empty_source_yields_empty_test() {
+  from_list([]) |> binary.bytes |> fold.to_list |> should.equal([])
+}
+
+pub fn bytes_preserves_full_byte_range_test() {
+  from_list([<<255, 0, 128>>])
+  |> binary.bytes
+  |> fold.to_list
+  |> should.equal([255, 0, 128])
+}
+
+// --- length_prefixed -----------------------------------------------------
+
+pub fn length_prefixed_one_byte_prefix_two_frames_test() {
+  from_list([<<2, 65, 66, 1, 67>>])
+  |> binary.length_prefixed(prefix_size: 1)
+  |> fold.to_list
+  |> should.equal([<<65, 66>>, <<67>>])
+}
+
+pub fn length_prefixed_chunk_boundary_inside_payload_test() {
+  from_list([<<2, 65>>, <<66>>])
+  |> binary.length_prefixed(prefix_size: 1)
+  |> fold.to_list
+  |> should.equal([<<65, 66>>])
+}
+
+pub fn length_prefixed_chunk_boundary_between_prefix_and_payload_test() {
+  from_list([<<2>>, <<65, 66>>])
+  |> binary.length_prefixed(prefix_size: 1)
+  |> fold.to_list
+  |> should.equal([<<65, 66>>])
+}
+
+pub fn length_prefixed_zero_length_frame_test() {
+  from_list([<<0>>])
+  |> binary.length_prefixed(prefix_size: 1)
+  |> fold.to_list
+  |> should.equal([<<>>])
+}
+
+pub fn length_prefixed_incomplete_payload_drops_frame_test() {
+  from_list([<<2, 65>>])
+  |> binary.length_prefixed(prefix_size: 1)
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn length_prefixed_incomplete_prefix_drops_frame_test() {
+  from_list([<<2>>])
+  |> binary.length_prefixed(prefix_size: 2)
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn length_prefixed_four_byte_big_endian_prefix_test() {
+  from_list([<<0, 0, 0, 1, 99>>])
+  |> binary.length_prefixed(prefix_size: 4)
+  |> fold.to_list
+  |> should.equal([<<99>>])
+}
+
+// --- delimited ----------------------------------------------------------
+
+pub fn delimited_yields_frames_separated_by_delimiter_test() {
+  from_list([<<65, 66, 10, 67, 10>>])
+  |> binary.delimited(on: <<10>>)
+  |> fold.to_list
+  |> should.equal([<<65, 66>>, <<67>>, <<>>])
+}
+
+pub fn delimited_preserves_empty_frames_between_consecutive_delimiters_test() {
+  from_list([<<65, 10, 10, 66, 10>>])
+  |> binary.delimited(on: <<10>>)
+  |> fold.to_list
+  |> should.equal([<<65>>, <<>>, <<66>>, <<>>])
+}
+
+pub fn delimited_chunk_boundary_after_delimiter_test() {
+  from_list([<<65, 66, 10>>, <<67>>])
+  |> binary.delimited(on: <<10>>)
+  |> fold.to_list
+  |> should.equal([<<65, 66>>, <<67>>])
+}
+
+pub fn delimited_delimiter_at_start_of_next_chunk_test() {
+  from_list([<<65>>, <<10, 66>>])
+  |> binary.delimited(on: <<10>>)
+  |> fold.to_list
+  |> should.equal([<<65>>, <<66>>])
+}
+
+pub fn delimited_trailing_partial_frame_preserved_test() {
+  from_list([<<65, 10, 66>>])
+  |> binary.delimited(on: <<10>>)
+  |> fold.to_list
+  |> should.equal([<<65>>, <<66>>])
+}
+
+pub fn delimited_empty_input_yields_no_frames_test() {
+  from_list([<<>>])
+  |> binary.delimited(on: <<10>>)
+  |> fold.to_list
+  |> should.equal([])
+}
+
+// --- fixed_size --------------------------------------------------------
+
+pub fn fixed_size_evenly_divisible_test() {
+  from_list([<<1, 2, 3, 4>>])
+  |> binary.fixed_size(size: 2)
+  |> fold.to_list
+  |> should.equal([<<1, 2>>, <<3, 4>>])
+}
+
+pub fn fixed_size_drops_trailing_partial_test() {
+  from_list([<<1, 2, 3, 4, 5>>])
+  |> binary.fixed_size(size: 2)
+  |> fold.to_list
+  |> should.equal([<<1, 2>>, <<3, 4>>])
+}
+
+pub fn fixed_size_frame_straddles_chunks_test() {
+  from_list([<<1, 2, 3>>, <<4, 5, 6>>])
+  |> binary.fixed_size(size: 2)
+  |> fold.to_list
+  |> should.equal([<<1, 2>>, <<3, 4>>, <<5, 6>>])
+}
+
+pub fn fixed_size_empty_input_yields_no_frames_test() {
+  from_list([<<>>])
+  |> binary.fixed_size(size: 2)
+  |> fold.to_list
+  |> should.equal([])
+}


### PR DESCRIPTION
## Summary

Phase 5 closes with `datastream/binary`: framing operations on `Stream(BitArray)` so callers can take a chunked byte stream from a real source (socket, file, pipe) and expose it as a stream of frames or bytes.

## Design decisions

- **`bytes` is the trivial bridge.** `Stream(BitArray)` → `Stream(Int)` (per-byte 0-255). Exists so callers don't write the `unfold` themselves.
- **`length_prefixed` accepts only 1, 2, 4, or 8 byte prefixes.** Big-endian unsigned. Any other size has no clear interpretation and silent acceptance would mask a bug, so the constructor `panic`s. Incomplete frames at EOF (short prefix or short payload) are silently dropped — the stream just halts.
- **`delimited` mirrors text-style splitting.** Empty frames between consecutive delimiters and the trailing partial frame after a no-trailing-delimiter input are preserved, so no structural information from the input is lost. The delimiter search is a sliding-window comparison over the buffer, which transparently handles delimiters that cross chunk boundaries.
- **`delimited` `has_seen_input` is gated on non-empty chunks.** A single empty `BitArray` input correctly yields the empty stream (`[<<>>]` → `[]`) rather than emitting one empty frame.
- **`fixed_size` discards the trailing partial.** A frame of fewer than `size` bytes by definition violates the invariant a fixed-size combinator promises. Callers who need partial bytes should use `delimited` or a custom `unfold`. `size < 1` `panic`s.
- **Two `panic` sites.** Both are programmer-error paths called out by the spec. `gleam.toml` ignores `avoid_panic` for this single source file so the linter does not block spec-mandated behaviour.

## Tests

`just all` is green: Erlang 249 / JS 228.

- `bytes` (4): two-chunk merge, empty chunk, empty source, full byte range (255 / 0 / 128 round-trip).
- `length_prefixed` (7): one-byte prefix two frames, chunk boundary inside payload, chunk boundary between prefix and payload, zero-length frame, incomplete payload, incomplete prefix, four-byte big-endian prefix.
- `delimited` (6): two frames + trailing empty, empty between consecutive delimiters, chunk boundary right after delimiter, delimiter at start of next chunk, trailing partial frame preserved, empty input → empty stream.
- `fixed_size` (4): evenly divisible, trailing partial dropped, frame straddles chunks, empty input.

Closes #16.