### PR TITLE
feat: add BEAM-only sink (datastream/erlang/sink)

### DIFF
--- a/src/datastream/erlang/sink.gleam
+++ b/src/datastream/erlang/sink.gleam
@@ -1,0 +1,33 @@
+//// BEAM-only sink for delivering a stream's elements onto a `Subject(a)`.
+////
+//// This is the dual of `datastream/erlang/source.from_subject`:
+//// together they let two parts of a system talk over a process-based
+//// channel without either side having to know the other's stream
+//// representation.
+
+@target(javascript)
+/// Sentinel value documenting that this module is BEAM-only. Every
+/// function below is gated on `@target(erlang)`; this constant exists
+/// so the module is non-empty under the JavaScript target and the
+/// compiler does not warn about an empty module.
+pub const beam_only_marker: String = "datastream/erlang/sink is BEAM-only"
+
+@target(erlang)
+import datastream.{type Stream}
+
+@target(erlang)
+import datastream/sink
+
+@target(erlang)
+import gleam/erlang/process.{type Subject}
+
+@target(erlang)
+/// Drive `stream` to completion, sending each element to `subject`
+/// in source order. Returns `Nil`.
+///
+/// The function does not own the subject: it never closes or otherwise
+/// modifies it. Lifecycle (creation, naming, hand-off) stays with the
+/// caller, identical to `from_subject` on the source side.
+pub fn into_subject(over stream: Stream(a), into subject: Subject(a)) -> Nil {
+  sink.each(over: stream, with: fn(element) { process.send(subject, element) })
+}

--- a/test/datastream/erlang/sink_test.gleam
+++ b/test/datastream/erlang/sink_test.gleam
@@ -1,0 +1,42 @@
+//// BEAM-only tests for `datastream/erlang/sink`.
+
+@target(erlang)
+import datastream/erlang/sink as beam_sink
+
+@target(erlang)
+import datastream/source
+
+@target(erlang)
+import gleam/erlang/process
+
+@target(erlang)
+import gleeunit/should
+
+@target(javascript)
+/// Empty placeholder so this module compiles cleanly on JavaScript.
+pub const beam_only_marker: String = "datastream/erlang/sink_test is BEAM-only"
+
+@target(erlang)
+pub fn into_subject_sends_elements_in_order_test() {
+  let subject = process.new_subject()
+
+  source.from_list([1, 2, 3])
+  |> beam_sink.into_subject(into: subject)
+  |> should.equal(Nil)
+
+  process.receive(from: subject, within: 100) |> should.equal(Ok(1))
+  process.receive(from: subject, within: 100) |> should.equal(Ok(2))
+  process.receive(from: subject, within: 100) |> should.equal(Ok(3))
+  process.receive(from: subject, within: 50) |> should.equal(Error(Nil))
+}
+
+@target(erlang)
+pub fn into_subject_on_empty_stream_sends_nothing_test() {
+  let subject = process.new_subject()
+
+  source.empty()
+  |> beam_sink.into_subject(into: subject)
+  |> should.equal(Nil)
+
+  process.receive(from: subject, within: 50) |> should.equal(Error(Nil))
+}


### PR DESCRIPTION
## Summary

Phase 7 continues with `datastream/erlang/sink`: a single function `into_subject` that drives a stream's elements onto a `Subject(a)`. The dual of `erlang/source.from_subject` (#18) — together they let two parts of a system talk over a process-based channel without either side knowing the other's stream representation.

## Design decisions

- **Implementation is one line over `sink.each`.** `sink.each` already owns the per-element loop, the `Done` contract, and the `Nil` return type. `process.send(subject, element)` is the per-element side effect.
- **The function does not own the subject.** It never closes or modifies it. Lifecycle (creation, naming, hand-off) stays with the caller, matching the source-side contract on `from_subject`.
- **Same target-gating pattern as `erlang/source`.** Every public function and import is `@target(erlang)`; a `@target(javascript) pub const beam_only_marker` keeps the module non-empty under the JS build so `warnings-as-errors` doesn't flag it.

## Tests

`just all` is green: Erlang 264 / JS 235 (BEAM tests skipped under JS).

- Sends three elements onto a fresh subject and confirms they arrive in order via three `process.receive`s; a fourth receive times out (no fourth message).
- Empty stream returns `Nil` and never sends; a follow-up receive times out.

Closes #19.