### PR TITLE
refactor(source): collapse try_resource onto a new datastream.try_resource helper

### DIFF
--- a/src/datastream.gleam
+++ b/src/datastream.gleam
@@ -119,6 +119,32 @@ pub fn resource(
   )
 }
 
+/// Variant of `resource` whose `open` may fail. On `Error(e)` the
+/// stream emits exactly one element produced by `on_open_error(e)`
+/// and halts; `close` is NOT called (no opened state exists). On
+/// `Ok(state)` behaviour follows `resource`.
+///
+/// Internal to the library — exposed publicly via
+/// `source.try_resource`.
+@internal
+pub fn try_resource(
+  open open: fn() -> Result(s, eo),
+  next next: fn(s) -> Step(a, s),
+  close close: fn(s) -> Nil,
+  on_open_error on_open_error: fn(eo) -> a,
+) -> Stream(a) {
+  Stream(
+    pull: fn() {
+      case open() {
+        Ok(state) -> pull_resource(state, next, close)
+        Error(e) ->
+          Next(on_open_error(e), Stream(pull: fn() { Done }, close: noop))
+      }
+    },
+    close: noop,
+  )
+}
+
 fn pull_resource(
   state: s,
   next: fn(s) -> Step(a, s),

--- a/src/datastream/source.gleam
+++ b/src/datastream/source.gleam
@@ -207,55 +207,16 @@ pub fn try_resource(
   next next: fn(state) -> Step(Result(a, next_error), state),
   close close: fn(state) -> Nil,
 ) -> Stream(Result(a, ResourceError(open_error, next_error))) {
-  datastream.make(
-    pull: fn() { try_resource_first_pull(open, next, close) },
-    close: fn() { Nil },
-  )
-}
-
-fn try_resource_first_pull(
-  open: fn() -> Result(state, open_error),
-  next: fn(state) -> Step(Result(a, next_error), state),
-  close: fn(state) -> Nil,
-) -> Step(
-  Result(a, ResourceError(open_error, next_error)),
-  Stream(Result(a, ResourceError(open_error, next_error))),
-) {
-  case open() {
-    Error(e) ->
-      Next(
-        element: Error(OpenError(e)),
-        state: datastream.make(pull: fn() { Done }, close: fn() { Nil }),
-      )
-    Ok(state) -> try_resource_pull(state, next, close)
-  }
-}
-
-fn try_resource_pull(
-  state: state,
-  next: fn(state) -> Step(Result(a, next_error), state),
-  close: fn(state) -> Nil,
-) -> Step(
-  Result(a, ResourceError(open_error, next_error)),
-  Stream(Result(a, ResourceError(open_error, next_error))),
-) {
-  case next(state) {
-    Done -> {
-      close(state)
-      Done
-    }
-    Next(element, next_state) -> {
-      let lifted = case element {
-        Ok(value) -> Ok(value)
-        Error(e) -> Error(NextError(e))
+  datastream.try_resource(
+    open: open,
+    next: fn(state) {
+      case next(state) {
+        Done -> Done
+        Next(Ok(value), next_state) -> Next(Ok(value), next_state)
+        Next(Error(e), next_state) -> Next(Error(NextError(e)), next_state)
       }
-      Next(
-        element: lifted,
-        state: datastream.make(
-          pull: fn() { try_resource_pull(next_state, next, close) },
-          close: fn() { close(next_state) },
-        ),
-      )
-    }
-  }
+    },
+    close: close,
+    on_open_error: fn(e) { Error(OpenError(e)) },
+  )
 }


### PR DESCRIPTION
## Summary

Fixes #59. \`source.try_resource\` previously reproduced \`pull_resource\`'s state machine in \`datastream.gleam\` as private \`try_resource_first_pull\` / \`try_resource_pull\` helpers (~45 lines). The two state machines had to stay in lock-step manually — any change to close-on-Done semantics or open-on-first-pull would need matching edits in both files.

## Changes

- \`src/datastream.gleam\`: add a new \`@internal\` \`try_resource(open, next, close, on_open_error)\` helper. It reuses the existing private \`pull_resource\` for the happy path, and on \`Error(e)\` from \`open\` it emits one element produced by \`on_open_error(e)\` and then halts.
- \`src/datastream/source.gleam\`: rewrite \`try_resource\` as a thin adapter — it lifts \`Result(a, next_error)\` into \`Result(a, ResourceError(open_error, next_error))\` and supplies \`on_open_error: fn(e) { Error(OpenError(e)) }\`. Delete the now-unused \`try_resource_first_pull\` and \`try_resource_pull\` helpers.

Net diff: -13 lines (-50 / +37). 322 erlang + 239 javascript tests still pass; the resource-close-contract suite covers both happy and open-error paths and is unchanged.

Closes #59