### PR TITLE
refactor(text,binary): extract maybe_close helper to dedupe close handler

### DIFF
--- a/src/datastream/binary.gleam
+++ b/src/datastream/binary.gleam
@@ -22,6 +22,13 @@ pub fn bytes(over stream: Stream(BitArray)) -> Stream(Int) {
   bytes_active(stream, <<>>, False)
 }
 
+fn maybe_close(source: Stream(a), source_drained: Bool) -> Nil {
+  case source_drained {
+    True -> Nil
+    False -> datastream.close(source)
+  }
+}
+
 fn bytes_active(
   source: Stream(BitArray),
   buffer: BitArray,
@@ -29,12 +36,7 @@ fn bytes_active(
 ) -> Stream(Int) {
   datastream.make(
     pull: fn() { bytes_pull(source, buffer, source_drained) },
-    close: fn() {
-      case source_drained {
-        True -> Nil
-        False -> datastream.close(source)
-      }
-    },
+    close: fn() { maybe_close(source, source_drained) },
   )
 }
 
@@ -90,12 +92,7 @@ fn length_prefixed_active(
     pull: fn() {
       length_prefixed_pull(source, buffer, prefix_size, source_drained)
     },
-    close: fn() {
-      case source_drained {
-        True -> Nil
-        False -> datastream.close(source)
-      }
-    },
+    close: fn() { maybe_close(source, source_drained) },
   )
 }
 
@@ -184,12 +181,7 @@ fn delimited_active(
     pull: fn() {
       delimited_pull(source, buffer, delimiter, source_drained, has_seen_input)
     },
-    close: fn() {
-      case source_drained {
-        True -> Nil
-        False -> datastream.close(source)
-      }
-    },
+    close: fn() { maybe_close(source, source_drained) },
   )
 }
 
@@ -294,12 +286,7 @@ fn fixed_size_active(
 ) -> Stream(BitArray) {
   datastream.make(
     pull: fn() { fixed_size_pull(source, buffer, size, source_drained) },
-    close: fn() {
-      case source_drained {
-        True -> Nil
-        False -> datastream.close(source)
-      }
-    },
+    close: fn() { maybe_close(source, source_drained) },
   )
 }
 

--- a/src/datastream/text.gleam
+++ b/src/datastream/text.gleam
@@ -31,6 +31,13 @@ pub fn lines(over stream: Stream(String)) -> Stream(String) {
   lines_active(stream, "", False)
 }
 
+fn maybe_close(source: Stream(a), source_drained: Bool) -> Nil {
+  case source_drained {
+    True -> Nil
+    False -> datastream.close(source)
+  }
+}
+
 fn lines_active(
   source: Stream(String),
   buffer: String,
@@ -38,12 +45,7 @@ fn lines_active(
 ) -> Stream(String) {
   datastream.make(
     pull: fn() { lines_pull(source, buffer, source_drained) },
-    close: fn() {
-      case source_drained {
-        True -> Nil
-        False -> datastream.close(source)
-      }
-    },
+    close: fn() { maybe_close(source, source_drained) },
   )
 }
 
@@ -171,12 +173,7 @@ fn graphemes_active(
 ) -> Stream(String) {
   datastream.make(
     pull: fn() { graphemes_pull(source, pending, source_drained) },
-    close: fn() {
-      case source_drained {
-        True -> Nil
-        False -> datastream.close(source)
-      }
-    },
+    close: fn() { maybe_close(source, source_drained) },
   )
 }
 
@@ -225,12 +222,7 @@ fn utf8_decode_active(
 ) -> Stream(Result(String, Nil)) {
   datastream.make(
     pull: fn() { utf8_decode_pull(source, buffer, source_drained) },
-    close: fn() {
-      case source_drained {
-        True -> Nil
-        False -> datastream.close(source)
-      }
-    },
+    close: fn() { maybe_close(source, source_drained) },
   )
 }
 


### PR DESCRIPTION
## Summary

Fixes #71. Seven combinators across \`text.gleam\` (3) and \`binary.gleam\` (4) repeated the same 6-line close callback:

\`\`\`gleam
case source_drained {
  True -> Nil
  False -> datastream.close(source)
}
\`\`\`

The \`source_drained\` flag was threaded through every helper specifically to feed that single check. \`time.gleam\` already solves the same problem with \`maybe_stop\`.

## Changes

- \`src/datastream/text.gleam\`: add private \`maybe_close(source, source_drained)\`; replace 3 inline \`case\` blocks with single calls.
- \`src/datastream/binary.gleam\`: same, for 4 inline blocks (\`bytes_active\`, \`length_prefixed_active\`, \`delimited_active\`, \`fixed_size_active\`).

The pull-side \`case source_drained { True -> Done; False -> ... pull ... }\` blocks are intentionally left in place — those are control flow, not close handling.

Net diff: -21 lines (-42 / +21).

Closes #71