### PR TITLE
test(binary): cover length_prefixed prefix sizes 2/8 and chunk-boundary prefix

### DIFF
--- a/test/datastream/binary_test.gleam
+++ b/test/datastream/binary_test.gleam
@@ -1,6 +1,7 @@
 import datastream.{Done, Next}
 import datastream/binary
 import datastream/fold
+import gleam/list
 import gleeunit
 import gleeunit/should
 
@@ -90,6 +91,41 @@ pub fn length_prefixed_four_byte_big_endian_prefix_test() {
   |> binary.length_prefixed(prefix_size: 4)
   |> fold.to_list
   |> should.equal([<<99>>])
+}
+
+pub fn length_prefixed_two_byte_prefix_decodes_big_endian_test() {
+  // Length 257 = 0x0101 = <<1, 1>>; payload is 257 bytes.
+  let payload = list.repeat(7, 257)
+  let payload_bits = list.fold(payload, <<>>, fn(acc, b) { <<acc:bits, b>> })
+  from_list([<<<<1, 1>>:bits, payload_bits:bits>>])
+  |> binary.length_prefixed(prefix_size: 2)
+  |> fold.to_list
+  |> should.equal([payload_bits])
+}
+
+pub fn length_prefixed_eight_byte_prefix_small_frame_test() {
+  from_list([<<0, 0, 0, 0, 0, 0, 0, 2, 65, 66>>])
+  |> binary.length_prefixed(prefix_size: 8)
+  |> fold.to_list
+  |> should.equal([<<65, 66>>])
+}
+
+pub fn length_prefixed_prefix_split_across_chunks_test() {
+  // prefix_size = 4, prefix bytes <<0, 0, 0, 1>> spans chunks
+  // [<<0, 0>>, <<0, 1, 99>>]; payload is the trailing 0x63.
+  from_list([<<0, 0>>, <<0, 1, 99>>])
+  |> binary.length_prefixed(prefix_size: 4)
+  |> fold.to_list
+  |> should.equal([<<99>>])
+}
+
+pub fn length_prefixed_multiple_frames_back_to_back_two_byte_prefix_test() {
+  // Three frames of length 1, 2, 3 each with a 2-byte big-endian
+  // prefix, all in a single chunk.
+  from_list([<<0, 1, 65, 0, 2, 66, 67, 0, 3, 68, 69, 70>>])
+  |> binary.length_prefixed(prefix_size: 2)
+  |> fold.to_list
+  |> should.equal([<<65>>, <<66, 67>>, <<68, 69, 70>>])
 }
 
 // --- delimited ----------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #61. \`binary.length_prefixed\` accepts prefix sizes \`{1, 2, 4, 8}\` but the suite previously only exercised:

- prefix_size 1 (multiple cases)
- prefix_size 2 (one incomplete-prefix case only)
- prefix_size 4 (one happy-path case)

prefix_size 8 was untested entirely, big-endian decoding beyond one byte was unverified, and the headline edge case — a prefix split across chunks — had no coverage.

## Changes

\`test/datastream/binary_test.gleam\`: add four tests.

- \`length_prefixed_two_byte_prefix_decodes_big_endian_test\` — proves big-endian decoding for length 257 (0x0101).
- \`length_prefixed_eight_byte_prefix_small_frame_test\` — exercises the prefix_size 8 path.
- \`length_prefixed_prefix_split_across_chunks_test\` — prefix_size 4 with chunks \`<<0,0>>\`, \`<<0,1,99>>\`. The chunk-aware combinator's reason for being.
- \`length_prefixed_multiple_frames_back_to_back_two_byte_prefix_test\` — three frames in a single chunk, prefix_size 2.

Also adds \`import gleam/list\` (used by the new tests for repeating bytes).

Net diff: +36 lines, +1 import. Test count: 313 (was 309).

Closes #61