### PR TITLE
docs(source): clarify try_resource partial-acquisition and fold pairing

### DIFF
--- a/src/datastream.gleam
+++ b/src/datastream.gleam
@@ -121,8 +121,9 @@ pub fn resource(
 
 /// Variant of `resource` whose `open` may fail. On `Error(e)` the
 /// stream emits exactly one element produced by `on_open_error(e)`
-/// and halts; `close` is NOT called (no opened state exists). On
-/// `Ok(state)` behaviour follows `resource`.
+/// and halts; `close` is NOT called (no opened state exists, so the
+/// `open` callback is responsible for rolling back any partial
+/// acquisition). On `Ok(state)` behaviour follows `resource`.
 ///
 /// Internal to the library — exposed publicly via
 /// `source.try_resource`.

--- a/src/datastream/source.gleam
+++ b/src/datastream/source.gleam
@@ -150,6 +150,10 @@ pub fn unfold(
 /// emits exactly one of these and halts. `NextError(e)` wraps a
 /// per-element read error returned by `next`; the stream continues
 /// after one of these unless the caller stops it.
+///
+/// Pair with `fold.collect_result` to stop on the first error, or
+/// with `fold.partition_result` to drive the stream to completion
+/// and split successes from errors.
 pub type ResourceError(open_error, next_error) {
   OpenError(open_error)
   NextError(next_error)
@@ -202,6 +206,10 @@ pub fn resource(
 /// Downstream sees a single `Stream(Result(a, ResourceError(o, n)))`,
 /// so `fold.collect_result` and `fold.partition_result` work without
 /// further adaptation.
+///
+/// `open` is responsible for rolling back any partial acquisition
+/// itself: when `open` returns `Error(e)`, the library has no state
+/// to close.
 pub fn try_resource(
   open open: fn() -> Result(state, open_error),
   next next: fn(state) -> Step(Result(a, next_error), state),


### PR DESCRIPTION
## Summary

The `ResourceError` type and `source.try_resource` left two questions unanswered for a first-time user: who owns rollback when `open` partially acquires resources and then fails, and which terminal to reach for when consuming `Stream(Result(a, ResourceError(...)))`. This PR extends the docstrings with the answers, keeping the terse reference style of the module.

## Changes

- `src/datastream/source.gleam`
  - `ResourceError` type docstring: add a one-paragraph note pointing to `fold.collect_result` for fail-fast and `fold.partition_result` for full-traversal consumption.
  - `source.try_resource` docstring: add a note that `open` is responsible for rolling back partial acquisition, since the library has no state to close when `open` returns `Error`.
- `src/datastream.gleam`
  - `@internal datastream.try_resource` docstring: mirror the partial-acquisition note so the internal contract matches the public one.

## Design Decisions

- Added only factual, reference-style sentences — no prose expansion, no marketing.
- Placed the `fold` pairing hint on the `ResourceError` type rather than only on `try_resource`, because a user looking at the element type is the reader who needs the pairing recommendation.
- Left the existing `NextError` "continues after one of these" wording alone since it already answers the fatal-vs-continuable question; no duplication added.

Closes #122