### PR TITLE
docs(readme): move 'Target support' above the examples section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ gleam add datastream
 
 API reference: <https://hexdocs.pm/datastream>
 
+## Target support
+
+- Erlang target: every module in this package
+- JavaScript target: the cross-target core only
+- `datastream/erlang/*` modules are BEAM-only
+- On JavaScript, `datastream` does not provide async streaming I/O
+  adapters. Resolve async I/O outside the library, then feed the data into
+  the core with constructors such as `source.from_list`,
+  `source.from_bit_array`, or `source.once`
+
 ## Use cases
 
 - Build pipelines from lists, ranges, options, results, or custom state
@@ -265,16 +275,6 @@ pub fn main() {
 - `datastream/erlang/sink`: BEAM-only subject sink
 - `datastream/erlang/par`: BEAM-only bounded parallel combinators and `race`
 - `datastream/erlang/time`: BEAM-only time-based combinators
-
-## Target support
-
-- Erlang target: every module in this package
-- JavaScript target: the cross-target core only
-- `datastream/erlang/*` modules are BEAM-only
-- On JavaScript, `datastream` does not provide async streaming I/O
-  adapters. Resolve async I/O outside the library, then feed the data into
-  the core with constructors such as `source.from_list`,
-  `source.from_bit_array`, or `source.once`
 
 ## Semantics
 


### PR DESCRIPTION
## Summary

The README previously placed "Target support" after the Module guide, at the bottom of the file. A reader following the document top-down encountered the BEAM-labelled examples (bounded parallel map, time-bucketed stream) before the section that defines what the `(BEAM)` label means or what the JavaScript target does not provide. This PR moves "Target support" to immediately after "Install" so the target model is in context before any example references a target.

## Changes

- `README.md`: relocate the "Target support" bullet list from below "Module guide" to immediately after the "Install" block.

## Design Decisions

- Pure reordering — no content change to the Target support bullets, no additional prose, no changes to any example. This keeps the PR reviewable as a single structural move.
- "Semantics" stays at the bottom because it describes evaluation semantics that build on already-seen examples, not prerequisites.
- Chosen to place it right after "Install" (rather than after "When to use") so the target reality is visible before a user starts scanning use-case bullets that mention `datastream/erlang/*`.

Closes #119