### PR TITLE
test(erlang/par): pin 'panic in f hangs the pipeline' behaviour

### DIFF
--- a/test/datastream/erlang/par_test.gleam
+++ b/test/datastream/erlang/par_test.gleam
@@ -516,3 +516,63 @@ pub fn merge_with_panics_on_zero_max_buffer_test() {
     })
   did_panic |> should.be_true
 }
+
+// --- panic-in-f leaves the pipeline blocked (pinned behaviour) -----------
+//
+// Module-level docs already warn that a panicking `f(x)` leaves the
+// pipeline blocked. These tests pin that contract so a future
+// "trap worker exits" change has to update them deliberately. We
+// spawn the failing terminal in an unlinked process and assert it
+// does NOT complete within a generous timeout.
+//
+// The unlinked spawnee leaks one BEAM process per test; this is
+// acceptable because the leak is bounded (one per test) and isolated
+// from the test runner.
+
+@target(erlang)
+fn does_not_complete(thunk: fn() -> Nil) -> Bool {
+  let done = process.new_subject()
+  let _pid =
+    process.spawn_unlinked(fn() {
+      thunk()
+      process.send(done, Nil)
+    })
+  case process.receive(from: done, within: 200) {
+    Ok(_) -> False
+    Error(_) -> True
+  }
+}
+
+@target(erlang)
+pub fn map_unordered_with_hangs_when_f_panics_test() {
+  let hung =
+    does_not_complete(fn() {
+      let _result =
+        source.from_list([1, 2, 3])
+        |> par.map_unordered_with(
+          with: fn(_x) { panic as "boom" },
+          max_workers: 2,
+          max_buffer: 4,
+        )
+        |> fold.to_list
+      Nil
+    })
+  hung |> should.be_true
+}
+
+@target(erlang)
+pub fn map_ordered_with_hangs_when_f_panics_test() {
+  let hung =
+    does_not_complete(fn() {
+      let _result =
+        source.from_list([1, 2, 3])
+        |> par.map_ordered_with(
+          with: fn(_x) { panic as "boom" },
+          max_workers: 2,
+          max_buffer: 4,
+        )
+        |> fold.to_list
+      Nil
+    })
+  hung |> should.be_true
+}


### PR DESCRIPTION
## Summary

Closes #63 by pinning the current behaviour rather than fixing it. The module-level doc already warned that a panicking \`f(x)\` leaves the pipeline blocked (worker dies silently, coordinator blocks on \`receive_forever\`); these tests freeze that contract so a future "trap worker exits" change has to update them deliberately.

## Changes

\`test/datastream/erlang/par_test.gleam\`:

- Add private \`does_not_complete(thunk)\` helper that spawns \`thunk\` in an unlinked process and asserts no completion message arrives within 200 ms.
- \`map_unordered_with_hangs_when_f_panics_test\` — feeds \`[1, 2, 3]\` into \`map_unordered_with\` whose \`f\` panics. The terminal \`fold.to_list\` hangs.
- \`map_ordered_with_hangs_when_f_panics_test\` — same shape for \`map_ordered_with\`.

The unlinked spawnee leaks one BEAM process per test. That's documented inline as the cost of pinning the behaviour and is bounded.

## Why pin rather than fix

The "fix" path requires switching workers from \`spawn_unlinked\` to \`spawn_link\` plus \`trap_exit\` and surfacing worker exits as a stream-level error. That is a real behaviour change deserving its own design discussion. Pinning the current behaviour now means the existing contract is verifiable today and any future fix has to update the assertions consciously.

Closes #63