### PR TITLE
docs(par): explain why map_unordered_with enforces max_buffer >= max_workers

### DIFF
--- a/src/datastream/erlang/par.gleam
+++ b/src/datastream/erlang/par.gleam
@@ -150,10 +150,14 @@ pub fn map_unordered(over stream: Stream(a), with f: fn(a) -> b) -> Stream(b) {
 /// Results are emitted in the order they finish, NOT input order.
 ///
 /// `max_workers >= 1` and `max_buffer >= max_workers` are required;
-/// violations `panic` at construction. Because `map_unordered` emits
-/// each result the moment it arrives, `in_flight = workers_busy`, and
-/// `max_buffer` only adds a ceiling redundant with `max_workers`. The
-/// argument is kept for symmetry with `map_ordered` and `merge`.
+/// violations `panic` at construction. The `max_buffer >= max_workers`
+/// rule is enforced uniformly across `par.*` so callers can swap
+/// between `map_unordered_with`, `map_ordered_with`, and `merge_with`
+/// without re-tuning. Note however that `map_unordered` emits each
+/// result the moment it arrives, so `in_flight = workers_busy` and
+/// `max_buffer` adds no extra ceiling beyond `max_workers` here. See
+/// `default_max_workers` and `default_max_buffer` for sensible
+/// starting values.
 pub fn map_unordered_with(
   over stream: Stream(a),
   with f: fn(a) -> b,


### PR DESCRIPTION
## Summary

Fixes #66. The \`map_unordered_with\` doc comment said "max_buffer only adds a ceiling redundant with max_workers; the argument is kept for symmetry" — but \`validate_par_args\` still panics on \`max_buffer < max_workers\`, so a caller who reads the doc as "this argument doesn't really do anything for unordered" gets a hard panic.

## Changes

- \`src/datastream/erlang/par.gleam\`: rewrite the doc to make the validation rule the headline (\`max_buffer >= max_workers\` is enforced uniformly so callers can swap between \`map_unordered_with\` / \`map_ordered_with\` / \`merge_with\` without re-tuning) and keep the existing note about the ceiling being redundant for this specific combinator.

## Design Decisions

Two fixes were on the table: (a) drop the \`max_buffer >= max_workers\` check for \`map_unordered_with\`, (b) document that the rule applies uniformly. Picked (b) because the uniform rule is what makes the three \`_with\` functions interchangeable from a caller's tuning perspective; relaxing only one of them would create a footgun when callers refactor between them.

Closes #66