### PR TITLE
docs(datastream): mark Step as part of the public API in its docstring

### DIFF
--- a/src/datastream.gleam
+++ b/src/datastream.gleam
@@ -39,6 +39,11 @@ pub opaque type Stream(a) {
 /// There is intentionally no `Error` variant: the core does not impose a
 /// failure model. Callers that need errors carry them as element-shaped
 /// values (`Stream(Result(a, e))`, `Stream(Validated(a, e))`, …).
+///
+/// Unlike `Stream(a)`, `Step` is a transparent public type: callers
+/// return `Next` / `Done` from the `next` callback passed to
+/// `source.resource` and `source.try_resource`. The enum shape is
+/// stable from v0.1.0 onward.
 pub type Step(a, state) {
   Next(element: a, state: state)
   Done


### PR DESCRIPTION
## Summary

`Stream(a)` is `pub opaque`, but `Step(a, state)` is a transparent `pub type`. A reader skimming the module could mistake `Step` for an internal detail (since `pull` / `close` / `unfold` / `make` / `resource` / `try_resource` are all `@internal` in the same file) and be unsure whether importing `Next` / `Done` at call sites is intentional. This PR pins the intent in the docstring: `Step` is public because `source.resource` / `source.try_resource` need callers to return its variants from the `next` callback.

## Changes

- `src/datastream.gleam`: extend the `Step(a, state)` docstring with a paragraph stating that `Step` / `Next` / `Done` are public — unlike `Stream(a)` — and that the enum shape is stable from v0.1.0.

## Design Decisions

- No code change; no API shape change. Just a docstring clarification so v0.1.0 documents the public / opaque boundary explicitly.
- Placed the note on `Step` (the load-bearing declaration), not on a separate module-level section, so anyone looking up the type sees the contract immediately.
- Kept the wording terse per the project doc style.

Closes #120