### PR TITLE
docs(readme): add worked example for source.try_resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,39 @@ pub fn main() {
 }
 ```
 
+### Resource with fallible open
+
+`source.try_resource` is the variant whose `open` and per-element `next`
+can fail. A failed open emits exactly one `Error(source.OpenError(e))`
+element and halts without calling `close`; per-element failures surface
+as `Error(source.NextError(e))` and do not halt the stream.
+
+```gleam
+import datastream.{Done, Next}
+import datastream/fold
+import datastream/source
+import gleam/io
+
+pub fn main() {
+  let stream =
+    source.try_resource(
+      open: fn() -> Result(Int, String) { Error("not available") },
+      next: fn(n) {
+        case n > 3 {
+          True -> Done
+          False -> Next(element: Ok(n), state: n + 1)
+        }
+      },
+      close: fn(_state) { Nil },
+    )
+
+  stream
+  |> fold.to_list
+  |> io.debug
+  // [Error(OpenError("not available"))]
+}
+```
+
 ### Bounded parallel map (BEAM)
 
 ```gleam


### PR DESCRIPTION
## Summary

The README showed a worked example for `source.resource` but none for `source.try_resource`, so a first-time user had no reference for how fallible opens are modelled or what the emitted element type looks like on an `OpenError`. This PR adds a focused example that pins the shape.

## Changes

- `README.md`: add a new "Resource with fallible open" section placed between the existing "Resource-backed stream" and "Bounded parallel map (BEAM)" sections.

## Design Decisions

- Example intentionally exercises the `OpenError` path rather than the happy path — the happy path already overlaps with the `resource` example. Showing the failure shape is what the Issue specifically calls for.
- Kept the prose reference-style (two sentences) per the project's documented doc conventions.
- Example is a complete `pub fn main()` in the same copy-paste format as the other README examples, so a user can verify it with `gleam new app && gleam add datastream && gleam run`.
- The construction mirrors `test/datastream/try_resource_test.gleam`'s `try_resource_open_error_yields_one_open_error_test`, so the illustrated output is already pinned by the test suite.

Closes #106