### PR TITLE
feat: add datastream/dataprep integration helpers

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -20,6 +20,11 @@ gleam = ">= 1.15.0"
 
 [dependencies]
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+# `dataprep` is required by the `datastream/dataprep` integration
+# helpers (#17). Callers who do not import that module never use
+# `dataprep` at runtime; the dependency only exists so the helper
+# module can compile.
+dataprep = ">= 0.2.0 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,9 +3,11 @@
 
 packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
+  { name = "dataprep", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib"], otp_app = "dataprep", source = "hex", outer_checksum = "FB5EB04A1AE5A85BD7C33E4A0CB4ED63C0669610275AE3DB7868E21C54C7C7B5" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
+  { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
@@ -17,6 +19,7 @@ packages = [
 ]
 
 [requirements]
+dataprep = { version = ">= 0.2.0 and < 1.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.14.0 and < 3.0.0" }

--- a/src/datastream/dataprep.gleam
+++ b/src/datastream/dataprep.gleam
@@ -1,0 +1,76 @@
+//// Optional integration helpers between `datastream` and the
+//// `dataprep` validation library.
+////
+//// Two helpers, both full-traversal: applicative error accumulation
+//// is incompatible with early exit because the whole point is to
+//// surface every failure from one pass.
+////
+//// The core `datastream` API does not depend on `dataprep`. Only
+//// callers who import this module pay the dependency cost.
+
+import dataprep/non_empty_list.{type NonEmptyList}
+import dataprep/validated.{type Validated, Invalid, Valid}
+import datastream.{type Stream}
+import datastream/fold
+import gleam/list
+
+/// Accumulate every element of the stream into a single
+/// `Validated(List(a), e)`.
+///
+/// Returns `Valid(values_in_order)` when every element is `Valid`.
+/// On any `Invalid`, returns `Invalid(errors_accumulated_in_order)` —
+/// errors from later `Invalid` elements append to the running
+/// error list, preserving source order across all failures.
+///
+/// Empty stream → `Valid([])`.
+///
+/// Drives the entire stream; never short-circuits.
+pub fn collect_validated(
+  over stream: Stream(Validated(a, e)),
+) -> Validated(List(a), e) {
+  let folded = fold.fold(over: stream, from: Valid([]), with: collect_step)
+  case folded {
+    Valid(values) -> Valid(list.reverse(values))
+    Invalid(errors) -> Invalid(errors)
+  }
+}
+
+fn collect_step(
+  acc: Validated(List(a), e),
+  next: Validated(a, e),
+) -> Validated(List(a), e) {
+  case acc, next {
+    Valid(values), Valid(value) -> Valid([value, ..values])
+    Valid(_), Invalid(errors) -> Invalid(errors)
+    Invalid(acc_errors), Valid(_) -> Invalid(acc_errors)
+    Invalid(acc_errors), Invalid(errors) ->
+      Invalid(non_empty_list.append(acc_errors, errors))
+  }
+}
+
+/// Split the stream into a list of valid values and a list of
+/// per-element error groups, both in source order.
+///
+/// Each `Invalid(NonEmptyList(e))` element contributes one entry to
+/// the right-hand list, keeping the per-element error grouping that
+/// the validation library guarantees on its `Invalid` constructor.
+///
+/// Drives the entire stream; never short-circuits.
+pub fn partition_validated(
+  over stream: Stream(Validated(a, e)),
+) -> #(List(a), List(NonEmptyList(e))) {
+  let #(valids, invalids) =
+    fold.fold(over: stream, from: #([], []), with: partition_step)
+  #(list.reverse(valids), list.reverse(invalids))
+}
+
+fn partition_step(
+  acc: #(List(a), List(NonEmptyList(e))),
+  next: Validated(a, e),
+) -> #(List(a), List(NonEmptyList(e))) {
+  let #(valids, invalids) = acc
+  case next {
+    Valid(value) -> #([value, ..valids], invalids)
+    Invalid(errors) -> #(valids, [errors, ..invalids])
+  }
+}

--- a/test/datastream/dataprep_test.gleam
+++ b/test/datastream/dataprep_test.gleam
@@ -1,0 +1,109 @@
+import dataprep/non_empty_list
+import dataprep/validated.{Invalid, Valid}
+import datastream.{Done, Next}
+import datastream/dataprep
+import gleeunit
+import gleeunit/should
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+fn from_list(list) {
+  datastream.unfold(from: list, with: fn(xs) {
+    case xs {
+      [] -> Done
+      [head, ..tail] -> Next(element: head, state: tail)
+    }
+  })
+}
+
+// --- collect_validated ---------------------------------------------------
+
+pub fn collect_validated_all_valid_test() {
+  from_list([Valid(1), Valid(2), Valid(3)])
+  |> dataprep.collect_validated
+  |> should.equal(Valid([1, 2, 3]))
+}
+
+pub fn collect_validated_empty_test() {
+  let empty: List(validated.Validated(Int, String)) = []
+  from_list(empty)
+  |> dataprep.collect_validated
+  |> should.equal(Valid([]))
+}
+
+pub fn collect_validated_accumulates_errors_in_source_order_test() {
+  let result =
+    from_list([
+      Valid(1),
+      Invalid(non_empty_list.single("e1")),
+      Valid(2),
+      Invalid(non_empty_list.NonEmptyList(first: "e2", rest: ["e3"])),
+    ])
+    |> dataprep.collect_validated
+  case result {
+    Valid(_) -> panic as "expected Invalid"
+    Invalid(errors) ->
+      non_empty_list.to_list(errors) |> should.equal(["e1", "e2", "e3"])
+  }
+}
+
+pub fn collect_validated_first_invalid_alone_test() {
+  let result =
+    from_list([Valid(1), Invalid(non_empty_list.single("only"))])
+    |> dataprep.collect_validated
+  case result {
+    Valid(_) -> panic as "expected Invalid"
+    Invalid(errors) -> non_empty_list.to_list(errors) |> should.equal(["only"])
+  }
+}
+
+// --- partition_validated ------------------------------------------------
+
+pub fn partition_validated_one_valid_one_invalid_test() {
+  let #(valids, invalids) =
+    from_list([Valid(1), Invalid(non_empty_list.single("e"))])
+    |> dataprep.partition_validated
+  valids |> should.equal([1])
+  invalids
+  |> list_of_nel_to_list_of_list
+  |> should.equal([["e"]])
+}
+
+pub fn partition_validated_preserves_per_element_grouping_test() {
+  let #(valids, invalids) =
+    from_list([
+      Invalid(non_empty_list.NonEmptyList(first: "e1", rest: ["e2"])),
+      Valid(7),
+      Invalid(non_empty_list.single("e3")),
+    ])
+    |> dataprep.partition_validated
+  valids |> should.equal([7])
+  invalids
+  |> list_of_nel_to_list_of_list
+  |> should.equal([["e1", "e2"], ["e3"]])
+}
+
+pub fn partition_validated_empty_test() {
+  let empty: List(validated.Validated(Int, String)) = []
+  let #(valids, invalids) =
+    from_list(empty)
+    |> dataprep.partition_validated
+  valids |> should.equal([])
+  invalids
+  |> list_of_nel_to_list_of_list
+  |> should.equal([])
+}
+
+fn list_of_nel_to_list_of_list(
+  nels: List(non_empty_list.NonEmptyList(e)),
+) -> List(List(e)) {
+  case nels {
+    [] -> []
+    [head, ..tail] -> [
+      non_empty_list.to_list(head),
+      ..list_of_nel_to_list_of_list(tail)
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Phase 6 (the only phase): bridge a stream of `dataprep.Validated` values into either an accumulated batch result or a partitioned pair. Adds the optional `datastream/dataprep` module.

## Public API

```gleam
pub fn collect_validated(
  Stream(dataprep.Validated(a, e)),
) -> dataprep.Validated(List(a), e)

pub fn partition_validated(
  Stream(dataprep.Validated(a, e)),
) -> #(List(a), List(non_empty_list.NonEmptyList(e)))
```

## Design decisions

- **Both helpers are full-traversal.** Applicative error accumulation is incompatible with early exit — the whole point is to surface every failure from one pass.
- **`collect_validated` accumulates errors in source order.** Folding starts with `Valid([])`; each `Invalid` either switches the state to `Invalid` or `non_empty_list.append`s its errors onto the running list. On all-`Valid`, the values list is reversed once at the end.
- **`partition_validated` preserves per-element error grouping.** Each `Invalid(NonEmptyList(e))` element contributes one entry to the right-hand list, keeping the per-row grouping the validation library guarantees on its `Invalid` constructor. The two output lists are reversed once at the end.
- **`dataprep` is added to `[dependencies]`, not `[dev-dependencies]`.** The helper module needs the types at compile time. Callers who never `import datastream/dataprep` execute no `dataprep` code at runtime; they just pay the compile-time cost. This is the closest Gleam gets to optional integration.

## Tests

`just all` is green: Erlang 256 / JS 235.

- `collect_validated`: 4 cases — all valid, empty stream → `Valid([])`, multiple invalids accumulating errors across them in source order, single trailing invalid.
- `partition_validated`: 3 cases — one valid + one invalid, three elements with mixed valid/invalid preserving per-element grouping, empty stream.
- A `list_of_nel_to_list_of_list` helper unwraps `NonEmptyList` for cross-target equality assertions because `should.equal` on `NonEmptyList` types didn't pin error ordering as cleanly as a plain list.

Closes #17.