### PR TITLE
test(resource): cover fold.find / any / all / collect_result close contract

### DIFF
--- a/test/datastream/resource_test.gleam
+++ b/test/datastream/resource_test.gleam
@@ -502,3 +502,51 @@ pub fn resource_zip_closes_right_then_left_test() {
   events("c12_log_zip")
   |> should.equal(["open:left", "open:right", "close:left", "close:right"])
 }
+
+@target(erlang)
+pub fn resource_fold_find_closes_once_on_match_test() {
+  reset("c12_open_find")
+  reset("c12_close_find")
+  counted_resource([1, 2, 3, 4], "c12_open_find", "c12_close_find")
+  |> fold.find(satisfying: fn(x) { x == 2 })
+  |> should.equal(option.Some(2))
+  get_dict("c12_open_find") |> should.equal(1)
+  get_dict("c12_close_find") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn resource_fold_any_closes_once_on_first_true_test() {
+  reset("c12_open_any")
+  reset("c12_close_any")
+  counted_resource([1, 2, 3, 4], "c12_open_any", "c12_close_any")
+  |> fold.any(satisfying: fn(x) { x >= 2 })
+  |> should.equal(True)
+  get_dict("c12_open_any") |> should.equal(1)
+  get_dict("c12_close_any") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn resource_fold_all_closes_once_on_first_false_test() {
+  reset("c12_open_all")
+  reset("c12_close_all")
+  counted_resource([1, 2, 3, 4], "c12_open_all", "c12_close_all")
+  |> fold.all(satisfying: fn(x) { x < 2 })
+  |> should.equal(False)
+  get_dict("c12_open_all") |> should.equal(1)
+  get_dict("c12_close_all") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn resource_fold_collect_result_closes_once_on_first_error_test() {
+  reset("c12_open_cr")
+  reset("c12_close_cr")
+  counted_resource(
+    [Ok(1), Ok(2), Error("bad"), Ok(3)],
+    "c12_open_cr",
+    "c12_close_cr",
+  )
+  |> fold.collect_result
+  |> should.equal(Error("bad"))
+  get_dict("c12_open_cr") |> should.equal(1)
+  get_dict("c12_close_cr") |> should.equal(1)
+}


### PR DESCRIPTION
## Summary

Fixes #60. The resource close-contract suite covered \`fold.to_list\`, \`fold.first\`, \`stream.take\`, \`stream.append\`, \`stream.zip\`, \`stream.flat_map\`, and \`sink.try_each\`, but not the four short-circuiting fold terminals — \`fold.find\`, \`fold.any\`, \`fold.all\`, \`fold.collect_result\` — even though each one explicitly calls \`datastream.close(rest)\` on its early-exit path. A regression dropping any of those calls would not have been caught.

## Changes

- \`test/datastream/resource_test.gleam\`: add four Erlang-only counted-resource tests, each asserting \`opens == closes == 1\`:
  - \`resource_fold_find_closes_once_on_match_test\` — find on \`x == 2\` against \`[1,2,3,4]\`
  - \`resource_fold_any_closes_once_on_first_true_test\` — any on \`x >= 2\` against \`[1,2,3,4]\`
  - \`resource_fold_all_closes_once_on_first_false_test\` — all on \`x < 2\` against \`[1,2,3,4]\`
  - \`resource_fold_collect_result_closes_once_on_first_error_test\` — collect_result against \`[Ok(1), Ok(2), Error("bad"), Ok(3)]\`

Total Erlang test count: 305 → 309.

Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added four new tests verifying proper resource cleanup when fold operations (find, any, all, collect_result) terminate early. Each test confirms resources are correctly opened and closed exactly once when reaching their terminal conditions (matching element, first true/false value, or first error).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->