### PR TITLE
docs(changelog): list missing fold functions in 0.1.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ rename this heading to `## [0.1.0] - YYYY-MM-DD` and start a fresh
   operations `chunks_of` and `group_adjacent`.
 - `datastream/fold`: pure terminals — `to_list`, `count`, `first`,
   `last`, `fold`, `reduce`, `drain`, `all`, `any`, `find`,
-  `collect_result`.
+  `sum_int`, `sum_float`, `product_int`, `collect_result`,
+  `partition_result`, `partition_map`.
 - `datastream/sink`: effectful terminals — `each`, `try_each`,
   `println`.
 - `datastream/chunk`: opaque `Chunk(a)` type with `empty`, `singleton`,


### PR DESCRIPTION
## Summary

The `Unreleased` section of `CHANGELOG.md` enumerated `datastream/fold` with 11 of its 16 public functions, leaving `sum_int`, `sum_float`, `product_int`, `partition_result`, and `partition_map` undocumented. This would have shipped v0.1.0 with API surface the changelog did not describe.

## Changes

- `CHANGELOG.md`: extend the `datastream/fold` line to include the five missing public functions, preserving the existing source-order convention in the list.

## Design Decisions

- Insertion order follows the definition order in `src/datastream/fold.gleam` (`sum_int` → `sum_float` → `product_int` before `collect_result`; `partition_result` → `partition_map` after it), matching the convention used for the other module entries.
- Confirmed the full public set by grepping `pub fn` in `src/datastream/fold.gleam`; the changelog now matches exactly.

Closes #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog to reflect new pure terminal functions available for datastream/fold operations, including summation variants, product calculation, and result-partitioning options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->