### PR TITLE
docs(erlang): document BEAM-only import vs call-site failure mode on JS target

### DIFF
--- a/src/datastream/erlang/par.gleam
+++ b/src/datastream/erlang/par.gleam
@@ -4,6 +4,13 @@
 //// involved, so callers can tell at the import site whether a
 //// pipeline runs in parallel.
 ////
+//// Every public function in this module is gated on
+//// `@target(erlang)`. On the JavaScript target the module still
+//// compiles, so `import datastream/erlang/par` itself does not fail,
+//// but calling any function fails at the call site. The
+//// `beam_only_marker` constant exists solely to keep the module
+//// non-empty on the JavaScript target.
+////
 //// ## Concurrency knobs
 ////
 //// - `max_workers`: degree of parallelism. The maximum number of BEAM

--- a/src/datastream/erlang/sink.gleam
+++ b/src/datastream/erlang/sink.gleam
@@ -4,6 +4,13 @@
 //// together they let two parts of a system talk over a process-based
 //// channel without either side having to know the other's stream
 //// representation.
+////
+//// Every public function in this module is gated on
+//// `@target(erlang)`. On the JavaScript target the module still
+//// compiles, so `import datastream/erlang/sink` itself does not
+//// fail, but calling any function fails at the call site. The
+//// `beam_only_marker` constant exists solely to keep the module
+//// non-empty on the JavaScript target.
 
 @target(javascript)
 /// Sentinel value documenting that this module is BEAM-only. Every

--- a/src/datastream/erlang/source.gleam
+++ b/src/datastream/erlang/source.gleam
@@ -3,8 +3,14 @@
 //// These bridge between Erlang's process / timer primitives and the
 //// cross-target `Stream(a)` value. The cross-target core has no
 //// business knowing about `Subject`, monotonic time, or BEAM timers,
-//// so they live here in `datastream/erlang/source` and never compile
-//// on the JavaScript target.
+//// so they live here in `datastream/erlang/source`.
+////
+//// Every public function in this module is gated on
+//// `@target(erlang)`. On the JavaScript target the module still
+//// compiles, so `import datastream/erlang/source` itself does not
+//// fail, but calling any function fails at the call site. The
+//// `beam_only_marker` constant exists solely to keep the module
+//// non-empty on the JavaScript target.
 
 @target(javascript)
 /// Sentinel value documenting that this module is BEAM-only. Every

--- a/src/datastream/erlang/time.gleam
+++ b/src/datastream/erlang/time.gleam
@@ -10,6 +10,13 @@
 //// `process.receive(within: ms)` to wait simultaneously for the next
 //// element and for a timer deadline.
 ////
+//// Every public function in this module is gated on
+//// `@target(erlang)`. On the JavaScript target the module still
+//// compiles, so `import datastream/erlang/time` itself does not fail,
+//// but calling any function fails at the call site. The
+//// `beam_only_marker` constant exists solely to keep the module
+//// non-empty on the JavaScript target.
+////
 //// ## Limitation: incompatible with `from_subject`
 ////
 //// Because every combinator pulls inside a spawned worker process,


### PR DESCRIPTION
## Summary

The four `datastream/erlang/*` modules gate every public function on `@target(erlang)` and keep a `beam_only_marker` constant so the module stays non-empty on JavaScript. The practical consequence — `import datastream/erlang/par` succeeds on JS but every call fails at the call site — was not stated anywhere users would see it. On `erlang/source` the module doc even claimed the file "never compiles on the JavaScript target", which was misleading. This PR adds a uniform note to each module's top-level doc and corrects the `erlang/source` phrasing.

## Changes

- `src/datastream/erlang/source.gleam`: remove the misleading "never compile on the JavaScript target" phrase; add the uniform BEAM-only note.
- `src/datastream/erlang/sink.gleam`: add the uniform BEAM-only note.
- `src/datastream/erlang/par.gleam`: add the uniform BEAM-only note immediately after the opening summary, before the "Concurrency knobs" section.
- `src/datastream/erlang/time.gleam`: add the uniform BEAM-only note immediately after the implementation strategy paragraph, before the "Limitation: incompatible with `from_subject`" section.

## Design Decisions

- Chose the "document it" option from the Issue's Suggested fix rather than attempting a module-level `@target(erlang)` attribute. Gleam 1.15 supports target attributes on individual declarations, not on modules — applying it at the module top would reject valid code or have no effect depending on the compiler's handling, and changing the import failure surface is a behaviour change that does not belong in a v0.1.0 clarification PR.
- Identical wording across all four modules on purpose: the contract is the same, so the doc should say the same thing each time.
- The note is placed in the module-level `////` doc so it appears in HexDocs as part of the module summary.

Closes #118