### PR TITLE
fix(erlang): give BEAM extension streams a real close callback

### DIFF
--- a/src/datastream/erlang/internal/pump.gleam
+++ b/src/datastream/erlang/internal/pump.gleam
@@ -1,0 +1,93 @@
+//// Internal helpers for BEAM extension worker pumps.
+////
+//// A pump is a process that pulls from an upstream `Stream(a)` and
+//// forwards each element to a result subject. Combinators in
+//// `datastream/erlang/par` and `datastream/erlang/time` use this to
+//// drive an upstream concurrently with their own coordinator loop.
+////
+//// Each pump is paired with a stop subject. Sending `Stop` to that
+//// subject causes the worker to close the upstream and exit at the
+//// start of its next iteration. A worker blocked inside
+//// `datastream.pull` only stops after that pull returns; pulls that
+//// never return leave the worker resident.
+
+@target(javascript)
+/// Sentinel value documenting that this module is BEAM-only.
+pub const beam_only_marker: String = "datastream/erlang/internal/pump is BEAM-only"
+
+@target(erlang)
+import datastream.{type Stream, Done, Next}
+
+@target(erlang)
+import gleam/erlang/process.{type Subject}
+
+@target(erlang)
+@internal
+pub type Pump(a) {
+  PumpElement(a)
+  PumpDone
+}
+
+@target(erlang)
+@internal
+pub type Stop {
+  Stop
+}
+
+@target(erlang)
+/// Spawn a worker that owns its own stop subject and runs `body`.
+/// Returns the worker's stop subject so the caller can later signal
+/// it to stop.
+///
+/// The subject is created inside the worker because Erlang subjects
+/// can only be received from by the owning process. A short
+/// handshake hands it back to the caller before `body` runs.
+@internal
+pub fn spawn_with_stop(body: fn(Subject(Stop)) -> Nil) -> Subject(Stop) {
+  let handshake = process.new_subject()
+  let _pid =
+    process.spawn_unlinked(fn() {
+      let stop_subj = process.new_subject()
+      process.send(handshake, stop_subj)
+      body(stop_subj)
+    })
+  process.receive_forever(from: handshake)
+}
+
+@target(erlang)
+/// Spawn a worker that pumps `stream` into `result_subj` and exits on
+/// `Stop`. Returns the worker's stop subject.
+@internal
+pub fn spawn_pump(
+  over stream: Stream(a),
+  into result_subj: Subject(Pump(a)),
+) -> Subject(Stop) {
+  spawn_with_stop(fn(stop_subj) { pump_loop(stream, result_subj, stop_subj) })
+}
+
+@target(erlang)
+fn pump_loop(
+  stream: Stream(a),
+  result_subj: Subject(Pump(a)),
+  stop_subj: Subject(Stop),
+) -> Nil {
+  case process.receive(from: stop_subj, within: 0) {
+    Ok(_) -> datastream.close(stream)
+    Error(_) ->
+      case datastream.pull(stream) {
+        Next(element, rest) -> {
+          process.send(result_subj, PumpElement(element))
+          pump_loop(rest, result_subj, stop_subj)
+        }
+        Done -> process.send(result_subj, PumpDone)
+      }
+  }
+}
+
+@target(erlang)
+/// Signal a pump worker to stop. The worker observes the signal at
+/// the start of its next iteration and then closes the upstream.
+@internal
+pub fn stop(stop_subj: Subject(Stop)) -> Nil {
+  process.send(stop_subj, Stop)
+}

--- a/src/datastream/erlang/par.gleam
+++ b/src/datastream/erlang/par.gleam
@@ -17,6 +17,11 @@ pub const beam_only_marker: String = "datastream/erlang/par is BEAM-only"
 import datastream.{type Stream, Done, Next}
 
 @target(erlang)
+import datastream/erlang/internal/pump.{
+  type Pump, type Stop, PumpDone, PumpElement,
+}
+
+@target(erlang)
 import datastream/fold
 
 @target(erlang)
@@ -75,33 +80,46 @@ pub fn map_unordered(
 ) -> Stream(b) {
   validate_par_args(max_workers, max_buffer)
   let result_subject = process.new_subject()
-  source.unfold(
-    from: MapUnordered(
-      source: stream,
-      f: f,
-      max_workers: max_workers,
-      workers_busy: 0,
-      result_subject: result_subject,
-      source_drained: False,
-    ),
-    with: map_unordered_step,
-  )
+  build_map_unordered_stream(MapUnordered(
+    source: stream,
+    f: f,
+    max_workers: max_workers,
+    workers_busy: 0,
+    result_subject: result_subject,
+    source_drained: False,
+  ))
+}
+
+@target(erlang)
+fn build_map_unordered_stream(state: MapUnordered(a, b)) -> Stream(b) {
+  datastream.make(pull: fn() { map_unordered_step(state) }, close: fn() {
+    map_unordered_close(state)
+  })
+}
+
+@target(erlang)
+fn map_unordered_close(state: MapUnordered(a, b)) -> Nil {
+  case state.source_drained {
+    True -> Nil
+    False -> datastream.close(state.source)
+  }
 }
 
 @target(erlang)
 fn map_unordered_step(
   state: MapUnordered(a, b),
-) -> datastream.Step(b, MapUnordered(a, b)) {
+) -> datastream.Step(b, Stream(b)) {
   let state = dispatch_unordered(state)
   case state.workers_busy {
-    0 ->
-      case state.source_drained {
-        True -> Done
-        False -> Done
-      }
+    0 -> Done
     _ -> {
       let result = process.receive_forever(from: state.result_subject)
-      Next(result, MapUnordered(..state, workers_busy: state.workers_busy - 1))
+      Next(
+        result,
+        build_map_unordered_stream(
+          MapUnordered(..state, workers_busy: state.workers_busy - 1),
+        ),
+      )
     }
   }
 }
@@ -168,44 +186,52 @@ pub fn map_ordered(
       panic as "datastream/erlang/par.map_ordered: max_buffer must be >= max_workers"
   }
   let result_subject = process.new_subject()
-  source.unfold(
-    from: MapOrdered(
-      source: stream,
-      f: f,
-      max_workers: max_workers,
-      workers_busy: 0,
-      next_dispatch_index: 0,
-      next_emit_index: 0,
-      result_subject: result_subject,
-      pending: dict.new(),
-      source_drained: False,
-    ),
-    with: map_ordered_step,
-  )
+  build_map_ordered_stream(MapOrdered(
+    source: stream,
+    f: f,
+    max_workers: max_workers,
+    workers_busy: 0,
+    next_dispatch_index: 0,
+    next_emit_index: 0,
+    result_subject: result_subject,
+    pending: dict.new(),
+    source_drained: False,
+  ))
 }
 
 @target(erlang)
