### PR TITLE
test(erlang/par): pin construction-time panic behaviour for invalid knobs

### DIFF
--- a/test/datastream/erlang/par_test.gleam
+++ b/test/datastream/erlang/par_test.gleam
@@ -478,7 +478,7 @@ fn panicked(thunk: fn() -> Nil) -> Bool {
 pub fn map_unordered_with_panics_on_zero_max_workers_test() {
   let did_panic =
     panicked(fn() {
-      let _ =
+      let _result =
         par.map_unordered_with(
           source.from_list([1]),
           with: fn(x) { x },
@@ -494,7 +494,7 @@ pub fn map_unordered_with_panics_on_zero_max_workers_test() {
 pub fn map_ordered_with_panics_on_max_buffer_below_max_workers_test() {
   let did_panic =
     panicked(fn() {
-      let _ =
+      let _result =
         par.map_ordered_with(
           source.from_list([1]),
           with: fn(x) { x },
@@ -510,7 +510,8 @@ pub fn map_ordered_with_panics_on_max_buffer_below_max_workers_test() {
 pub fn merge_with_panics_on_zero_max_buffer_test() {
   let did_panic =
     panicked(fn() {
-      let _ = par.merge_with(streams: [source.from_list([1])], max_buffer: 0)
+      let _result =
+        par.merge_with(streams: [source.from_list([1])], max_buffer: 0)
       Nil
     })
   did_panic |> should.be_true

--- a/test/datastream/erlang/par_test.gleam
+++ b/test/datastream/erlang/par_test.gleam
@@ -450,3 +450,68 @@ pub fn merge_with_slow_consumer_does_not_overproduce_test() {
   let peak = event_log.peak_concurrent(events, named: "pump")
   { peak <= 2 } |> should.be_true
 }
+
+// --- construction-time panics --------------------------------------------
+//
+// `validate_par_args` and `validate_buffer` panic on construction
+// when concurrency knobs are out of range. Catching a Gleam `panic`
+// directly is awkward, but spawning the failing call in an unlinked
+// process and observing that no completion message arrives within a
+// short timeout is sufficient: a panicking process never sends, while
+// a non-panicking call here completes in microseconds.
+
+@target(erlang)
+fn panicked(thunk: fn() -> Nil) -> Bool {
+  let done = process.new_subject()
+  let _pid =
+    process.spawn_unlinked(fn() {
+      thunk()
+      process.send(done, Nil)
+    })
+  case process.receive(from: done, within: 100) {
+    Ok(_) -> False
+    Error(_) -> True
+  }
+}
+
+@target(erlang)
+pub fn map_unordered_with_panics_on_zero_max_workers_test() {
+  let did_panic =
+    panicked(fn() {
+      let _ =
+        par.map_unordered_with(
+          source.from_list([1]),
+          with: fn(x) { x },
+          max_workers: 0,
+          max_buffer: 4,
+        )
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
+@target(erlang)
+pub fn map_ordered_with_panics_on_max_buffer_below_max_workers_test() {
+  let did_panic =
+    panicked(fn() {
+      let _ =
+        par.map_ordered_with(
+          source.from_list([1]),
+          with: fn(x) { x },
+          max_workers: 4,
+          max_buffer: 2,
+        )
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
+@target(erlang)
+pub fn merge_with_panics_on_zero_max_buffer_test() {
+  let did_panic =
+    panicked(fn() {
+      let _ = par.merge_with(streams: [source.from_list([1])], max_buffer: 0)
+      Nil
+    })
+  did_panic |> should.be_true
+}


### PR DESCRIPTION
## Summary

Fixes #73. \`validate_par_args\` and \`validate_buffer\` panic on invalid concurrency knobs (\`max_workers < 1\`, \`max_buffer < max_workers\` for the \`_with\` family, \`max_buffer < 1\` for \`merge_with\`). Until now those panic paths were only documented; nothing prevented a future "let's relax this check to support 0 workers" from silently breaking the invariant.

Catching a Gleam panic directly is awkward, but spawning the failing call in an unlinked process and observing that no completion message arrives within a short timeout is sufficient: a panicking process never sends, and a non-panicking call here completes in microseconds.

## Changes

\`test/datastream/erlang/par_test.gleam\`:

- Add private \`panicked(thunk)\` helper that spawns \`thunk\` in an unlinked process, sends \`Nil\` on completion, and waits for it with a 100 ms timeout. Returns \`True\` if no message arrived (i.e. the process died, almost certainly via panic).
- Add three tests under a new "construction-time panics" section:
  - \`map_unordered_with_panics_on_zero_max_workers_test\` — \`max_workers: 0\`
  - \`map_ordered_with_panics_on_max_buffer_below_max_workers_test\` — \`max_workers: 4, max_buffer: 2\`
  - \`merge_with_panics_on_zero_max_buffer_test\` — \`max_buffer: 0\`

The Erlang test runner prints a CRASH REPORT for each spawned panic. That's expected — the panic is the signal we're testing for — and the test still passes because the report comes from the unlinked spawnee, not the test process.

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for concurrency configuration parameters, confirming construction-time panics occur for invalid configurations in mapping and merging operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->