### PR TITLE
fix(erlang/par): stop race from hanging when all sources finish without emitting

### DIFF
--- a/src/datastream/erlang/par.gleam
+++ b/src/datastream/erlang/par.gleam
@@ -384,13 +384,17 @@ pub fn race(streams streams: List(Stream(a))) -> Stream(a) {
 @target(erlang)
 fn race_with(streams: List(Stream(a))) -> Stream(a) {
   let result_subject = process.new_subject()
+  let total = list.length(streams)
   list.index_map(streams, fn(stream, idx) {
     let subj = result_subject
     let _pid =
       process.spawn_unlinked(fn() { race_first_pull(stream, idx, subj) })
     Nil
   })
-  source.unfold(from: RaceWaiting(streams, result_subject), with: race_step)
+  source.unfold(
+    from: RaceWaiting(streams, total, result_subject),
+    with: race_step,
+  )
 }
 
 @target(erlang)
@@ -408,27 +412,30 @@ fn race_first_pull(
 
 @target(erlang)
 type RaceState(a) {
-  RaceWaiting(streams: List(Stream(a)), subj: Subject(RaceMsg(a)))
+  RaceWaiting(
+    streams: List(Stream(a)),
+    remaining: Int,
+    subj: Subject(RaceMsg(a)),
+  )
   RaceWinning(stream: Stream(a))
-  RaceFinished
 }
 
 @target(erlang)
 fn race_step(state: RaceState(a)) -> datastream.Step(a, RaceState(a)) {
   case state {
-    RaceFinished -> Done
     RaceWinning(stream) ->
       case datastream.pull(stream) {
         Next(element, rest) -> Next(element, RaceWinning(rest))
         Done -> Done
       }
-    RaceWaiting(streams, subj) ->
+    RaceWaiting(_, 0, _) -> Done
+    RaceWaiting(streams, remaining, subj) ->
       case process.receive_forever(from: subj) {
         RaceNext(index, element, rest) -> {
           close_losers(streams, index)
           Next(element, RaceWinning(rest))
         }
-        RaceDone(_index) -> race_step(RaceWaiting(streams, subj))
+        RaceDone(_) -> race_step(RaceWaiting(streams, remaining - 1, subj))
       }
   }
 }

--- a/test/datastream/erlang/par_test.gleam
+++ b/test/datastream/erlang/par_test.gleam
@@ -111,3 +111,31 @@ pub fn race_single_source_passes_through_test() {
   |> fold.to_list
   |> should.equal([1, 2, 3])
 }
+
+@target(erlang)
+pub fn race_all_empty_contenders_yields_empty_test() {
+  par.race(streams: [source.empty(), source.empty()])
+  |> fold.to_list
+  |> should.equal([])
+}
+
+@target(erlang)
+pub fn race_one_empty_and_one_emitting_yields_emitting_test() {
+  par.race(streams: [source.empty(), source.from_list([1, 2, 3])])
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+}
+
+@target(erlang)
+pub fn race_multiple_empties_and_one_emitting_yields_emitting_test() {
+  par.race(streams: [source.empty(), source.empty(), source.from_list([42])])
+  |> fold.to_list
+  |> should.equal([42])
+}
+
+@target(erlang)
+pub fn race_emitting_first_and_empties_later_yields_emitting_test() {
+  par.race(streams: [source.from_list([7, 8]), source.empty(), source.empty()])
+  |> fold.to_list
+  |> should.equal([7, 8])
+}


### PR DESCRIPTION
## Summary

Fixes #44. `par.race` previously hung forever when every input stream returned `Done` on its first pull, because `race_step` did not track how many contenders had already finished. The state stayed in `RaceWaiting` and the next `process.receive_forever` blocked permanently.

## Changes

- `src/datastream/erlang/par.gleam`: add `remaining: Int` to `RaceWaiting` state, decrement it on each `RaceDone`, and return `Done` once it reaches zero. Remove the dead `RaceFinished` variant that had no producer.
- `test/datastream/erlang/par_test.gleam`: add Erlang-target regression tests covering all-empty contenders, mixed empty + emitting contenders, and emitter-position symmetry.

## Design Decisions

- Mirror the `merge` combinator's bookkeeping: `merge` keeps `#(total, completed)` to know when every worker is done. `race` now does the same with a single `remaining` counter on `RaceWaiting`.
- Place the `RaceWaiting(_, 0, _) -> Done` arm before the general `RaceWaiting(streams, remaining, subj) -> ...` arm so the terminal case wins before any `receive_forever` call.
- `RaceFinished` was unused dead code (no producer). Removing it keeps the state machine to the two reachable variants.
- Worker cancellation on winner selection (closing late `RaceNext`/`RaceDone` messages from losing workers) is intentionally out of scope here. That is tracked in #45, which redesigns BEAM-extension streams to carry a real `close` callback instead of relying on `source.unfold` alone.

## Limitations

- Tests verify the hang-free termination contract, not the close contract for losers. Resource-counter tests for the close contract require the broader infrastructure planned in #45.

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added four new test cases for parallel race operations covering empty and emitting stream combinations, ensuring correct behavior across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->