### PR TITLE
refactor(stream): drop redundant identity wrapper from drop_while and append

### DIFF
--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -159,22 +159,10 @@ fn drop_while_pull(
     Next(element, rest) ->
       case predicate(element) {
         True -> drop_while_pull(rest, predicate)
-        False -> Next(element, identity(rest))
+        False -> Next(element, rest)
       }
     Done -> Done
   }
-}
-
-fn identity(stream: Stream(a)) -> Stream(a) {
-  datastream.make(
-    pull: fn() {
-      case datastream.pull(stream) {
-        Next(element, rest) -> Next(element, identity(rest))
-        Done -> Done
-      }
-    },
-    close: fn() { datastream.close(stream) },
-  )
 }
 
 /// Yield all of `first`, then all of `second`. If `first` is infinite,
@@ -198,7 +186,7 @@ fn append_pull(first: Stream(a), second: Stream(a)) -> Step(a, Stream(a)) {
 
 fn append_pull_second(stream: Stream(a)) -> Step(a, Stream(a)) {
   case datastream.pull(stream) {
-    Next(element, rest) -> Next(element, identity(rest))
+    Next(element, rest) -> Next(element, rest)
     Done -> Done
   }
 }


### PR DESCRIPTION
## Summary

Fixes #69. \`stream.identity\` was a private 11-line helper that wrapped a stream in a fresh \`datastream.make\` whose \`pull\` and \`close\` simply forwarded to the underlying stream. The two callers (\`drop_while_pull\` and \`append_pull_second\`) only ever applied it to a \`rest\` returned from \`datastream.pull\` — and that \`rest\` is already a well-formed \`Stream(a)\` with \`pull\` and \`close\` that honour the contract.

The wrap added a closure allocation per pull with no behaviour change.

## Changes

- \`src/datastream/stream.gleam\`: replace \`Next(element, identity(rest))\` with \`Next(element, rest)\` at both call sites; delete \`identity/1\`.

305 erlang + 235 javascript tests still pass.

Closes #69