### PR TITLE
ci(release): drop 'I am not using semantic versioning' echo from publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         run: gleam build
 
       - name: Publish to Hex
-        run: echo 'I am not using semantic versioning' | gleam publish -y
+        run: gleam publish -y
         env:
           HEXPM_API_KEY: ${{ secrets.HEXPM_API_KEY }}
 


### PR DESCRIPTION
## Summary

Fixes #53. \`CHANGELOG.md\` declares "this project adheres to Semantic Versioning", but \`.github/workflows/release.yml\` piped the literal string \`I am not using semantic versioning\` into \`gleam publish -y\` — the prompt confirmation Gleam asks for non-SemVer packages. The two stated contracts contradicted each other.

This commit makes the workflow honour SemVer (the documented policy). \`gleam publish -y\` is sufficient for SemVer-conformant versions.

## Changes

- \`.github/workflows/release.yml\`: replace the echo-piped publish line with a plain \`gleam publish -y\`.

Closes #53