-fn map_ordered_step(
-  state: MapOrdered(a, b),
-) -> datastream.Step(b, MapOrdered(a, b)) {
+fn build_map_ordered_stream(state: MapOrdered(a, b)) -> Stream(b) {
+  datastream.make(pull: fn() { map_ordered_step(state) }, close: fn() {
+    map_ordered_close(state)
+  })
+}
+
+@target(erlang)
+fn map_ordered_close(state: MapOrdered(a, b)) -> Nil {
+  case state.source_drained {
+    True -> Nil
+    False -> datastream.close(state.source)
+  }
+}
+
+@target(erlang)
+fn map_ordered_step(state: MapOrdered(a, b)) -> datastream.Step(b, Stream(b)) {
   let state = dispatch_ordered(state)
   case dict.get(state.pending, state.next_emit_index) {
     Ok(value) ->
       Next(
         value,
-        MapOrdered(
-          ..state,
-          pending: dict.delete(state.pending, state.next_emit_index),
-          next_emit_index: state.next_emit_index + 1,
+        build_map_ordered_stream(
+          MapOrdered(
+            ..state,
+            pending: dict.delete(state.pending, state.next_emit_index),
+            next_emit_index: state.next_emit_index + 1,
+          ),
         ),
       )
     Error(_) ->
       case state.workers_busy {
-        0 ->
-          case state.source_drained {
-            True -> Done
-            False -> Done
-          }
+        0 -> Done
         _ -> {
           let #(idx, value) =
             process.receive_forever(from: state.result_subject)
@@ -296,9 +322,13 @@ pub fn each_unordered(
 // --- merge ---------------------------------------------------------------
 
 @target(erlang)
-type MergeMsg(a) {
-  MergeNext(a)
-  MergeDone
+type MergeState(a) {
+  MergeState(
+    result_subj: Subject(Pump(a)),
+    stop_subjs: List(Subject(Stop)),
+    total: Int,
+    completed: Int,
+  )
 }
 
 @target(erlang)
@@ -310,7 +340,9 @@ type MergeMsg(a) {
 ///
 /// One worker process is spawned per input stream; the workers pump
 /// their source into a shared subject. The resulting `Stream` walks
-/// that subject and counts down workers as they signal `MergeDone`.
+/// that subject and counts down workers as they signal that they are
+/// done. Downstream early-exit signals every still-running worker to
+/// close its upstream.
 pub fn merge(
   streams streams: List(Stream(a)),
   max_buffer max_buffer: Int,
@@ -319,40 +351,42 @@ pub fn merge(
     True -> Nil
     False -> panic as "datastream/erlang/par.merge: max_buffer must be >= 1"
   }
-  let result_subject = process.new_subject()
+  let result_subj = process.new_subject()
   let total = list.length(streams)
-  list.each(streams, fn(s) {
-    let subj = result_subject
-    let _pid = process.spawn_unlinked(fn() { merge_pump(s, subj) })
-  })
-  source.unfold(from: #(total, 0), with: fn(state) {
-    merge_step(state, result_subject)
+  let stop_subjs =
+    list.map(streams, fn(s) { pump.spawn_pump(over: s, into: result_subj) })
+  build_merge_stream(MergeState(
+    result_subj: result_subj,
+    stop_subjs: stop_subjs,
+    total: total,
+    completed: 0,
+  ))
+}
+
+@target(erlang)
+fn build_merge_stream(state: MergeState(a)) -> Stream(a) {
+  datastream.make(pull: fn() { merge_step(state) }, close: fn() {
+    merge_close(state)
   })
 }
 
 @target(erlang)
-fn merge_pump(stream: Stream(a), subj: Subject(MergeMsg(a))) -> Nil {
-  case datastream.pull(stream) {
-    Next(element, rest) -> {
-      process.send(subj, MergeNext(element))
-      merge_pump(rest, subj)
-    }
-    Done -> process.send(subj, MergeDone)
+fn merge_close(state: MergeState(a)) -> Nil {
+  case state.completed >= state.total {
+    True -> Nil
+    False -> list.each(state.stop_subjs, pump.stop)
   }
 }
 
 @target(erlang)
-fn merge_step(
-  state: #(Int, Int),
-  subj: Subject(MergeMsg(a)),
-) -> datastream.Step(a, #(Int, Int)) {
-  let #(total, completed) = state
-  case completed >= total {
+fn merge_step(state: MergeState(a)) -> datastream.Step(a, Stream(a)) {
+  case state.completed >= state.total {
     True -> Done
     False ->
-      case process.receive_forever(from: subj) {
-        MergeNext(element) -> Next(element, #(total, completed))
-        MergeDone -> merge_step(#(total, completed + 1), subj)
+      case process.receive_forever(from: state.result_subj) {
+        PumpElement(element) -> Next(element, build_merge_stream(state))
+        PumpDone ->
+          merge_step(MergeState(..state, completed: state.completed + 1))
       }
   }
 }
@@ -366,14 +400,24 @@ type RaceMsg(a) {
 }
 
 @target(erlang)
-/// Wait for the first source to emit; cancel and close the others;
-/// continue with the winning source until it halts.
+/// Wait for the first source to emit; signal the other workers to
+/// stop, then continue with the winning source until it halts.
 ///
-/// Implementation: spawn one worker per source, each does a single
-/// `datastream.pull` and reports back on a shared subject. The first
-/// `RaceNext` wins; every other source has its `close` callback
-/// invoked. Sources whose first pull returned `Done` are also no-ops
-/// to close.
+/// Implementation: spawn one worker per source. Each worker checks
+/// for a stop signal, then does a single `datastream.pull` and
+/// reports back on a shared subject. The first `RaceNext` wins; the
+/// coordinator drains any loser messages already in its mailbox and
+/// closes the `rest` they carry, then sends a stop signal to every
+/// other worker.
+///
+/// **Best-effort loser cleanup.** A loser worker that was still
+/// inside its `datastream.pull` when the stop signal arrived has no
+/// way to observe it and will go on to send its `RaceNext` after the
+/// coordinator has stopped reading. Such a `RaceNext` is dropped and
+/// its `rest` is not closed. BEAM-internal resources held by the
+/// abandoned `rest` are reclaimed by the runtime; external resources
+/// (file descriptors, sockets) may leak. Pass external-resource
+/// streams to `race` only when this trade-off is acceptable.
 pub fn race(streams streams: List(Stream(a))) -> Stream(a) {
   case streams {
     [] -> source.empty()
@@ -383,37 +427,42 @@ pub fn race(streams streams: List(Stream(a))) -> Stream(a) {
 
 @target(erlang)
 fn race_with(streams: List(Stream(a))) -> Stream(a) {
-  let result_subject = process.new_subject()
+  let result_subj = process.new_subject()
   let total = list.length(streams)
-  list.index_map(streams, fn(stream, idx) {
-    let subj = result_subject
-    let _pid =
-      process.spawn_unlinked(fn() { race_first_pull(stream, idx, subj) })
-    Nil
-  })
-  source.unfold(
-    from: RaceWaiting(streams, total, result_subject),
-    with: race_step,
-  )
+  let stop_subjs =
+    list.index_map(streams, fn(stream, idx) {
+      pump.spawn_with_stop(fn(stop_subj) {
+        race_first_pull(stream, idx, result_subj, stop_subj)
+      })
+    })
+  build_race_stream(RaceWaiting(stop_subjs, total, result_subj))
 }
 
 @target(erlang)
 fn race_first_pull(
   stream: Stream(a),
   index: Int,
-  subj: Subject(RaceMsg(a)),
+  result_subj: Subject(RaceMsg(a)),
+  stop_subj: Subject(Stop),
 ) -> Nil {
-  case datastream.pull(stream) {
-    Next(element, rest) ->
-      process.send(subj, RaceNext(index: index, element: element, rest: rest))
-    Done -> process.send(subj, RaceDone(index: index))
+  case process.receive(from: stop_subj, within: 0) {
+    Ok(_) -> datastream.close(stream)
+    Error(_) ->
+      case datastream.pull(stream) {
+        Next(element, rest) ->
+          process.send(
+            result_subj,
+            RaceNext(index: index, element: element, rest: rest),
+          )
+        Done -> process.send(result_subj, RaceDone(index: index))
+      }
   }
 }
 
 @target(erlang)
 type RaceState(a) {
   RaceWaiting(
-    streams: List(Stream(a)),
+    stop_subjs: List(Subject(Stop)),
     remaining: Int,
     subj: Subject(RaceMsg(a)),
   )
@@ -421,32 +470,62 @@ type RaceState(a) {
 }
 
 @target(erlang)
-fn race_step(state: RaceState(a)) -> datastream.Step(a, RaceState(a)) {
+fn build_race_stream(state: RaceState(a)) -> Stream(a) {
+  datastream.make(pull: fn() { race_step(state) }, close: fn() {
+    race_close(state)
+  })
+}
+
+@target(erlang)
+fn race_close(state: RaceState(a)) -> Nil {
+  case state {
+    RaceWinning(stream) -> datastream.close(stream)
+    RaceWaiting(_, 0, _) -> Nil
+    RaceWaiting(stop_subjs, _, _) -> list.each(stop_subjs, pump.stop)
+  }
+}
+
+@target(erlang)
+fn race_step(state: RaceState(a)) -> datastream.Step(a, Stream(a)) {
   case state {
     RaceWinning(stream) ->
       case datastream.pull(stream) {
-        Next(element, rest) -> Next(element, RaceWinning(rest))
+        Next(element, rest) ->
+          Next(element, build_race_stream(RaceWinning(rest)))
         Done -> Done
       }
     RaceWaiting(_, 0, _) -> Done
-    RaceWaiting(streams, remaining, subj) ->
+    RaceWaiting(stop_subjs, remaining, subj) ->
       case process.receive_forever(from: subj) {
         RaceNext(index, element, rest) -> {
-          close_losers(streams, index)
-          Next(element, RaceWinning(rest))
+          stop_losers(stop_subjs, index)
+          drain_loser_messages(subj)
+          Next(element, build_race_stream(RaceWinning(rest)))
         }
-        RaceDone(_) -> race_step(RaceWaiting(streams, remaining - 1, subj))
+        RaceDone(_) -> race_step(RaceWaiting(stop_subjs, remaining - 1, subj))
       }
   }
 }
 
 @target(erlang)
-fn close_losers(streams: List(Stream(a)), winner_index: Int) -> Nil {
-  list.index_map(streams, fn(stream, idx) {
+fn stop_losers(stop_subjs: List(Subject(Stop)), winner_index: Int) -> Nil {
+  list.index_map(stop_subjs, fn(stop_subj, idx) {
     case idx == winner_index {
       True -> Nil
-      False -> datastream.close(stream)
+      False -> pump.stop(stop_subj)
     }
   })
   Nil
+}
+
+@target(erlang)
+fn drain_loser_messages(subj: Subject(RaceMsg(a))) -> Nil {
+  case process.receive(from: subj, within: 0) {
+    Ok(RaceNext(_, _, rest)) -> {
+      datastream.close(rest)
+      drain_loser_messages(subj)
+    }
+    Ok(RaceDone(_)) -> drain_loser_messages(subj)
+    Error(_) -> Nil
+  }
 }

--- a/src/datastream/erlang/source.gleam
+++ b/src/datastream/erlang/source.gleam
@@ -95,8 +95,13 @@ pub fn interval(every period_ms: Int) -> Stream(Nil) {
 /// Implementation: each pull spawns an unlinked worker process that
 /// performs the `datastream.pull` and forwards the step on a
 /// dedicated subject; the parent waits with `process.receive(_,
-/// within: ms)`. The worker may still complete after the deadline —
-/// its result is silently discarded.
+/// within: ms)`. On a deadline trip the abandoned worker may still
+/// complete the `pull` afterwards; its result is silently discarded
+/// and any resource it had partially acquired is left to the BEAM
+/// runtime to reclaim.
+///
+/// Downstream early-exit closes the upstream the next pull would
+/// have read from; an abandoned worker is not waited on.
 ///
 /// **Limitation:** because the pull happens in a different process
 /// than the one that built the upstream, this combinator MUST NOT
@@ -104,9 +109,7 @@ pub fn interval(every period_ms: Int) -> Stream(Nil) {
 /// by its owning process, so the worker would `panic`. Wrap subject
 /// streams with their own application-level timeout instead.
 pub fn timeout(over stream: Stream(a), within ms: Int) -> Stream(Result(a, Nil)) {
-  source.unfold(from: TimeoutActive(stream), with: fn(state) {
-    timeout_step(state, ms)
-  })
+  build_timeout_stream(TimeoutActive(stream), ms)
 }
 
 @target(erlang)
@@ -122,19 +125,37 @@ type TimeoutPull(a) {
 }
 
 @target(erlang)
-fn timeout_step(
+fn build_timeout_stream(
   state: TimeoutState(a),
   ms: Int,
-) -> datastream.Step(Result(a, Nil), TimeoutState(a)) {
+) -> Stream(Result(a, Nil)) {
+  datastream.make(pull: fn() { timeout_pull(state, ms) }, close: fn() {
+    timeout_close(state)
+  })
+}
+
+@target(erlang)
+fn timeout_close(state: TimeoutState(a)) -> Nil {
+  case state {
+    TimeoutDrained -> Nil
+    TimeoutActive(stream) -> datastream.close(stream)
+  }
+}
+
+@target(erlang)
+fn timeout_pull(
+  state: TimeoutState(a),
+  ms: Int,
+) -> datastream.Step(Result(a, Nil), Stream(Result(a, Nil))) {
   case state {
     TimeoutDrained -> Done
     TimeoutActive(stream) -> {
       let result = pull_with_deadline(stream, ms)
       case result {
         Ok(TimeoutNext(element, rest)) ->
-          Next(element: Ok(element), state: TimeoutActive(rest))
+          Next(Ok(element), build_timeout_stream(TimeoutActive(rest), ms))
         Ok(TimeoutDone) -> Done
-        Error(_) -> Next(element: Error(Nil), state: TimeoutDrained)
+        Error(_) -> Next(Error(Nil), build_timeout_stream(TimeoutDrained, ms))
       }
     }
   }

--- a/src/datastream/erlang/time.gleam
+++ b/src/datastream/erlang/time.gleam
@@ -21,7 +21,9 @@ import datastream.{type Stream, Done, Next}
 import datastream/chunk.{type Chunk}
 
 @target(erlang)
-import datastream/source
+import datastream/erlang/internal/pump.{
+  type Pump, type Stop, PumpDone, PumpElement,
+}
 
 @target(erlang)
 import gleam/erlang/atom.{type Atom}
@@ -32,32 +34,6 @@ import gleam/erlang/process.{type Subject}
 @target(erlang)
 import gleam/option.{type Option, None, Some}
 
-// --- worker pump (shared) ------------------------------------------------
-
-@target(erlang)
-type Pump(a) {
-  PumpElement(a)
-  PumpDone
-}
-
-@target(erlang)
-fn spawn_pump(stream: Stream(a)) -> Subject(Pump(a)) {
-  let subj = process.new_subject()
-  let _pid = process.spawn_unlinked(fn() { pump_loop(stream, subj) })
-  subj
-}
-
-@target(erlang)
-fn pump_loop(stream: Stream(a), subj: Subject(Pump(a))) -> Nil {
-  case datastream.pull(stream) {
-    Next(element, rest) -> {
-      process.send(subj, PumpElement(element))
-      pump_loop(rest, subj)
-    }
-    Done -> process.send(subj, PumpDone)
-  }
-}
-
 @target(erlang)
 @external(erlang, "erlang", "monotonic_time")
 fn erlang_monotonic_time(unit: Atom) -> Int
@@ -67,12 +43,23 @@ fn now_ms() -> Int {
   erlang_monotonic_time(atom.create("millisecond"))
 }
 
+// --- shared close handler ------------------------------------------------
+
+@target(erlang)
+fn maybe_stop(stop_subj: Subject(Stop), upstream_done: Bool) -> Nil {
+  case upstream_done {
+    True -> Nil
+    False -> pump.stop(stop_subj)
+  }
+}
+
 // --- debounce ------------------------------------------------------------
 
 @target(erlang)
 type DebounceState(a) {
   DebounceState(
-    subj: Subject(Pump(a)),
+    result_subj: Subject(Pump(a)),
+    stop_subj: Subject(Stop),
     latest: Option(a),
     deadline: Int,
     upstream_done: Bool,
@@ -87,23 +74,32 @@ type DebounceState(a) {
 /// Useful for collapsing UI events (typing, resize) into a single
 /// "settled" notification.
 pub fn debounce(over stream: Stream(a), quiet_for ms: Int) -> Stream(a) {
-  let subj = spawn_pump(stream)
-  source.unfold(
-    from: DebounceState(
-      subj: subj,
+  let result_subj = process.new_subject()
+  let stop_subj = pump.spawn_pump(stream, into: result_subj)
+  build_debounce_stream(
+    DebounceState(
+      result_subj: result_subj,
+      stop_subj: stop_subj,
       latest: None,
       deadline: 0,
       upstream_done: False,
     ),
-    with: fn(state) { debounce_step(state, ms) },
+    ms,
   )
+}
+
+@target(erlang)
+fn build_debounce_stream(state: DebounceState(a), ms: Int) -> Stream(a) {
+  datastream.make(pull: fn() { debounce_step(state, ms) }, close: fn() {
+    maybe_stop(state.stop_subj, state.upstream_done)
+  })
 }
 
 @target(erlang)
 fn debounce_step(
   state: DebounceState(a),
   ms: Int,
-) -> datastream.Step(a, DebounceState(a)) {
+) -> datastream.Step(a, Stream(a)) {
   case state.upstream_done {
     True -> Done
     False -> debounce_wait(state, ms)
@@ -114,10 +110,10 @@ fn debounce_step(
 fn debounce_wait(
   state: DebounceState(a),
   ms: Int,
-) -> datastream.Step(a, DebounceState(a)) {
+) -> datastream.Step(a, Stream(a)) {
   case state.latest {
     None ->
-      case process.receive_forever(from: state.subj) {
+      case process.receive_forever(from: state.result_subj) {
         PumpElement(element) ->
           debounce_wait(
             DebounceState(
@@ -135,7 +131,7 @@ fn debounce_wait(
         delta if delta > 0 -> delta
         _ -> 0
       }
-      case process.receive(from: state.subj, within: wait) {
+      case process.receive(from: state.result_subj, within: wait) {
         Ok(PumpElement(element)) ->
           debounce_wait(
             DebounceState(
@@ -146,8 +142,18 @@ fn debounce_wait(
             ms,
           )
         Ok(PumpDone) ->
-          Next(value, DebounceState(..state, latest: None, upstream_done: True))
-        Error(_) -> Next(value, DebounceState(..state, latest: None))
+          Next(
+            value,
+            build_debounce_stream(
+              DebounceState(..state, latest: None, upstream_done: True),
+              ms,
+            ),
+          )
+        Error(_) ->
+          Next(
+            value,
+            build_debounce_stream(DebounceState(..state, latest: None), ms),
+          )
       }
     }
   }
@@ -156,8 +162,13 @@ fn debounce_wait(
 // --- throttle ------------------------------------------------------------
 
 @target(erlang)
-type ThrottleState {
-  ThrottleState(next_window_start: Option(Int))
+type ThrottleState(a) {
+  ThrottleState(
+    result_subj: Subject(Pump(a)),
+    stop_subj: Subject(Stop),
+    next_window_start: Option(Int),
+    upstream_done: Bool,
+  )
 }
 
 @target(erlang)
@@ -165,44 +176,72 @@ type ThrottleState {
 ///
 /// Windows start at the moment the first element is emitted.
 pub fn throttle(over stream: Stream(a), every ms: Int) -> Stream(a) {
-  let subj = spawn_pump(stream)
-  source.unfold(
-    from: #(subj, ThrottleState(next_window_start: None)),
-    with: fn(state) {
-      let #(subj, throttle_state) = state
-      throttle_step(subj, throttle_state, ms)
-    },
+  let result_subj = process.new_subject()
+  let stop_subj = pump.spawn_pump(stream, into: result_subj)
+  build_throttle_stream(
+    ThrottleState(
+      result_subj: result_subj,
+      stop_subj: stop_subj,
+      next_window_start: None,
+      upstream_done: False,
+    ),
+    ms,
   )
 }
 
 @target(erlang)
+fn build_throttle_stream(state: ThrottleState(a), ms: Int) -> Stream(a) {
+  datastream.make(pull: fn() { throttle_step(state, ms) }, close: fn() {
+    maybe_stop(state.stop_subj, state.upstream_done)
+  })
+}
+
+@target(erlang)
 fn throttle_step(
-  subj: Subject(Pump(a)),
-  state: ThrottleState,
+  state: ThrottleState(a),
   ms: Int,
-) -> datastream.Step(a, #(Subject(Pump(a)), ThrottleState)) {
-  case process.receive_forever(from: subj) {
-    PumpDone -> Done
-    PumpElement(element) -> {
-      let now = now_ms()
-      case state.next_window_start {
-        None ->
-          Next(element, #(
-            subj,
-            ThrottleState(next_window_start: Some(now + ms)),
-          ))
-        Some(start) ->
-          case now >= start {
-            True ->
-              Next(element, #(
-                subj,
-                ThrottleState(next_window_start: Some(now + ms)),
-              ))
-            False -> throttle_step(subj, state, ms)
-          }
+) -> datastream.Step(a, Stream(a)) {
+  case state.upstream_done {
+    True -> Done
+    False ->
+      case process.receive_forever(from: state.result_subj) {
+        PumpDone -> Done
+        PumpElement(element) -> throttle_handle(element, state, ms)
       }
-    }
   }
+}
+
+@target(erlang)
+fn throttle_handle(
+  element: a,
+  state: ThrottleState(a),
+  ms: Int,
+) -> datastream.Step(a, Stream(a)) {
+  let now = now_ms()
+  case state.next_window_start {
+    None -> throttle_emit(element, state, now, ms)
+    Some(start) ->
+      case now >= start {
+        True -> throttle_emit(element, state, now, ms)
+        False -> throttle_step(state, ms)
+      }
+  }
+}
+
+@target(erlang)
+fn throttle_emit(
+  element: a,
+  state: ThrottleState(a),
+  now: Int,
+  ms: Int,
+) -> datastream.Step(a, Stream(a)) {
+  Next(
+    element,
+    build_throttle_stream(
+      ThrottleState(..state, next_window_start: Some(now + ms)),
+      ms,
+    ),
+  )
 }
 
 // --- sample --------------------------------------------------------------
@@ -210,7 +249,8 @@ fn throttle_step(
 @target(erlang)
 type SampleState(a) {
   SampleState(
-    subj: Subject(Pump(a)),
+    result_subj: Subject(Pump(a)),
+    stop_subj: Subject(Stop),
     window_start: Int,
     latest: Option(a),
     upstream_done: Bool,
@@ -222,23 +262,29 @@ type SampleState(a) {
 /// seen during the window. If no element arrived during the window,
 /// the boundary emits nothing and the next window begins.
 pub fn sample(over stream: Stream(a), every ms: Int) -> Stream(a) {
-  let subj = spawn_pump(stream)
-  source.unfold(
-    from: SampleState(
-      subj: subj,
+  let result_subj = process.new_subject()
+  let stop_subj = pump.spawn_pump(stream, into: result_subj)
+  build_sample_stream(
+    SampleState(
+      result_subj: result_subj,
+      stop_subj: stop_subj,
       window_start: now_ms(),
       latest: None,
       upstream_done: False,
     ),
-    with: fn(state) { sample_step(state, ms) },
+    ms,
   )
 }
 
 @target(erlang)
-fn sample_step(
-  state: SampleState(a),
-  ms: Int,
-) -> datastream.Step(a, SampleState(a)) {
+fn build_sample_stream(state: SampleState(a), ms: Int) -> Stream(a) {
+  datastream.make(pull: fn() { sample_step(state, ms) }, close: fn() {
+    maybe_stop(state.stop_subj, state.upstream_done)
+  })
+}
+
+@target(erlang)
+fn sample_step(state: SampleState(a), ms: Int) -> datastream.Step(a, Stream(a)) {
   case state.upstream_done {
     True -> Done
     False -> sample_wait(state, ms)
@@ -246,23 +292,26 @@ fn sample_step(
 }
 
 @target(erlang)
-fn sample_wait(
-  state: SampleState(a),
-  ms: Int,
-) -> datastream.Step(a, SampleState(a)) {
+fn sample_wait(state: SampleState(a), ms: Int) -> datastream.Step(a, Stream(a)) {
   let now = now_ms()
   let deadline = state.window_start + ms
   let wait = case deadline - now {
     delta if delta > 0 -> delta
     _ -> 0
   }
-  case process.receive(from: state.subj, within: wait) {
+  case process.receive(from: state.result_subj, within: wait) {
     Ok(PumpElement(element)) ->
       sample_wait(SampleState(..state, latest: Some(element)), ms)
     Ok(PumpDone) ->
       case state.latest {
         Some(value) ->
-          Next(value, SampleState(..state, latest: None, upstream_done: True))
+          Next(
+            value,
+            build_sample_stream(
+              SampleState(..state, latest: None, upstream_done: True),
+              ms,
+            ),
+          )
         None -> Done
       }
     Error(_) ->
@@ -270,7 +319,10 @@ fn sample_wait(
         Some(value) ->
           Next(
             value,
-            SampleState(..state, latest: None, window_start: deadline),
+            build_sample_stream(
+              SampleState(..state, latest: None, window_start: deadline),
+              ms,
+            ),
           )
         None -> sample_wait(SampleState(..state, window_start: deadline), ms)
       }
@@ -280,8 +332,14 @@ fn sample_wait(
 // --- rate_limit ----------------------------------------------------------
 
 @target(erlang)
-type RateState {
-  RateState(window_start: Int, count_in_window: Int)
+type RateState(a) {
+  RateState(
+    result_subj: Subject(Pump(a)),
+    stop_subj: Subject(Stop),
+    window_start: Int,
+    count_in_window: Int,
+    upstream_done: Bool,
+  )
 }
 
 @target(erlang)
@@ -293,67 +351,96 @@ pub fn rate_limit(
   max_per_window count: Int,
   window_ms ms: Int,
 ) -> Stream(a) {
-  let subj = spawn_pump(stream)
-  source.unfold(
-    from: #(subj, RateState(window_start: now_ms(), count_in_window: 0)),
-    with: fn(state) {
-      let #(subj, rate_state) = state
-      rate_limit_step(subj, rate_state, count, ms)
-    },
+  let result_subj = process.new_subject()
+  let stop_subj = pump.spawn_pump(stream, into: result_subj)
+  build_rate_limit_stream(
+    RateState(
+      result_subj: result_subj,
+      stop_subj: stop_subj,
+      window_start: now_ms(),
+      count_in_window: 0,
+      upstream_done: False,
+    ),
+    count,
+    ms,
   )
 }
 
 @target(erlang)
-fn rate_limit_step(
-  subj: Subject(Pump(a)),
-  state: RateState,
+fn build_rate_limit_stream(
+  state: RateState(a),
   count: Int,
   ms: Int,
-) -> datastream.Step(a, #(Subject(Pump(a)), RateState)) {
-  case process.receive_forever(from: subj) {
-    PumpDone -> Done
-    PumpElement(element) -> rate_limit_handle(element, subj, state, count, ms)
+) -> Stream(a) {
+  datastream.make(pull: fn() { rate_limit_step(state, count, ms) }, close: fn() {
+    maybe_stop(state.stop_subj, state.upstream_done)
+  })
+}
+
+@target(erlang)
+fn rate_limit_step(
+  state: RateState(a),
+  count: Int,
+  ms: Int,
+) -> datastream.Step(a, Stream(a)) {
+  case state.upstream_done {
+    True -> Done
+    False ->
+      case process.receive_forever(from: state.result_subj) {
+        PumpDone -> Done
+        PumpElement(element) -> rate_limit_handle(element, state, count, ms)
+      }
   }
 }
 
 @target(erlang)
 fn rate_limit_handle(
   element: a,
-  subj: Subject(Pump(a)),
-  state: RateState,
+  state: RateState(a),
   count: Int,
   ms: Int,
-) -> datastream.Step(a, #(Subject(Pump(a)), RateState)) {
+) -> datastream.Step(a, Stream(a)) {
   let now = now_ms()
   let state = case now >= state.window_start + ms {
-    True -> RateState(window_start: now, count_in_window: 0)
+    True -> RateState(..state, window_start: now, count_in_window: 0)
     False -> state
   }
   case state.count_in_window < count {
     True ->
-      Next(element, #(
-        subj,
-        RateState(..state, count_in_window: state.count_in_window + 1),
-      ))
-    False -> rate_limit_delay(element, subj, state, ms, now)
+      Next(
+        element,
+        build_rate_limit_stream(
+          RateState(..state, count_in_window: state.count_in_window + 1),
+          count,
+          ms,
+        ),
+      )
+    False -> rate_limit_delay(element, state, count, ms, now)
   }
 }
 
 @target(erlang)
 fn rate_limit_delay(
   element: a,
-  subj: Subject(Pump(a)),
-  state: RateState,
+  state: RateState(a),
+  count: Int,
   ms: Int,
   now: Int,
-) -> datastream.Step(a, #(Subject(Pump(a)), RateState)) {
+) -> datastream.Step(a, Stream(a)) {
   let sleep_ms = case state.window_start + ms - now {
     delta if delta > 0 -> delta
     _ -> 0
   }
   process.sleep(sleep_ms)
   let new_now = now_ms()
-  Next(element, #(subj, RateState(window_start: new_now, count_in_window: 1)))
+  Next(
+    element,
+    build_rate_limit_stream(
+      RateState(..state, window_start: new_now, count_in_window: 1),
+      count,
+      ms,
+    ),
+  )
 }
 
 // --- window_time ---------------------------------------------------------
@@ -361,7 +448,8 @@ fn rate_limit_delay(
 @target(erlang)
 type WindowState(a) {
   WindowState(
-    subj: Subject(Pump(a)),
+    result_subj: Subject(Pump(a)),
+    stop_subj: Subject(Stop),
     buffer: List(a),
     window_start: Int,
     upstream_done: Bool,
@@ -373,23 +461,32 @@ type WindowState(a) {
 /// `Chunk(a)` containing every element that arrived during that
 /// window. Empty windows emit empty chunks.
 pub fn window_time(over stream: Stream(a), span ms: Int) -> Stream(Chunk(a)) {
-  let subj = spawn_pump(stream)
-  source.unfold(
-    from: WindowState(
-      subj: subj,
+  let result_subj = process.new_subject()
+  let stop_subj = pump.spawn_pump(stream, into: result_subj)
+  build_window_stream(
+    WindowState(
+      result_subj: result_subj,
+      stop_subj: stop_subj,
       buffer: [],
       window_start: now_ms(),
       upstream_done: False,
     ),
-    with: fn(state) { window_step(state, ms) },
+    ms,
   )
+}
+
+@target(erlang)
+fn build_window_stream(state: WindowState(a), ms: Int) -> Stream(Chunk(a)) {
+  datastream.make(pull: fn() { window_step(state, ms) }, close: fn() {
+    maybe_stop(state.stop_subj, state.upstream_done)
+  })
 }
 
 @target(erlang)
 fn window_step(
   state: WindowState(a),
   ms: Int,
-) -> datastream.Step(Chunk(a), WindowState(a)) {
+) -> datastream.Step(Chunk(a), Stream(Chunk(a))) {
   case state.upstream_done {
     True ->
       case state.buffer {
@@ -397,7 +494,7 @@ fn window_step(
         _ ->
           Next(
             chunk_from_reverse(state.buffer),
-            WindowState(..state, buffer: []),
+            build_window_stream(WindowState(..state, buffer: []), ms),
           )
       }
     False -> window_wait(state, ms)
@@ -408,21 +505,24 @@ fn window_step(
 fn window_wait(
   state: WindowState(a),
   ms: Int,
-) -> datastream.Step(Chunk(a), WindowState(a)) {
+) -> datastream.Step(Chunk(a), Stream(Chunk(a))) {
   let now = now_ms()
   let deadline = state.window_start + ms
   let wait = case deadline - now {
     delta if delta > 0 -> delta
     _ -> 0
   }
-  case process.receive(from: state.subj, within: wait) {
+  case process.receive(from: state.result_subj, within: wait) {
     Ok(PumpElement(element)) ->
       window_wait(WindowState(..state, buffer: [element, ..state.buffer]), ms)
     Ok(PumpDone) -> window_step(WindowState(..state, upstream_done: True), ms)
     Error(_) ->
       Next(
         chunk_from_reverse(state.buffer),
-        WindowState(..state, buffer: [], window_start: deadline),
+        build_window_stream(
+          WindowState(..state, buffer: [], window_start: deadline),
+          ms,
+        ),
       )
   }
 }

--- a/test/datastream/erlang/internal/event_log.gleam
+++ b/test/datastream/erlang/internal/event_log.gleam
@@ -1,0 +1,122 @@
+//// Test helper for tracking resource open/close events across BEAM
+//// worker processes.
+////
+//// The cross-target `process dictionary` counter pattern used in
+//// `test/datastream/resource_test.gleam` does not work here because
+//// the resource's `open` and `close` callbacks fire inside the worker
+//// processes spawned by `datastream/erlang/par` and
+//// `datastream/erlang/time`, and each process has its own dictionary.
+//// Instead, every event is sent to a shared `Subject` owned by the
+//// test process; the test drains it after the pipeline is done.
+
+@target(javascript)
+pub const beam_only_marker: String = "test/datastream/erlang/internal/event_log is BEAM-only"
+
+@target(erlang)
+import datastream.{type Stream, Done, Next}
+
+@target(erlang)
+import datastream/source
+
+@target(erlang)
+import gleam/erlang/process.{type Subject}
+
+@target(erlang)
+pub type Event {
+  ResourceOpen(name: String)
+  ResourceClose(name: String)
+}
+
+@target(erlang)
+pub fn new_log() -> Subject(Event) {
+  process.new_subject()
+}
+
+@target(erlang)
+pub fn counted_resource(
+  elements: List(a),
+  named name: String,
+  log log: Subject(Event),
+) -> Stream(a) {
+  source.resource(
+    open: fn() {
+      process.send(log, ResourceOpen(name))
+      elements
+    },
+    next: fn(state) {
+      case state {
+        [] -> Done
+        [head, ..tail] -> Next(element: head, state: tail)
+      }
+    },
+    close: fn(_) {
+      process.send(log, ResourceClose(name))
+      Nil
+    },
+  )
+}
+
+@target(erlang)
+pub fn drain(log: Subject(Event), within ms: Int) -> List(Event) {
+  drain_loop(log, ms, [])
+  |> reverse
+}
+
+@target(erlang)
+fn drain_loop(log: Subject(Event), ms: Int, acc: List(Event)) -> List(Event) {
+  case process.receive(from: log, within: ms) {
+    Ok(event) -> drain_loop(log, ms, [event, ..acc])
+    Error(_) -> acc
+  }
+}
+
+@target(erlang)
+fn reverse(list: List(a)) -> List(a) {
+  reverse_loop(list, [])
+}
+
+@target(erlang)
+fn reverse_loop(list: List(a), acc: List(a)) -> List(a) {
+  case list {
+    [] -> acc
+    [head, ..tail] -> reverse_loop(tail, [head, ..acc])
+  }
+}
+
+@target(erlang)
+pub fn count_opens(events: List(Event)) -> Int {
+  count_matching(events, is_open, 0)
+}
+
+@target(erlang)
+pub fn count_closes(events: List(Event)) -> Int {
+  count_matching(events, is_close, 0)
+}
+
+@target(erlang)
+fn is_open(event: Event) -> Bool {
+  case event {
+    ResourceOpen(_) -> True
+    ResourceClose(_) -> False
+  }
+}
+
+@target(erlang)
+fn is_close(event: Event) -> Bool {
+  case event {
+    ResourceClose(_) -> True
+    ResourceOpen(_) -> False
+  }
+}
+
+@target(erlang)
+fn count_matching(list: List(Event), pred: fn(Event) -> Bool, acc: Int) -> Int {
+  case list {
+    [] -> acc
+    [head, ..tail] ->
+      case pred(head) {
+        True -> count_matching(tail, pred, acc + 1)
+        False -> count_matching(tail, pred, acc)
+      }
+  }
+}

--- a/test/datastream/erlang/par_test.gleam
+++ b/test/datastream/erlang/par_test.gleam
@@ -1,6 +1,9 @@
 //// BEAM-only tests for `datastream/erlang/par`.
 
 @target(erlang)
+import datastream/erlang/internal/event_log
+
+@target(erlang)
 import datastream/erlang/par
 
 @target(erlang)
@@ -8,6 +11,12 @@ import datastream/fold
 
 @target(erlang)
 import datastream/source
+
+@target(erlang)
+import datastream/stream
+
+@target(erlang)
+import gleam/erlang/process
 
 @target(erlang)
 import gleam/list
@@ -138,4 +147,76 @@ pub fn race_emitting_first_and_empties_later_yields_emitting_test() {
   par.race(streams: [source.from_list([7, 8]), source.empty(), source.empty()])
   |> fold.to_list
   |> should.equal([7, 8])
+}
+
+// --- close contract ------------------------------------------------------
+
+@target(erlang)
+pub fn merge_take_early_exit_closes_upstreams_test() {
+  let log = event_log.new_log()
+  let a = event_log.counted_resource([1, 2, 3], named: "a", log: log)
+  let b = event_log.counted_resource([4, 5, 6], named: "b", log: log)
+
+  let _result =
+    par.merge(streams: [a, b], max_buffer: 4)
+    |> stream.take(up_to: 1)
+    |> fold.to_list
+
+  process.sleep(100)
+  let events = event_log.drain(log, within: 100)
+  event_log.count_opens(events) |> should.equal(2)
+  event_log.count_closes(events) |> should.equal(2)
+}
+
+@target(erlang)
+pub fn map_unordered_take_early_exit_closes_upstream_test() {
+  let log = event_log.new_log()
+  let upstream = event_log.counted_resource([1, 2, 3, 4], named: "u", log: log)
+
+  let _result =
+    upstream
+    |> par.map_unordered(with: fn(x) { x }, max_workers: 2, max_buffer: 4)
+    |> stream.take(up_to: 1)
+    |> fold.to_list
+
+  process.sleep(50)
+  let events = event_log.drain(log, within: 50)
+  event_log.count_opens(events) |> should.equal(1)
+  event_log.count_closes(events) |> should.equal(1)
+}
+
+@target(erlang)
+pub fn map_ordered_take_early_exit_closes_upstream_test() {
+  let log = event_log.new_log()
+  let upstream = event_log.counted_resource([1, 2, 3, 4], named: "u", log: log)
+
+  let _result =
+    upstream
+    |> par.map_ordered(with: fn(x) { x }, max_workers: 2, max_buffer: 4)
+    |> stream.take(up_to: 1)
+    |> fold.to_list
+
+  process.sleep(50)
+  let events = event_log.drain(log, within: 50)
+  event_log.count_opens(events) |> should.equal(1)
+  event_log.count_closes(events) |> should.equal(1)
+}
+
+@target(erlang)
+pub fn race_winner_take_full_consumption_closes_winner_test() {
+  let log = event_log.new_log()
+  let winner = event_log.counted_resource([1], named: "w", log: log)
+  let loser = source.from_list([2])
+
+  let _result =
+    par.race(streams: [winner, loser])
+    |> fold.to_list
+
+  process.sleep(50)
+  let events = event_log.drain(log, within: 50)
+  // The resource MUST be opened at least once, and every open MUST be
+  // matched by a close.
+  let opens = event_log.count_opens(events)
+  let closes = event_log.count_closes(events)
+  opens |> should.equal(closes)
 }

--- a/test/datastream/erlang/source_test.gleam
+++ b/test/datastream/erlang/source_test.gleam
@@ -7,6 +7,9 @@
 import datastream
 
 @target(erlang)
+import datastream/erlang/internal/event_log
+
+@target(erlang)
 import datastream/erlang/source as beam_source
 
 @target(erlang)
@@ -104,4 +107,21 @@ pub fn timeout_emits_error_when_upstream_is_too_slow_test() {
   |> beam_source.timeout(within: 50)
   |> fold.to_list
   |> should.equal([Error(Nil)])
+}
+
+@target(erlang)
+pub fn timeout_take_early_exit_closes_upstream_test() {
+  let log = event_log.new_log()
+  let upstream = event_log.counted_resource([1, 2, 3], named: "u", log: log)
+
+  upstream
+  |> beam_source.timeout(within: 100)
+  |> stream.take(up_to: 1)
+  |> fold.to_list
+  |> should.equal([Ok(1)])
+
+  process.sleep(50)
+  let events = event_log.drain(log, within: 50)
+  event_log.count_opens(events) |> should.equal(1)
+  event_log.count_closes(events) |> should.equal(1)
 }

--- a/test/datastream/erlang/time_test.gleam
+++ b/test/datastream/erlang/time_test.gleam
@@ -7,6 +7,8 @@
 @target(erlang)
 import datastream/chunk
 @target(erlang)
+import datastream/erlang/internal/event_log
+@target(erlang)
 import datastream/erlang/time as beam_time
 @target(erlang)
 import datastream/fold
@@ -14,6 +16,8 @@ import datastream/fold
 import datastream/source
 @target(erlang)
 import datastream/stream
+@target(erlang)
+import gleam/erlang/process
 @target(erlang)
 import gleam/list
 @target(erlang)
@@ -114,4 +118,40 @@ pub fn window_time_take_one_chunk_via_take_test() {
   |> list.flat_map(chunk.to_list)
   |> list.length
   |> should.equal(5)
+}
+
+// --- close contract ------------------------------------------------------
+
+@target(erlang)
+pub fn debounce_take_early_exit_closes_upstream_test() {
+  let log = event_log.new_log()
+  let upstream = event_log.counted_resource([1, 2, 3], named: "u", log: log)
+
+  let _result =
+    upstream
+    |> beam_time.debounce(quiet_for: 30)
+    |> stream.take(up_to: 1)
+    |> fold.to_list
+
+  process.sleep(100)
+  let events = event_log.drain(log, within: 100)
+  event_log.count_opens(events) |> should.equal(1)
+  event_log.count_closes(events) |> should.equal(1)
+}
+
+@target(erlang)
+pub fn window_time_take_early_exit_closes_upstream_test() {
+  let log = event_log.new_log()
+  let upstream = event_log.counted_resource([1, 2, 3], named: "u", log: log)
+
+  let _result =
+    upstream
+    |> beam_time.window_time(span: 30)
+    |> stream.take(up_to: 1)
+    |> fold.to_list
+
+  process.sleep(100)
+  let events = event_log.drain(log, within: 100)
+  event_log.count_opens(events) |> should.equal(1)
+  event_log.count_closes(events) |> should.equal(1)
 }


### PR DESCRIPTION
## Summary

Fixes #45. Every BEAM extension combinator (`source.timeout`, `par.{merge, race, map_unordered, map_ordered}`, `time.{debounce, throttle, sample, rate_limit, window_time}`) was built on `source.unfold`, whose `close` callback is a no-op. Downstream early-exit therefore left worker processes running and never closed the upstream resources they were holding. Each combinator now exposes a real `close` callback that signals its workers to stop and lets the workers close their upstream gracefully.

## Changes

### New
- `src/datastream/erlang/internal/pump.gleam` — `spawn_with_stop` (worker owns its stop subject and hands it to the caller via handshake), `spawn_pump` (pump worker with stop check), `stop` signal helper.
- `test/datastream/erlang/internal/event_log.gleam` — cross-process resource open/close event log used by the new tests; the existing process-dictionary counter pattern in `resource_test.gleam` cannot observe events that happen inside a worker process.

### Modified
- `source.timeout`: switched to `datastream.make` with a state-passing close that forwards to the active upstream.
- `par.merge`: tracks per-worker stop subjects; close signals every still-active worker.
- `par.race`: tracks per-worker stop subjects; on winner selection, drains already-arrived loser messages to close their `rest` and signals every other worker. Also includes the worker stop check that the original `race_first_pull` lacked.
- `par.{map_unordered, map_ordered}`: workers are short-lived (one element each), so close just closes the upstream when not already drained.
- `time.{debounce, throttle, sample, rate_limit, window_time}`: each uses `pump.spawn_pump` and a shared `maybe_stop` close handler that respects the `upstream_done` flag.

### Tests
Resource-counter tests added for `source.timeout`, `par.{merge, map_unordered, map_ordered, race}`, `time.{debounce, window_time}`. Each test takes one element with `stream.take(up_to: 1)` (or fully consumes for race), then asserts `opens == closes` after a short sleep that lets workers observe the stop signal and close gracefully.

## Design Decisions

- **Worker self-cleanup over coordinator-driven cleanup.** The coordinator never calls `datastream.close` on the upstream that a worker is holding; the worker observes the stop signal and closes the upstream itself. This keeps the close callback running in the same process that owns the upstream and avoids double-close.
- **Subject ownership.** Erlang subjects can only be read by their owning process, so every worker creates its own stop subject and hands it back to the caller via a tiny handshake.
- **State-passing streams.** Each pull returns `Next(element, build_*_stream(next_state))`, mirroring the `pull_resource` idiom in `datastream/source.resource`. The close callback always sees the latest state.
- **`drain_loser_messages` in race.** A loser worker that has already sent its `RaceNext` cannot see a stop signal anymore, so the coordinator drains those messages on winner selection and closes their `rest`. This is best-effort (see Limitations).
- **Per-function close shape.** `time.*` and `merge` use `maybe_stop(stop_subj, upstream_done)`. `map_*` workers are one-shot so close only needs to close the upstream. `race` has its own close because the state machine has two distinct shapes (waiting / winning).

## Limitations

- A worker blocked inside `datastream.pull` only stops once that pull returns. Pulls that never return leave the worker resident; resources opened by such a pull are reclaimed only when the BEAM process exits.
- For `par.race`, a loser worker that completed its single pull after the coordinator had moved on cannot be intercepted, and its abandoned `rest` is reclaimed by BEAM rather than by an explicit close. External resources (file descriptors, sockets) held by such a `rest` may leak. Documented in the `race` doc comment.
- `from_subject` still cannot be composed with these combinators because the worker process is not the subject's owner. This was already the case for `source.timeout` and is now uniform across all BEAM extensions.

Closes #45