### PR TITLE
docs(erlang): document from_subject incompatibility on par.* / time.* / timeout

### DIFF
--- a/src/datastream/erlang/par.gleam
+++ b/src/datastream/erlang/par.gleam
@@ -52,6 +52,16 @@
 ////   still alive, so the liveness probe says "keep going". Always
 ////   drive the stream to a terminal or call `close` explicitly.
 //// - Unbounded concurrency is intentionally not offered.
+////
+//// ## Limitation: incompatible with `from_subject`
+////
+//// Every combinator in this module pulls from its upstream inside a
+//// spawned worker process. Streams built from
+//// `datastream/erlang/source.from_subject` cannot survive that, since
+//// an Erlang `Subject` can only be received by its owning process —
+//// the worker would `panic` on the first pull. Wrap subject streams
+//// outside the parallel layer (e.g. materialise to a list first) or
+//// route them through a non-`par.*` pipeline.
 
 @target(erlang)
 const merge_worker_liveness_check_ms: Int = 5000

--- a/src/datastream/erlang/source.gleam
+++ b/src/datastream/erlang/source.gleam
@@ -36,6 +36,12 @@ import gleam/erlang/process.{type Subject}
 /// The `Subject`'s lifecycle is owned by the caller: this stream
 /// only reads, it never closes the subject. The terminal completing
 /// is sufficient to release the stream's hold.
+///
+/// **Limitation:** the resulting stream cannot be passed to any
+/// combinator in `datastream/erlang/par` or `datastream/erlang/time`,
+/// nor to `datastream/erlang/source.timeout` — those run the pull in
+/// a worker process and the `Subject`'s owner-only receive
+/// constraint causes a `panic`.
 pub fn from_subject(
   from subject: Subject(a),
   while keep_running: fn() -> Bool,

--- a/src/datastream/erlang/time.gleam
+++ b/src/datastream/erlang/time.gleam
@@ -9,6 +9,15 @@
 //// process drives the consuming `Stream` and uses
 //// `process.receive(within: ms)` to wait simultaneously for the next
 //// element and for a timer deadline.
+////
+//// ## Limitation: incompatible with `from_subject`
+////
+//// Because every combinator pulls inside a spawned worker process,
+//// streams built from `datastream/erlang/source.from_subject` cannot
+//// be passed through this layer — an Erlang `Subject` can only be
+//// received by its owning process and the worker would `panic` on
+//// the first pull. The same constraint applies to
+//// `datastream/erlang/par`.
 
 @target(javascript)
 /// Sentinel value documenting that this module is BEAM-only.


### PR DESCRIPTION
## Summary

Fixes #54. Streams built from \`datastream/erlang/source.from_subject\` cannot be passed to any combinator that runs the pull inside a worker process — an Erlang \`Subject\` can only be received by its owning process, so the worker would \`panic\` on the first pull. Only the \`source.timeout\` doc warned about this; \`par.*\` and \`time.*\` were silent.

## Changes

- \`src/datastream/erlang/par.gleam\`: add a "Limitation: incompatible with from_subject" section to the module doc.
- \`src/datastream/erlang/time.gleam\`: same, mirroring the wording so the constraint is discoverable from either module.
- \`src/datastream/erlang/source.gleam\`: extend the \`from_subject\` doc to call out which combinators reject it (the par layer, the time layer, and \`source.timeout\`).

No code changes — the runtime behaviour is unchanged; the error mode just becomes discoverable from the docs.

Closes #54