### PR TITLE
docs(readme): add pre-1.0 stability notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ It is meant for pipelines that should stay lazy, repeatable, and explicit
 about effects. A `Stream(a)` is a pipeline definition, not a materialized
 collection, so each terminal operation runs the source again.
 
+## Status
+
+Pre-1.0. The public API may change between any 0.x release. Pin a
+specific version in your `gleam.toml` and review the [CHANGELOG](CHANGELOG.md)
+before upgrading.
+
 ## Install
 
 ```sh


### PR DESCRIPTION
## Summary

Fixes #64. The README directs users to \`gleam add datastream\` but doesn't mention pre-1.0 status. Adopters reading the front page can't tell that the API may break in any 0.x release.

## Changes

- \`README.md\`: add a "Status" section right after the lead paragraph explaining the pre-1.0 contract and pointing readers to \`CHANGELOG.md\` before upgrading.

Closes #64