### PR TITLE
perf(binary): resume delimited scan from previous tail to drop O(N^2) re-scan

### DIFF
--- a/src/datastream/binary.gleam
+++ b/src/datastream/binary.gleam
@@ -167,7 +167,7 @@ pub fn delimited(
   over stream: Stream(BitArray),
   on delimiter: BitArray,
 ) -> Stream(BitArray) {
-  delimited_active(stream, <<>>, delimiter, False, False)
+  delimited_active(stream, <<>>, delimiter, False, False, 0)
 }
 
 fn delimited_active(
@@ -176,10 +176,18 @@ fn delimited_active(
   delimiter: BitArray,
   source_drained: Bool,
   has_seen_input: Bool,
+  scan_from: Int,
 ) -> Stream(BitArray) {
   datastream.make(
     pull: fn() {
-      delimited_pull(source, buffer, delimiter, source_drained, has_seen_input)
+      delimited_pull(
+        source,
+        buffer,
+        delimiter,
+        source_drained,
+        has_seen_input,
+        scan_from,
+      )
     },
     close: fn() { maybe_close(source, source_drained) },
   )
@@ -191,8 +199,9 @@ fn delimited_pull(
   delimiter: BitArray,
   source_drained: Bool,
   has_seen_input: Bool,
+  scan_from: Int,
 ) -> Step(BitArray, Stream(BitArray)) {
-  case find_delimiter(buffer, delimiter, 0) {
+  case find_delimiter(buffer, delimiter, scan_from) {
     Ok(pos) -> {
       let delim_size = bit_array.byte_size(delimiter)
       case
@@ -206,7 +215,7 @@ fn delimited_pull(
         Ok(frame), Ok(rest) ->
           Next(
             frame,
-            delimited_active(source, rest, delimiter, source_drained, True),
+            delimited_active(source, rest, delimiter, source_drained, True, 0),
           )
         _, _ -> Done
       }
@@ -227,11 +236,33 @@ fn delimited_pull(
                 delimiter,
                 False,
                 has_seen_input || bit_array.byte_size(chunk) > 0,
+                resume_scan_offset(buffer, delimiter),
               )
             Done ->
-              delimited_pull(source, buffer, delimiter, True, has_seen_input)
+              delimited_pull(
+                source,
+                buffer,
+                delimiter,
+                True,
+                has_seen_input,
+                scan_from,
+              )
           }
       }
+  }
+}
+
+/// Where to resume scanning the new (longer) buffer after appending a
+/// fresh chunk. The previous full scan covered everything except the
+/// last `delim_size - 1` bytes, since a delimiter shorter than that
+/// would already have matched. Backing off by `delim_size - 1` is
+/// enough to catch a delimiter that straddles the chunk boundary.
+fn resume_scan_offset(buffer: BitArray, delimiter: BitArray) -> Int {
+  let delim_size = bit_array.byte_size(delimiter)
+  let buffer_size = bit_array.byte_size(buffer)
+  case buffer_size - delim_size + 1 {
+    n if n > 0 -> n
+    _ -> 0
   }
 }
 


### PR DESCRIPTION
## Summary

Partial fix for #58 (\`binary.delimited\` half). The scanner re-walked the entire buffer from offset 0 every time a chunk was appended, so a delimiter that never matched paid an O(N^2) cost on input size. The new code resumes scanning from the previous tail, only backing off by \`delim_size - 1\` to catch a delimiter that straddles the chunk boundary.

\`text.lines\` has the same issue but the fix needs an accumulator + CR look-ahead refactor; tracking it as a follow-up task on issue #58 rather than bundling it here.

## Changes

- \`src/datastream/binary.gleam\`:
  - \`delimited_active\` / \`delimited_pull\` carry a new \`scan_from: Int\` parameter (0 on a fresh buffer; non-zero after appending a chunk to an unmatched buffer).
  - \`find_delimiter\` is called with \`scan_from\` instead of \`0\`.
  - On a chunk pull the new \`resume_scan_offset(buffer, delimiter)\` helper computes the resume position as \`max(0, prev_buffer_size - delim_size + 1)\`. That window is the smallest place a delimiter spanning the previous tail and the new chunk could start.

No behaviour change. 313 erlang + 239 javascript tests pass; the existing chunk-boundary tests for \`delimited\` (delimiter at chunk boundary, partial frame across chunks, etc.) keep passing because the back-off matches the worst-case overlap exactly.

## Follow-up

\`text.lines\` rescans the buffer on every chunk arrival via \`do_extract_line\`. Resuming there requires threading an accumulator through \`lines_pull\` and handling the CR look-ahead at chunk boundaries. Left as a follow-up; #58 stays open until that lands.