### PR TITLE
docs: bundle of cosmetic fixes from project review (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ pub fn main() {
 - `datastream/text`: chunk-aware text helpers
 - `datastream/binary`: chunk-aware byte and framing helpers
 - `datastream/dataprep`: helpers for `Validated`
-- `datastream/erlang/source`: BEAM-only subject and timer sources
+- `datastream/erlang/source`: BEAM-only subject / timer sources and per-element `timeout`
 - `datastream/erlang/sink`: BEAM-only subject sink
-- `datastream/erlang/par`: BEAM-only bounded parallel combinators
+- `datastream/erlang/par`: BEAM-only bounded parallel combinators and `race`
 - `datastream/erlang/time`: BEAM-only time-based combinators
 
 ## Target support

--- a/src/datastream.gleam
+++ b/src/datastream.gleam
@@ -17,15 +17,15 @@
 /// want replay should materialise once with `fold.to_list`.
 ///
 /// The internal representation is intentionally hidden so the library is
-/// free to change it (list-backed, function-backed, chunk-batched, …)
+/// free to change it (list-backed, function-batched, chunk-batched, …)
 /// without a breaking change. `==` / `!=` carry no specified meaning;
 /// observational equality is via terminal reduction.
 ///
-/// Internally a `Stream(a)` carries both a `pull` function and a
-/// `close` function so the resource-safe sources from `source.resource`
-/// can be cleaned up on every termination path the library controls
-/// (normal end, downstream early-exit, early-exit folds, `try_each`
-/// failure). Pure `unfold`-built streams use a no-op `close`.
+/// The library threads a cleanup callback through every stream value so
+/// resource-safe sources from `source.resource` can be released on every
+/// termination path (normal end, downstream early-exit, early-exit
+/// folds, `try_each` failure). Pure (`unfold`-built) streams use a
+/// no-op cleanup.
 pub opaque type Stream(a) {
   Stream(pull: fn() -> Step(a, Stream(a)), close: fn() -> Nil)
 }

--- a/src/datastream/chunk.gleam
+++ b/src/datastream/chunk.gleam
@@ -47,7 +47,8 @@ pub fn to_list(chunk: Chunk(a)) -> List(a) {
   chunk.elements
 }
 
-/// Number of elements in `chunk`.
+/// Number of elements in `chunk`. O(n) in the current implementation
+/// (the chunk's element list is walked).
 pub fn size(chunk: Chunk(a)) -> Int {
   list.length(chunk.elements)
 }

--- a/src/datastream/erlang/par.gleam
+++ b/src/datastream/erlang/par.gleam
@@ -21,7 +21,7 @@
 ////
 //// | function | behaviour |
 //// |----------|-----------|
-//// | `map_unordered` | new dispatch is paused; in-flight workers finish |
+//// | `map_unordered` | bound collapses to `max_workers` (results emit on receive); new dispatch is paused |
 //// | `map_ordered`   | new dispatch is paused; pending dict + workers cap |
 //// | `merge`         | per-worker `Continue` ack is withheld; workers wait |
 ////
@@ -223,11 +223,11 @@ fn map_unordered_step(
 
 @target(erlang)
 fn dispatch_unordered(state: MapUnordered(a, b)) -> MapUnordered(a, b) {
-  case
-    state.source_drained
-    || state.workers_busy >= state.max_workers
-    || state.workers_busy >= state.max_buffer
-  {
+  // The `workers_busy >= max_buffer` check is implied by
+  // `workers_busy >= max_workers` together with the validated
+  // `max_buffer >= max_workers`, so it is intentionally not duplicated
+  // here.
+  case state.source_drained || state.workers_busy >= state.max_workers {
     True -> state
     False ->
       case datastream.pull(state.source) {


### PR DESCRIPTION
## Summary

Fixes #76. Bundles five small cosmetic doc / wording fixes flagged in the project review.

## Changes

- **\`chunk.size\` documents O(n) cost** — \`src/datastream/chunk.gleam\`. Hover-preview now states the cost so callers don't accidentally hit O(N²) by calling it in a hot loop.
- **\`par\` knob table fixes \`map_unordered\` row** — \`src/datastream/erlang/par.gleam\`. Changed from "new dispatch is paused; in-flight workers finish" to clarify that the bound collapses to \`max_workers\` for \`map_unordered\` (results emit on receive).
- **\`dispatch_unordered\` redundant condition removed** — \`src/datastream/erlang/par.gleam\`. The \`workers_busy >= max_buffer\` check is implied by \`workers_busy >= max_workers\` plus the validated \`max_buffer >= max_workers\`. Replaced with a comment explaining why the second check is intentionally absent.
- **README module guide adds \`erlang/source.timeout\` and \`erlang/par.race\`** — \`README.md\`. Bullet entries previously omitted these public functions; users searching the guide could not find them.
- **\`datastream.Stream\` opaque type doc no longer leaks the internal record** — \`src/datastream.gleam\`. Replaced the paragraph that fully spelled out the \`Stream(pull, close)\` shape with an abstract description of the cleanup-callback threading. The \`pub opaque\` line still tells the compiler the truth; only the published HexDocs prose changes.

The \`time.throttle\` / \`rate_limit\` \`upstream_done\` consistency item from the original bundle is intentionally not addressed: \`Done\` is returned at the same point either way, and the \`close\` callback contract guarantees no spurious \`stop\` signal will reach the worker post-\`Done\`.

Closes #76