### PR TITLE
docs(datastream): remove dead reference to non-existent doc/reference/spec.md

### DIFF
--- a/src/datastream.gleam
+++ b/src/datastream.gleam
@@ -8,8 +8,6 @@
 //// This module defines the foundational types every later module builds
 //// on: the opaque pipeline value `Stream(a)` and the pull-result enum
 //// `Step(a, state)`.
-////
-//// See `doc/reference/spec.md` for the full specification.
 
 /// A lazy, pull-based pipeline that yields elements of type `a`.
 ///


### PR DESCRIPTION
## Summary

Fixes #55. The root module doc comment ended with \`See \`doc/reference/spec.md\` for the full specification.\`, but no such file exists. HexDocs renders that link, sending readers to nothing.

## Changes

- \`src/datastream.gleam\`: drop the trailing \`See doc/reference/spec.md ...\` line from the module doc comment.

## Design Decisions

The earliest user feedback in the project review was that \`spec.md\` is intentionally not coming back. Removal is preferred over writing a stub.

Closes #55