### PR TITLE
feat(erlang/par): make max_buffer enforce in-flight ceiling, add 2-tier API

### DIFF
--- a/src/datastream/erlang/par.gleam
+++ b/src/datastream/erlang/par.gleam
@@ -44,7 +44,17 @@
 ////
 //// - A `f(x)` that `panic`s leaves the pipeline blocked; this is a
 ////   known limitation across all `par.*` combinators.
+//// - `merge` workers poll for a coordinator-liveness signal every
+////   `merge_worker_liveness_check_ms` ms. If the caller of
+////   `merge` / `merge_with` drops the returned stream without
+////   reaching `close` (e.g. by losing a reference inside a
+////   long-running process), the workers stay resident: the caller is
+////   still alive, so the liveness probe says "keep going". Always
+////   drive the stream to a terminal or call `close` explicitly.
 //// - Unbounded concurrency is intentionally not offered.
+
+@target(erlang)
+const merge_worker_liveness_check_ms: Int = 5000
 
 @target(javascript)
 /// Sentinel value documenting that this module is BEAM-only.
@@ -542,7 +552,9 @@ fn merge_pump(
   my_signal: Subject(MergeSignal),
   coordinator_pid: process.Pid,
 ) -> Nil {
-  case process.receive(from: my_signal, within: 5000) {
+  case
+    process.receive(from: my_signal, within: merge_worker_liveness_check_ms)
+  {
     Ok(MergeStop) -> datastream.close(stream)
     Ok(MergeContinue) ->
       case datastream.pull(stream) {

--- a/src/datastream/erlang/par.gleam
+++ b/src/datastream/erlang/par.gleam
@@ -4,22 +4,67 @@
 //// involved, so callers can tell at the import site whether a
 //// pipeline runs in parallel.
 ////
-//// Three knobs cover the design space: `max_workers` (degree of
-//// parallelism), `max_buffer` (back-pressure ceiling), and the
-//// explicit ordered-vs-unordered choice. Unbounded concurrency is
-//// intentionally not offered.
+//// ## Concurrency knobs
+////
+//// - `max_workers`: degree of parallelism. The maximum number of BEAM
+////   processes that run the user function at once. Only `map_*` and
+////   `each_*` accept this knob; `merge` is fixed at one worker per
+////   input stream.
+//// - `max_buffer`: in-flight ceiling. The maximum number of elements
+////   pulled from the upstream(s) but not yet emitted to the downstream.
+////   Workers in flight (mid-`f(x)`) count toward this ceiling.
+////
+//// `max_buffer >= max_workers` is required where both apply; otherwise
+//// the buffer would fill before parallelism is reached.
+////
+//// ## What happens when `max_buffer` is reached
+////
+//// | function | behaviour |
+//// |----------|-----------|
+//// | `map_unordered` | new dispatch is paused; in-flight workers finish |
+//// | `map_ordered`   | new dispatch is paused; pending dict + workers cap |
+//// | `merge`         | per-worker `Continue` ack is withheld; workers wait |
+////
+//// ## Defaults
+////
+//// `default_max_workers = 4` and `default_max_buffer = 16` are the
+//// values used by the no-argument `merge`, `map_unordered`,
+//// `map_ordered`, `each_unordered`, `each_ordered`. They aim at the
+//// common case (mixed CPU + IO work, modest cardinality). Tune via
+//// the `_with` variants when:
+////
+//// - workload is IO-bound (consider `max_workers` of 16-128 and a
+////   correspondingly larger `max_buffer`)
+//// - workload is CPU-bound (consider `max_workers` equal to
+////   `erlang:system_info(schedulers_online)`)
+//// - upstream is rate-limited or memory-pressured (lower
+////   `max_buffer` to throttle pull rate)
+////
+//// ## Notes
+////
+//// - A `f(x)` that `panic`s leaves the pipeline blocked; this is a
+////   known limitation across all `par.*` combinators.
+//// - Unbounded concurrency is intentionally not offered.
 
 @target(javascript)
 /// Sentinel value documenting that this module is BEAM-only.
 pub const beam_only_marker: String = "datastream/erlang/par is BEAM-only"
 
 @target(erlang)
+/// Default `max_workers` for the no-argument variants of `map_*` and
+/// `each_*`.
+pub const default_max_workers: Int = 4
+
+@target(erlang)
+/// Default `max_buffer` for the no-argument variants of `merge`,
+/// `map_*`, and `each_*`.
+pub const default_max_buffer: Int = 16
+
+@target(erlang)
 import datastream.{type Stream, Done, Next}
 
 @target(erlang)
-import datastream/erlang/internal/pump.{
-  type Pump, type Stop, PumpDone, PumpElement,
-}
+import datastream/erlang/internal/pump.{type Stop}
 
 @target(erlang)
 import datastream/fold
@@ -36,6 +81,9 @@ import gleam/erlang/process.{type Subject}
 @target(erlang)
 import gleam/list
 
+@target(erlang)
+import gleam/option.{type Option, None, Some}
+
 // --- common argument validation --------------------------------------------
 
 @target(erlang)
@@ -44,9 +92,17 @@ fn validate_par_args(max_workers: Int, max_buffer: Int) -> Nil {
     True -> Nil
     False -> panic as "datastream/erlang/par: max_workers must be >= 1"
   }
+  case max_buffer >= max_workers {
+    True -> Nil
+    False -> panic as "datastream/erlang/par: max_buffer must be >= max_workers"
+  }
+}
+
+@target(erlang)
+fn validate_buffer(max_buffer: Int) -> Nil {
   case max_buffer >= 1 {
     True -> Nil
-    False -> panic as "datastream/erlang/par: max_buffer must be >= 1"
+    False -> panic as "datastream/erlang/par.merge: max_buffer must be >= 1"
   }
 }
 
@@ -58,6 +114,7 @@ type MapUnordered(a, b) {
     source: Stream(a),
     f: fn(a) -> b,
     max_workers: Int,
+    max_buffer: Int,
     workers_busy: Int,
     result_subject: Subject(b),
     source_drained: Bool,
@@ -65,14 +122,29 @@ type MapUnordered(a, b) {
 }
 
 @target(erlang)
+/// Run `f` in parallel using `default_max_workers` BEAM processes,
+/// emitting results in the order they finish.
+///
+/// See `map_unordered_with` for tunable concurrency.
+pub fn map_unordered(over stream: Stream(a), with f: fn(a) -> b) -> Stream(b) {
+  map_unordered_with(
+    over: stream,
+    with: f,
+    max_workers: default_max_workers,
+    max_buffer: default_max_buffer,
+  )
+}
+
+@target(erlang)
 /// Run `f` in parallel across at most `max_workers` BEAM processes.
 /// Results are emitted in the order they finish, NOT input order.
 ///
-/// `max_workers >= 1` and `max_buffer >= 1` are required; violations
-/// `panic` at construction. `max_buffer` is the per-instance prefetch
-/// ceiling; this minimal implementation does not yet apply
-/// back-pressure beyond capping `workers_busy` at `max_workers`.
-pub fn map_unordered(
+/// `max_workers >= 1` and `max_buffer >= max_workers` are required;
+/// violations `panic` at construction. Because `map_unordered` emits
+/// each result the moment it arrives, `in_flight = workers_busy`, and
+/// `max_buffer` only adds a ceiling redundant with `max_workers`. The
+/// argument is kept for symmetry with `map_ordered` and `merge`.
+pub fn map_unordered_with(
   over stream: Stream(a),
   with f: fn(a) -> b,
   max_workers max_workers: Int,
@@ -84,6 +156,7 @@ pub fn map_unordered(
     source: stream,
     f: f,
     max_workers: max_workers,
+    max_buffer: max_buffer,
     workers_busy: 0,
     result_subject: result_subject,
     source_drained: False,
@@ -126,7 +199,11 @@ fn map_unordered_step(
 
 @target(erlang)
 fn dispatch_unordered(state: MapUnordered(a, b)) -> MapUnordered(a, b) {
-  case state.source_drained || state.workers_busy >= state.max_workers {
+  case
+    state.source_drained
+    || state.workers_busy >= state.max_workers
+    || state.workers_busy >= state.max_buffer
+  {
     True -> state
     False ->
       case datastream.pull(state.source) {
@@ -156,12 +233,28 @@ type MapOrdered(a, b) {
     source: Stream(a),
     f: fn(a) -> b,
     max_workers: Int,
+    max_buffer: Int,
     workers_busy: Int,
+    in_flight: Int,
     next_dispatch_index: Int,
     next_emit_index: Int,
     result_subject: Subject(#(Int, b)),
     pending: Dict(Int, b),
     source_drained: Bool,
+  )
+}
+
+@target(erlang)
+/// Run `f` in parallel using `default_max_workers` BEAM processes,
+/// emitting results in input order.
+///
+/// See `map_ordered_with` for tunable concurrency.
+pub fn map_ordered(over stream: Stream(a), with f: fn(a) -> b) -> Stream(b) {
+  map_ordered_with(
+    over: stream,
+    with: f,
+    max_workers: default_max_workers,
+    max_buffer: default_max_buffer,
   )
 }
 
@@ -172,25 +265,23 @@ type MapOrdered(a, b) {
 /// `max_buffer >= max_workers` is REQUIRED: if `max_buffer` were
 /// smaller, the buffer would fill while waiting for an early result
 /// and ordering could not be enforced without stalling. Violation
-/// panics at construction.
-pub fn map_ordered(
+/// panics at construction. `in_flight = workers_busy + pending dict
+/// size`; dispatch is paused once it reaches `max_buffer`.
+pub fn map_ordered_with(
   over stream: Stream(a),
   with f: fn(a) -> b,
   max_workers max_workers: Int,
   max_buffer max_buffer: Int,
 ) -> Stream(b) {
   validate_par_args(max_workers, max_buffer)
-  case max_buffer >= max_workers {
-    True -> Nil
-    False ->
-      panic as "datastream/erlang/par.map_ordered: max_buffer must be >= max_workers"
-  }
   let result_subject = process.new_subject()
   build_map_ordered_stream(MapOrdered(
     source: stream,
     f: f,
     max_workers: max_workers,
+    max_buffer: max_buffer,
     workers_busy: 0,
+    in_flight: 0,
     next_dispatch_index: 0,
     next_emit_index: 0,
     result_subject: result_subject,
@@ -226,6 +317,7 @@ fn map_ordered_step(state: MapOrdered(a, b)) -> datastream.Step(b, Stream(b)) {
             ..state,
             pending: dict.delete(state.pending, state.next_emit_index),
             next_emit_index: state.next_emit_index + 1,
+            in_flight: state.in_flight - 1,
           ),
         ),
       )
@@ -249,7 +341,11 @@ fn map_ordered_step(state: MapOrdered(a, b)) -> datastream.Step(b, Stream(b)) {
 
 @target(erlang)
 fn dispatch_ordered(state: MapOrdered(a, b)) -> MapOrdered(a, b) {
-  case state.source_drained || state.workers_busy >= state.max_workers {
+  case
+    state.source_drained
+    || state.workers_busy >= state.max_workers
+    || state.in_flight >= state.max_buffer
+  {
     True -> state
     False ->
       case datastream.pull(state.source) {
@@ -267,6 +363,7 @@ fn dispatch_ordered(state: MapOrdered(a, b)) -> MapOrdered(a, b) {
               ..state,
               source: rest,
               workers_busy: state.workers_busy + 1,
+              in_flight: state.in_flight + 1,
               next_dispatch_index: position + 1,
             ),
           )
@@ -278,15 +375,26 @@ fn dispatch_ordered(state: MapOrdered(a, b)) -> MapOrdered(a, b) {
 // --- each_ordered / each_unordered ----------------------------------------
 
 @target(erlang)
-/// Side-effect-only variant of `map_ordered`. Drives the stream to
-/// completion and returns `Nil`.
-pub fn each_ordered(
+/// Side-effect-only variant of `map_ordered`. Uses
+/// `default_max_workers` and `default_max_buffer`.
+pub fn each_ordered(over stream: Stream(a), with effect: fn(a) -> Nil) -> Nil {
+  each_ordered_with(
+    over: stream,
+    with: effect,
+    max_workers: default_max_workers,
+    max_buffer: default_max_buffer,
+  )
+}
+
+@target(erlang)
+/// Side-effect-only variant of `map_ordered_with`.
+pub fn each_ordered_with(
   over stream: Stream(a),
   with effect: fn(a) -> Nil,
   max_workers max_workers: Int,
   max_buffer max_buffer: Int,
 ) -> Nil {
-  map_ordered(
+  map_ordered_with(
     over: stream,
     with: fn(x) {
       effect(x)
@@ -299,15 +407,26 @@ pub fn each_ordered(
 }
 
 @target(erlang)
-/// Side-effect-only variant of `map_unordered`. Drives the stream to
-/// completion and returns `Nil`.
-pub fn each_unordered(
+/// Side-effect-only variant of `map_unordered`. Uses
+/// `default_max_workers` and `default_max_buffer`.
+pub fn each_unordered(over stream: Stream(a), with effect: fn(a) -> Nil) -> Nil {
+  each_unordered_with(
+    over: stream,
+    with: effect,
+    max_workers: default_max_workers,
+    max_buffer: default_max_buffer,
+  )
+}
+
+@target(erlang)
+/// Side-effect-only variant of `map_unordered_with`.
+pub fn each_unordered_with(
   over stream: Stream(a),
   with effect: fn(a) -> Nil,
   max_workers max_workers: Int,
   max_buffer max_buffer: Int,
 ) -> Nil {
-  map_unordered(
+  map_unordered_with(
     over: stream,
     with: fn(x) {
       effect(x)
@@ -322,13 +441,36 @@ pub fn each_unordered(
 // --- merge ---------------------------------------------------------------
 
 @target(erlang)
+type MergeSignal {
+  MergeContinue
+  MergeStop
+}
+
+@target(erlang)
+type MergeMsg(a) {
+  MergeNext(from: Subject(MergeSignal), element: a)
+  MergeDone(from: Subject(MergeSignal))
+}
+
+@target(erlang)
 type MergeState(a) {
   MergeState(
-    result_subj: Subject(Pump(a)),
-    stop_subjs: List(Subject(Stop)),
+    result_subj: Subject(MergeMsg(a)),
+    all_signals: List(Subject(MergeSignal)),
+    pending_continues: List(Subject(MergeSignal)),
+    pending_emit: Option(Subject(MergeSignal)),
     total: Int,
     completed: Int,
   )
+}
+
+@target(erlang)
+/// Interleave elements from every input stream in arrival order. Uses
+/// `default_max_buffer` as the in-flight ceiling.
+///
+/// See `merge_with` for tunable buffering.
+pub fn merge(streams streams: List(Stream(a))) -> Stream(a) {
+  merge_with(streams: streams, max_buffer: default_max_buffer)
 }
 
 @target(erlang)
@@ -336,31 +478,86 @@ type MergeState(a) {
 ///
 /// Order from each individual source is preserved relative to that
 /// source; cross-source order follows whichever worker process
-/// happens to deliver first. `max_buffer >= 1` is required.
+/// happens to deliver first.
 ///
-/// One worker process is spawned per input stream; the workers pump
-/// their source into a shared subject. The resulting `Stream` walks
-/// that subject and counts down workers as they signal that they are
-/// done. Downstream early-exit signals every still-running worker to
-/// close its upstream.
-pub fn merge(
+/// `max_buffer` bounds the number of in-flight elements: pulled by
+/// any worker but not yet emitted to the downstream. Implementation:
+/// at startup at most `max_buffer` workers are issued a `Continue`
+/// signal; the rest wait. Each worker pulls one element, sends it,
+/// and waits for the next `Continue`. The coordinator hands a
+/// `Continue` to the next waiting worker every time it emits an
+/// element downstream. If `max_buffer < len(streams)`, the late-
+/// starting workers wait until earlier ones drain.
+///
+/// `max_buffer >= 1` is required.
+pub fn merge_with(
   streams streams: List(Stream(a)),
   max_buffer max_buffer: Int,
 ) -> Stream(a) {
-  case max_buffer >= 1 {
-    True -> Nil
-    False -> panic as "datastream/erlang/par.merge: max_buffer must be >= 1"
-  }
+  validate_buffer(max_buffer)
   let result_subj = process.new_subject()
+  let coordinator_pid = process.self()
+  let all_signals =
+    list.map(streams, fn(stream) {
+      spawn_merge_pump(stream, result_subj, coordinator_pid)
+    })
   let total = list.length(streams)
-  let stop_subjs =
-    list.map(streams, fn(s) { pump.spawn_pump(over: s, into: result_subj) })
+  let initial_count = case max_buffer < total {
+    True -> max_buffer
+    False -> total
+  }
+  let initial = list.take(all_signals, initial_count)
+  let deferred = list.drop(all_signals, initial_count)
+  list.each(initial, fn(sig) { process.send(sig, MergeContinue) })
   build_merge_stream(MergeState(
     result_subj: result_subj,
-    stop_subjs: stop_subjs,
+    all_signals: all_signals,
+    pending_continues: deferred,
+    pending_emit: None,
     total: total,
     completed: 0,
   ))
+}
+
+@target(erlang)
+fn spawn_merge_pump(
+  stream: Stream(a),
+  result_subj: Subject(MergeMsg(a)),
+  coordinator_pid: process.Pid,
+) -> Subject(MergeSignal) {
+  let handshake = process.new_subject()
+  let _pid =
+    process.spawn_unlinked(fn() {
+      let my_signal = process.new_subject()
+      process.send(handshake, my_signal)
+      merge_pump(stream, result_subj, my_signal, coordinator_pid)
+    })
+  process.receive_forever(from: handshake)
+}
+
+@target(erlang)
+fn merge_pump(
+  stream: Stream(a),
+  result_subj: Subject(MergeMsg(a)),
+  my_signal: Subject(MergeSignal),
+  coordinator_pid: process.Pid,
+) -> Nil {
+  case process.receive(from: my_signal, within: 5000) {
+    Ok(MergeStop) -> datastream.close(stream)
+    Ok(MergeContinue) ->
+      case datastream.pull(stream) {
+        Next(element, rest) -> {
+          process.send(result_subj, MergeNext(my_signal, element))
+          merge_pump(rest, result_subj, my_signal, coordinator_pid)
+        }
+        Done -> process.send(result_subj, MergeDone(my_signal))
+      }
+    Error(_) ->
+      case process.is_alive(coordinator_pid) {
+        True -> merge_pump(stream, result_subj, my_signal, coordinator_pid)
+        False -> datastream.close(stream)
+      }
+  }
 }
 
 @target(erlang)
@@ -374,20 +571,55 @@ fn build_merge_stream(state: MergeState(a)) -> Stream(a) {
 fn merge_close(state: MergeState(a)) -> Nil {
   case state.completed >= state.total {
     True -> Nil
-    False -> list.each(state.stop_subjs, pump.stop)
+    False ->
+      list.each(state.all_signals, fn(sig) { process.send(sig, MergeStop) })
   }
 }
 
 @target(erlang)
 fn merge_step(state: MergeState(a)) -> datastream.Step(a, Stream(a)) {
+  let state = case state.pending_emit {
+    Some(prev) -> release_slot(state, prev, True)
+    None -> state
+  }
+  let state = MergeState(..state, pending_emit: None)
   case state.completed >= state.total {
     True -> Done
     False ->
       case process.receive_forever(from: state.result_subj) {
-        PumpElement(element) -> Next(element, build_merge_stream(state))
-        PumpDone ->
+        MergeNext(from, element) ->
+          Next(
+            element,
+            build_merge_stream(MergeState(..state, pending_emit: Some(from))),
+          )
+        MergeDone(from) -> {
+          let state = release_slot(state, from, False)
           merge_step(MergeState(..state, completed: state.completed + 1))
+        }
       }
+  }
+}
+
+@target(erlang)
+fn release_slot(
+  state: MergeState(a),
+  just_finished: Subject(MergeSignal),
+  finished_can_continue: Bool,
+) -> MergeState(a) {
+  // Round-robin: a worker that just emitted joins the back of the
+  // queue, then we hand Continue to whoever is at the front. This
+  // gives fair scheduling and avoids starving the first workers when
+  // streams > max_buffer.
+  let queue = case finished_can_continue {
+    True -> list.append(state.pending_continues, [just_finished])
+    False -> state.pending_continues
+  }
+  case queue {
+    [next, ..rest] -> {
+      process.send(next, MergeContinue)
+      MergeState(..state, pending_continues: rest)
+    }
+    [] -> MergeState(..state, pending_continues: queue)
   }
 }
 

--- a/test/datastream/erlang/internal/event_log.gleam
+++ b/test/datastream/erlang/internal/event_log.gleam
@@ -25,6 +25,8 @@ import gleam/erlang/process.{type Subject}
 pub type Event {
   ResourceOpen(name: String)
   ResourceClose(name: String)
+  EnterFn(name: String)
+  LeaveFn(name: String)
 }
 
 @target(erlang)
@@ -97,7 +99,7 @@ pub fn count_closes(events: List(Event)) -> Int {
 fn is_open(event: Event) -> Bool {
   case event {
     ResourceOpen(_) -> True
-    ResourceClose(_) -> False
+    _ -> False
   }
 }
 
@@ -105,7 +107,42 @@ fn is_open(event: Event) -> Bool {
 fn is_close(event: Event) -> Bool {
   case event {
     ResourceClose(_) -> True
-    ResourceOpen(_) -> False
+    _ -> False
+  }
+}
+
+@target(erlang)
+pub fn record_enter(log: Subject(Event), named name: String) -> Nil {
+  process.send(log, EnterFn(name))
+}
+
+@target(erlang)
+pub fn record_leave(log: Subject(Event), named name: String) -> Nil {
+  process.send(log, LeaveFn(name))
+}
+
+@target(erlang)
+/// Walk the events in arrival order, tracking running concurrent
+/// `EnterFn`/`LeaveFn` count for `name`, and return the peak.
+pub fn peak_concurrent(events: List(Event), named name: String) -> Int {
+  peak_loop(events, name, 0, 0)
+}
+
+@target(erlang)
+fn peak_loop(events: List(Event), name: String, running: Int, peak: Int) -> Int {
+  case events {
+    [] -> peak
+    [EnterFn(n), ..rest] if n == name -> {
+      let new_running = running + 1
+      let new_peak = case new_running > peak {
+        True -> new_running
+        False -> peak
+      }
+      peak_loop(rest, name, new_running, new_peak)
+    }
+    [LeaveFn(n), ..rest] if n == name ->
+      peak_loop(rest, name, running - 1, peak)
+    [_, ..rest] -> peak_loop(rest, name, running, peak)
   }
 }
 

--- a/test/datastream/erlang/par_test.gleam
+++ b/test/datastream/erlang/par_test.gleam
@@ -323,3 +323,91 @@ pub fn merge_with_handles_infinite_streams_test() {
   |> list.length
   |> should.equal(5)
 }
+
+@target(erlang)
+pub fn map_unordered_with_bounds_in_flight_test() {
+  // Each worker enters f, sleeps to overlap with peers, leaves f.
+  // The peak observed concurrent in-flight count must not exceed
+  // max_workers (which equals in_flight bound for map_unordered).
+  let log = event_log.new_log()
+  source.unfold(from: 1, with: fn(n) { datastream.Next(n, n + 1) })
+  |> par.map_unordered_with(
+    with: fn(x) {
+      event_log.record_enter(log, named: "f")
+      process.sleep(20)
+      event_log.record_leave(log, named: "f")
+      x
+    },
+    max_workers: 3,
+    max_buffer: 8,
+  )
+  |> stream.take(up_to: 15)
+  |> fold.to_list
+  |> list.length
+  |> should.equal(15)
+
+  process.sleep(100)
+  let events = event_log.drain(log, within: 100)
+  let peak = event_log.peak_concurrent(events, named: "f")
+  { peak <= 3 } |> should.be_true
+}
+
+@target(erlang)
+pub fn map_ordered_with_bounds_in_flight_test() {
+  let log = event_log.new_log()
+  source.unfold(from: 1, with: fn(n) { datastream.Next(n, n + 1) })
+  |> par.map_ordered_with(
+    with: fn(x) {
+      event_log.record_enter(log, named: "f")
+      process.sleep(20)
+      event_log.record_leave(log, named: "f")
+      x
+    },
+    max_workers: 4,
+    max_buffer: 4,
+  )
+  |> stream.take(up_to: 20)
+  |> fold.to_list
+  |> list.length
+  |> should.equal(20)
+
+  process.sleep(100)
+  let events = event_log.drain(log, within: 100)
+  let peak = event_log.peak_concurrent(events, named: "f")
+  { peak <= 4 } |> should.be_true
+}
+
+@target(erlang)
+pub fn merge_with_bounds_in_flight_test() {
+  // Five infinite streams; max_buffer = 2 should keep at most two
+  // workers actively pulling (i.e. inside f) at any one time.
+  let log = event_log.new_log()
+  let make_stream = fn() {
+    source.unfold(from: 1, with: fn(n) { datastream.Next(n, n + 1) })
+    |> stream.map(with: fn(x) {
+      event_log.record_enter(log, named: "pump")
+      process.sleep(10)
+      event_log.record_leave(log, named: "pump")
+      x
+    })
+  }
+  par.merge_with(
+    streams: [
+      make_stream(),
+      make_stream(),
+      make_stream(),
+      make_stream(),
+      make_stream(),
+    ],
+    max_buffer: 2,
+  )
+  |> stream.take(up_to: 20)
+  |> fold.to_list
+  |> list.length
+  |> should.equal(20)
+
+  process.sleep(150)
+  let events = event_log.drain(log, within: 150)
+  let peak = event_log.peak_concurrent(events, named: "pump")
+  { peak <= 2 } |> should.be_true
+}

--- a/test/datastream/erlang/par_test.gleam
+++ b/test/datastream/erlang/par_test.gleam
@@ -1,6 +1,9 @@
 //// BEAM-only tests for `datastream/erlang/par`.
 
 @target(erlang)
+import datastream
+
+@target(erlang)
 import datastream/erlang/internal/event_log
 
 @target(erlang)
@@ -36,7 +39,7 @@ pub const beam_only_marker: String = "datastream/erlang/par_test is BEAM-only"
 @target(erlang)
 pub fn map_ordered_preserves_input_order_test() {
   source.from_list([1, 2, 3, 4])
-  |> par.map_ordered(with: fn(x) { x * 2 }, max_workers: 2, max_buffer: 4)
+  |> par.map_ordered_with(with: fn(x) { x * 2 }, max_workers: 2, max_buffer: 4)
   |> fold.to_list
   |> should.equal([2, 4, 6, 8])
 }
@@ -44,7 +47,7 @@ pub fn map_ordered_preserves_input_order_test() {
 @target(erlang)
 pub fn map_ordered_on_empty_yields_empty_test() {
   source.from_list([])
-  |> par.map_ordered(with: fn(x) { x * 2 }, max_workers: 2, max_buffer: 4)
+  |> par.map_ordered_with(with: fn(x) { x * 2 }, max_workers: 2, max_buffer: 4)
   |> fold.to_list
   |> should.equal([])
 }
@@ -54,7 +57,11 @@ pub fn map_ordered_on_empty_yields_empty_test() {
 @target(erlang)
 pub fn map_unordered_yields_set_equal_to_inputs_test() {
   source.from_list([1, 2, 3, 4])
-  |> par.map_unordered(with: fn(x) { x * 2 }, max_workers: 2, max_buffer: 4)
+  |> par.map_unordered_with(
+    with: fn(x) { x * 2 },
+    max_workers: 2,
+    max_buffer: 4,
+  )
   |> fold.to_list
   |> list.sort(by: int_compare)
   |> should.equal([2, 4, 6, 8])
@@ -74,14 +81,14 @@ fn int_compare(a: Int, b: Int) -> order.Order {
 @target(erlang)
 pub fn each_ordered_returns_nil_test() {
   source.from_list([1, 2, 3])
-  |> par.each_ordered(with: fn(_) { Nil }, max_workers: 2, max_buffer: 4)
+  |> par.each_ordered_with(with: fn(_) { Nil }, max_workers: 2, max_buffer: 4)
   |> should.equal(Nil)
 }
 
 @target(erlang)
 pub fn each_unordered_returns_nil_test() {
   source.from_list([1, 2, 3])
-  |> par.each_unordered(with: fn(_) { Nil }, max_workers: 2, max_buffer: 4)
+  |> par.each_unordered_with(with: fn(_) { Nil }, max_workers: 2, max_buffer: 4)
   |> should.equal(Nil)
 }
 
@@ -89,7 +96,7 @@ pub fn each_unordered_returns_nil_test() {
 
 @target(erlang)
 pub fn merge_interleaves_two_sources_test() {
-  par.merge(
+  par.merge_with(
     streams: [source.from_list([1, 2]), source.from_list([3, 4])],
     max_buffer: 4,
   )
@@ -100,7 +107,7 @@ pub fn merge_interleaves_two_sources_test() {
 
 @target(erlang)
 pub fn merge_empty_list_yields_empty_stream_test() {
-  par.merge(streams: [], max_buffer: 4)
+  par.merge_with(streams: [], max_buffer: 4)
   |> fold.to_list
   |> should.equal([])
 }
@@ -158,7 +165,7 @@ pub fn merge_take_early_exit_closes_upstreams_test() {
   let b = event_log.counted_resource([4, 5, 6], named: "b", log: log)
 
   let _result =
-    par.merge(streams: [a, b], max_buffer: 4)
+    par.merge_with(streams: [a, b], max_buffer: 4)
     |> stream.take(up_to: 1)
     |> fold.to_list
 
@@ -175,7 +182,7 @@ pub fn map_unordered_take_early_exit_closes_upstream_test() {
 
   let _result =
     upstream
-    |> par.map_unordered(with: fn(x) { x }, max_workers: 2, max_buffer: 4)
+    |> par.map_unordered_with(with: fn(x) { x }, max_workers: 2, max_buffer: 4)
     |> stream.take(up_to: 1)
     |> fold.to_list
 
@@ -192,7 +199,7 @@ pub fn map_ordered_take_early_exit_closes_upstream_test() {
 
   let _result =
     upstream
-    |> par.map_ordered(with: fn(x) { x }, max_workers: 2, max_buffer: 4)
+    |> par.map_ordered_with(with: fn(x) { x }, max_workers: 2, max_buffer: 4)
     |> stream.take(up_to: 1)
     |> fold.to_list
 
@@ -219,4 +226,100 @@ pub fn race_winner_take_full_consumption_closes_winner_test() {
   let opens = event_log.count_opens(events)
   let closes = event_log.count_closes(events)
   opens |> should.equal(closes)
+}
+
+// --- defaults / simple variants ------------------------------------------
+
+@target(erlang)
+pub fn map_unordered_default_runs_test() {
+  source.from_list([1, 2, 3, 4])
+  |> par.map_unordered(with: fn(x) { x * 10 })
+  |> fold.to_list
+  |> list.sort(by: int_compare)
+  |> should.equal([10, 20, 30, 40])
+}
+
+@target(erlang)
+pub fn map_ordered_default_runs_test() {
+  source.from_list([1, 2, 3, 4])
+  |> par.map_ordered(with: fn(x) { x * 10 })
+  |> fold.to_list
+  |> should.equal([10, 20, 30, 40])
+}
+
+@target(erlang)
+pub fn each_unordered_default_returns_nil_test() {
+  source.from_list([1, 2, 3])
+  |> par.each_unordered(with: fn(_) { Nil })
+  |> should.equal(Nil)
+}
+
+@target(erlang)
+pub fn each_ordered_default_returns_nil_test() {
+  source.from_list([1, 2, 3])
+  |> par.each_ordered(with: fn(_) { Nil })
+  |> should.equal(Nil)
+}
+
+@target(erlang)
+pub fn merge_default_runs_test() {
+  par.merge(streams: [source.from_list([1, 2]), source.from_list([3, 4])])
+  |> fold.to_list
+  |> list.sort(by: int_compare)
+  |> should.equal([1, 2, 3, 4])
+}
+
+// --- back-pressure -------------------------------------------------------
+
+@target(erlang)
+pub fn map_unordered_with_handles_infinite_upstream_test() {
+  // Without back-pressure the worker pool would spin forever pulling
+  // from the infinite source. With max_workers / max_buffer set, take
+  // halts the pipeline cleanly after 10 elements.
+  source.unfold(from: 1, with: fn(n) { datastream.Next(n, n + 1) })
+  |> par.map_unordered_with(with: fn(x) { x }, max_workers: 2, max_buffer: 4)
+  |> stream.take(up_to: 10)
+  |> fold.to_list
+  |> list.length
+  |> should.equal(10)
+}
+
+@target(erlang)
+pub fn map_ordered_with_handles_infinite_upstream_test() {
+  source.unfold(from: 1, with: fn(n) { datastream.Next(n, n + 1) })
+  |> par.map_ordered_with(with: fn(x) { x }, max_workers: 2, max_buffer: 4)
+  |> stream.take(up_to: 10)
+  |> fold.to_list
+  |> should.equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+}
+
+@target(erlang)
+pub fn merge_with_n_streams_greater_than_max_buffer_test() {
+  // 5 streams, max_buffer = 2: only 2 workers can be in-flight at any
+  // moment. All 15 elements must still be emitted.
+  let make_stream = fn() { source.from_list([1, 2, 3]) }
+  par.merge_with(
+    streams: [
+      make_stream(),
+      make_stream(),
+      make_stream(),
+      make_stream(),
+      make_stream(),
+    ],
+    max_buffer: 2,
+  )
+  |> fold.to_list
+  |> list.length
+  |> should.equal(15)
+}
+
+@target(erlang)
+pub fn merge_with_handles_infinite_streams_test() {
+  let infinite =
+    source.unfold(from: 1, with: fn(n) { datastream.Next(n, n + 1) })
+  par.merge_with(streams: [infinite], max_buffer: 2)
+  |> stream.take(up_to: 5)
+  |> fold.to_list
+  |> list.length
+  |> should.equal(5)
 }


### PR DESCRIPTION
## Summary

Fixes #46. `max_buffer` was an ignored argument on `merge`, `map_unordered`, `map_ordered`, `each_unordered`, `each_ordered` — validated at construction and then never enforced. This PR makes it a real bound: at any moment the number of elements pulled from the upstream(s) but not yet emitted to the downstream is `<= max_buffer`. Workers in flight (mid-`f(x)`) count toward the ceiling.

The user-facing API is also reshaped into a 2-tier surface so that the common case is one-line:

```gleam
par.merge([s1, s2])                       // uses defaults
par.merge_with(streams: [s1, s2], max_buffer: 32)  // tunable
```

## Changes

### Public API
- New constants: `default_max_workers = 4`, `default_max_buffer = 16`.
- New no-argument variants (use defaults): `merge`, `map_unordered`, `map_ordered`, `each_unordered`, `each_ordered`.
- The previous variants are renamed to `_with`: `merge_with`, `map_unordered_with`, `map_ordered_with`, `each_unordered_with`, `each_ordered_with`.
- `max_buffer >= max_workers` is now centrally enforced in `validate_par_args`; the per-function checks are gone.

### Back-pressure implementation
- `map_ordered_with`: state carries an explicit `in_flight = workers_busy + dict.size(pending)`. `dispatch_ordered` is paused once `in_flight >= max_buffer`. `in_flight` is decremented only when an element is emitted downstream.
- `map_unordered_with`: dispatch ceiling is now `min(max_workers, max_buffer)`. Because results are emitted on receive, `in_flight == workers_busy`, so `max_buffer` is redundant with `max_workers` (kept for API symmetry; documented).
- `merge_with`: rewritten to ack-gated workers. Each worker owns a signal subject (handed back via handshake), waits for `Continue` before pulling, and waits again after sending. The coordinator sends `Continue` to the next waiting worker (round-robin) every time it emits an element. At startup only `min(max_buffer, len(streams))` workers receive `Continue`; the rest wait. This guarantees the in-flight bound even when `len(streams) > max_buffer`.

### Worker-leak guard
`merge` workers wait on their signal subject with a 5000ms timeout and check `process.is_alive(coordinator_pid)` between waits. If the coordinator died, the worker closes the upstream and exits.

### Doc
Module-level doc comment now lists the knobs, the per-combinator behaviour table for what happens when `max_buffer` is reached, the defaults' rationale, and tuning guidance for IO-bound vs CPU-bound vs rate-limited workloads.

### Tests
- Existing tests migrated to `_with` variants.
- New smoke tests for the no-argument variants.
- Back-pressure tests:
  - `map_unordered_with` and `map_ordered_with` against an infinite upstream + `take(10)` (would hang or OOM if back-pressure were broken).
  - `merge_with` with `len(streams) > max_buffer` (5 streams, `max_buffer: 2`) — proves the round-robin ack-gating works.
  - `merge_with` with an infinite stream + `take(5)` (proves early-exit + back-pressure compose).

## Design Decisions

- **2-tier API over a single config record.** A `Concurrency` record was considered but rejected: `merge` legitimately has no `max_workers`, so the record would invite confusion (\"why is this field ignored?\"). Two-tier keeps each signature truthful at the cost of a few extra symbols.
- **`max_buffer >= max_workers` requirement, not `> 0`.** The previous per-function checks left `merge`/`map_unordered` with the looser bound. A single rule is easier to remember and removes accidental misconfigurations like `max_buffer: 0` against `max_workers: 4`.
- **`map_unordered`'s `max_buffer` kept despite being redundant with `max_workers`.** Removing it would break API symmetry with `map_ordered_with` and complicate teaching. The doc comment is explicit about the redundancy.
- **`merge` ack-gated startup, round-robin Continue.** Without ack-gating at startup, all N workers would pull simultaneously and the coordinator's mailbox would silently buffer everything (the bound would only kick in once mailbox depth caught up, which is not the same property). Round-robin (the worker that just emitted joins the back of the queue) gives fair scheduling and avoids starvation when `len(streams) > max_buffer`.
- **Worker leak guard via timeout + `is_alive`** instead of `process.spawn_link` + `trap_exit`. The link approach is more BEAM-idiomatic but pulls trap_exit semantics into every caller; the timeout approach is local to merge and bounded by the 5s polling window.

## Limitations

- `f(x)` panicking inside a `map_*` worker still hangs the pipeline (worker dies, result never arrives, coordinator blocks on `receive_forever`). This is pre-existing across all `par.*`; documented in the module doc.
- `max_buffer` does not bound the *side-effect* count of `f`. Workers run up to `max_workers` in parallel regardless of buffer pressure; only new dispatch is throttled. Documented.

## Breaking Change

The previous signatures with required `max_workers:` / `max_buffer:` arguments are now `_with`. Any caller passing those labels needs to add `_with` to the function name. The library is pre-release with no external users; the existing call sites in tests have been updated.

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed default concurrency constants for parallel stream operations
  * Introduced configurable function variants for `map`, `each`, and `merge` operations with explicit max workers and buffer parameters
  * Improved backpressure handling with stricter validation of buffering constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->