### PR TITLE
feat: add BEAM-only source constructors (datastream/erlang/source)

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -25,6 +25,10 @@ gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 # `dataprep` at runtime; the dependency only exists so the helper
 # module can compile.
 dataprep = ">= 0.2.0 and < 1.0.0"
+# `gleam_erlang` is required by the BEAM-only modules under
+# `datastream/erlang/*` (#18-#21). Every import of it is gated on
+# `@target(erlang)` so the JavaScript build never references it.
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "dataprep", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib"], otp_app = "dataprep", source = "hex", outer_checksum = "FB5EB04A1AE5A85BD7C33E4A0CB4ED63C0669610275AE3DB7868E21C54C7C7B5" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
@@ -20,6 +21,7 @@ packages = [
 
 [requirements]
 dataprep = { version = ">= 0.2.0 and < 1.0.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.14.0 and < 3.0.0" }

--- a/src/datastream/erlang/source.gleam
+++ b/src/datastream/erlang/source.gleam
@@ -1,0 +1,164 @@
+//// BEAM-only source constructors.
+////
+//// These bridge between Erlang's process / timer primitives and the
+//// cross-target `Stream(a)` value. The cross-target core has no
+//// business knowing about `Subject`, monotonic time, or BEAM timers,
+//// so they live here in `datastream/erlang/source` and never compile
+//// on the JavaScript target.
+
+@target(javascript)
+/// Sentinel value documenting that this module is BEAM-only. Every
+/// function below is gated on `@target(erlang)`; this constant exists
+/// so the module is non-empty under the JavaScript target and the
+/// compiler does not warn about an empty module.
+pub const beam_only_marker: String = "datastream/erlang/source is BEAM-only"
+
+@target(erlang)
+import datastream.{type Stream, Done, Next}
+
+@target(erlang)
+import datastream/source
+
+@target(erlang)
+import gleam/erlang/atom.{type Atom}
+
+@target(erlang)
+import gleam/erlang/process.{type Subject}
+
+@target(erlang)
+/// Bridge a process `Subject(a)` into a `Stream(a)`.
+///
+/// Each pull blocks on `process.receive` until either a message
+/// arrives — emitted as the next element — or `keep_running()`
+/// returns `False` between receives. The receive uses a short
+/// internal poll interval so `keep_running` stays responsive.
+///
+/// The `Subject`'s lifecycle is owned by the caller: this stream
+/// only reads, it never closes the subject. The terminal completing
+/// is sufficient to release the stream's hold.
+pub fn from_subject(
+  from subject: Subject(a),
+  while keep_running: fn() -> Bool,
+) -> Stream(a) {
+  source.unfold(from: Nil, with: fn(_) { receive_loop(subject, keep_running) })
+}
+
+@target(erlang)
+const subject_poll_ms: Int = 100
+
+@target(erlang)
+fn receive_loop(
+  subject: Subject(a),
+  keep_running: fn() -> Bool,
+) -> datastream.Step(a, Nil) {
+  case keep_running() {
+    False -> Done
+    True ->
+      case process.receive(from: subject, within: subject_poll_ms) {
+        Ok(message) -> Next(element: message, state: Nil)
+        Error(_) -> receive_loop(subject, keep_running)
+      }
+  }
+}
+
+@target(erlang)
+/// Emit a monotonic millisecond timestamp every `period_ms` ms.
+///
+/// The first element is emitted `period_ms` after the first pull.
+/// Pair with `stream.take` (or any early-exit terminal) to bound
+/// the run.
+pub fn ticks(every period_ms: Int) -> Stream(Int) {
+  source.unfold(from: Nil, with: fn(_) {
+    process.sleep(period_ms)
+    Next(element: monotonic_millis(), state: Nil)
+  })
+}
+
+@target(erlang)
+/// Emit `Nil` every `period_ms` ms. Same first-emission timing as
+/// `ticks`; differs only in element type.
+pub fn interval(every period_ms: Int) -> Stream(Nil) {
+  source.unfold(from: Nil, with: fn(_) {
+    process.sleep(period_ms)
+    Next(element: Nil, state: Nil)
+  })
+}
+
+@target(erlang)
+/// Wrap an upstream and add a per-element deadline.
+///
+/// Each element of `stream` that arrives within `ms` ms surfaces as
+/// `Ok(element)`. If the upstream produces nothing for longer than
+/// `ms` ms, exactly one `Error(Nil)` element is emitted and the
+/// stream halts.
+///
+/// Implementation: each pull spawns an unlinked worker process that
+/// performs the `datastream.pull` and forwards the step on a
+/// dedicated subject; the parent waits with `process.receive(_,
+/// within: ms)`. The worker may still complete after the deadline —
+/// its result is silently discarded.
+///
+/// **Limitation:** because the pull happens in a different process
+/// than the one that built the upstream, this combinator MUST NOT
+/// be composed with `from_subject`: a `Subject` can only be received
+/// by its owning process, so the worker would `panic`. Wrap subject
+/// streams with their own application-level timeout instead.
+pub fn timeout(over stream: Stream(a), within ms: Int) -> Stream(Result(a, Nil)) {
+  source.unfold(from: TimeoutActive(stream), with: fn(state) {
+    timeout_step(state, ms)
+  })
+}
+
+@target(erlang)
+type TimeoutState(a) {
+  TimeoutActive(stream: Stream(a))
+  TimeoutDrained
+}
+
+@target(erlang)
+type TimeoutPull(a) {
+  TimeoutNext(element: a, rest: Stream(a))
+  TimeoutDone
+}
+
+@target(erlang)
+fn timeout_step(
+  state: TimeoutState(a),
+  ms: Int,
+) -> datastream.Step(Result(a, Nil), TimeoutState(a)) {
+  case state {
+    TimeoutDrained -> Done
+    TimeoutActive(stream) -> {
+      let result = pull_with_deadline(stream, ms)
+      case result {
+        Ok(TimeoutNext(element, rest)) ->
+          Next(element: Ok(element), state: TimeoutActive(rest))
+        Ok(TimeoutDone) -> Done
+        Error(_) -> Next(element: Error(Nil), state: TimeoutDrained)
+      }
+    }
+  }
+}
+
+@target(erlang)
+fn pull_with_deadline(stream: Stream(a), ms: Int) -> Result(TimeoutPull(a), Nil) {
+  let result_subject = process.new_subject()
+  let _pid =
+    process.spawn_unlinked(fn() {
+      case datastream.pull(stream) {
+        Next(element, rest) ->
+          process.send(result_subject, TimeoutNext(element, rest))
+        Done -> process.send(result_subject, TimeoutDone)
+      }
+    })
+  process.receive(from: result_subject, within: ms)
+}
+
+@target(erlang)
+@external(erlang, "erlang", "monotonic_time")
+fn erlang_monotonic_time(unit: Atom) -> Int
+
+@target(erlang)
+fn monotonic_millis() -> Int {
+  erlang_monotonic_time(atom.create("millisecond"))
+}

--- a/test/datastream/erlang/source_test.gleam
+++ b/test/datastream/erlang/source_test.gleam
@@ -1,0 +1,107 @@
+//// BEAM-only tests for `datastream/erlang/source`.
+////
+//// Every test in this file is `@target(erlang)`; the JavaScript test
+//// run skips them entirely.
+
+@target(erlang)
+import datastream
+
+@target(erlang)
+import datastream/erlang/source as beam_source
+
+@target(erlang)
+import datastream/fold
+
+@target(erlang)
+import datastream/source
+
+@target(erlang)
+import datastream/stream
+
+@target(erlang)
+import gleam/erlang/process
+
+@target(erlang)
+import gleeunit/should
+
+@target(javascript)
+/// Empty placeholder so this module compiles cleanly on JavaScript.
+pub const beam_only_marker: String = "datastream/erlang/source_test is BEAM-only"
+
+// --- from_subject -------------------------------------------------------
+
+@target(erlang)
+pub fn from_subject_receives_messages_in_order_test() {
+  let subject = process.new_subject()
+  process.spawn(fn() {
+    process.send(subject, 1)
+    process.send(subject, 2)
+    process.send(subject, 3)
+  })
+
+  beam_source.from_subject(from: subject, while: fn() { True })
+  |> stream.take(up_to: 3)
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+}
+
+@target(erlang)
+pub fn from_subject_halts_when_keep_running_returns_false_test() {
+  let subject = process.new_subject()
+  // No messages ever sent; keep_running goes False on the first poll.
+  beam_source.from_subject(from: subject, while: fn() { False })
+  |> fold.to_list
+  |> should.equal([])
+}
+
+// --- ticks / interval ---------------------------------------------------
+
+@target(erlang)
+pub fn ticks_emits_three_monotonic_timestamps_test() {
+  let stamps =
+    beam_source.ticks(every: 20)
+    |> stream.take(up_to: 3)
+    |> fold.to_list
+
+  case stamps {
+    [a, b, c] -> {
+      should.be_true(b >= a)
+      should.be_true(c >= b)
+    }
+    _ -> panic as "expected three timestamps"
+  }
+}
+
+@target(erlang)
+pub fn interval_emits_three_nils_test() {
+  beam_source.interval(every: 20)
+  |> stream.take(up_to: 3)
+  |> fold.to_list
+  |> should.equal([Nil, Nil, Nil])
+}
+
+// --- timeout ------------------------------------------------------------
+
+@target(erlang)
+pub fn timeout_passes_fast_elements_through_test() {
+  source.from_list([1, 2, 3])
+  |> beam_source.timeout(within: 100)
+  |> fold.to_list
+  |> should.equal([Ok(1), Ok(2), Ok(3)])
+}
+
+@target(erlang)
+pub fn timeout_emits_error_when_upstream_is_too_slow_test() {
+  // upstream that sleeps 200ms before returning Done. The 50ms
+  // deadline trips first.
+  let slow =
+    source.unfold(from: Nil, with: fn(_) {
+      process.sleep(200)
+      datastream.Done
+    })
+
+  slow
+  |> beam_source.timeout(within: 50)
+  |> fold.to_list
+  |> should.equal([Error(Nil)])
+}


### PR DESCRIPTION
## Summary

Phase 7 starts with `datastream/erlang/source`: the BEAM-only source constructors that need Erlang's process / timer primitives. Adds `from_subject`, `ticks`, `interval`, and `timeout`. Quarantined to the Erlang target via `@target(erlang)` annotations on every function and import; the JavaScript build skips this module entirely (a sentinel `@target(javascript) pub const` keeps the module non-empty so `warnings-as-errors` doesn't flag it).

