### PR TITLE
docs(changelog): include try_resource in datastream internal constructor list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ rename this heading to `## [0.1.0] - YYYY-MM-DD` and start a fresh
 #### Cross-target core
 
 - `datastream`: opaque `Stream(a)` type and `Step(a, state)` pull-result
-  enum. Internal constructors `unfold`, `make`, `resource`, and the
-  internal `pull` / `close` operations.
+  enum. Internal constructors `unfold`, `make`, `resource`,
+  `try_resource`, and the internal `pull` / `close` operations.
 - `datastream/source`: stream constructors — `empty`, `once`,
   `from_list`, `from_bit_array`, `from_option`, `from_result`,
   `from_dict`, `range`, `repeat`, `iterate`, `unfold`. Resource-backed


### PR DESCRIPTION
## Summary

The `datastream` root-module bullet in the `Unreleased` CHANGELOG section listed four `@internal` constructors (`unfold`, `make`, `resource`) plus the internal `pull` / `close`, but omitted `try_resource`. The root module actually exposes six `@internal pub fn` (see `src/datastream.gleam` lines 60-195). This PR aligns the changelog with the published internal surface so v0.1.0 documents what is shipped.

## Changes

- `CHANGELOG.md`: add `try_resource` between `resource` and the `pull` / `close` mention, preserving the definition order from `src/datastream.gleam`.

## Design Decisions

- Insertion point matches the source order of `@internal` declarations in `src/datastream.gleam`. This keeps the list ordered consistently with how a reader discovers them by scrolling the module.
- The line re-wrap is a single trailing rewrap; no other content change.

Closes #105