## Design decisions

- **`from_subject` polls with a 100ms internal interval.** Lets `keep_running()` be re-checked between receives without forcing the caller to send a sentinel message. The check is the only way to halt the stream short of a `take`.
- **`ticks` / `interval` share the scheduling.** Both `process.sleep(period_ms)` then emit; `ticks` adds an `erlang:monotonic_time(:millisecond)` external for the timestamp. The first emission is `period_ms` after the first pull, matching the spec.
- **`timeout` spawns one worker per pull.** Each pull spawns an unlinked worker that calls `datastream.pull` on the upstream and sends the step (`TimeoutNext` or `TimeoutDone`) on a fresh subject; the parent waits with `process.receive(_, within: ms)`. Late workers complete after the deadline and their messages are silently dropped.
- **Unlinked workers, not linked.** A linked worker that crashes during pull would take the parent down; unlinked is the safer default.

## Limitations

`timeout` MUST NOT be composed with `from_subject`. A `Subject` can only be received by the process that owns it (gleam_erlang `panic`s otherwise), so the worker process would crash on the first receive. Subject-based streams need an application-level timeout (e.g. `process.receive(_, within: ms)` directly when consuming the subject) instead. Documented in the `timeout` doc comment.

## Tests

`just all` is green: Erlang 262 / JS 235 (BEAM tests skipped under JS).

- `from_subject`: receives three messages from a spawned producer in order; halts immediately when `keep_running` returns `False` and no messages exist.
- `ticks`: three timestamps come back in monotonically non-decreasing order.
- `interval`: three `Nil` elements come back.
- `timeout`: passes through fast list-backed elements unchanged; emits `[Error(Nil)]` when the upstream sleeps 200ms past a 50ms deadline.

Adds `gleam_erlang >= 1.3.0 and < 2.0.0` to `[dependencies]`. Callers who never import `datastream/erlang/*` never run `gleam_erlang` code at runtime.

Closes #18.