### PR TITLE
test(binary): pin construction-time panics for invalid prefix_size and size

### DIFF
--- a/test/datastream/binary_test.gleam
+++ b/test/datastream/binary_test.gleam
@@ -5,6 +5,9 @@ import gleam/list
 import gleeunit
 import gleeunit/should
 
+@target(erlang)
+import gleam/erlang/process
+
 pub fn main() -> Nil {
   gleeunit.main()
 }
@@ -200,4 +203,67 @@ pub fn fixed_size_empty_input_yields_no_frames_test() {
   |> binary.fixed_size(size: 2)
   |> fold.to_list
   |> should.equal([])
+}
+
+// --- construction-time panics (Erlang target) ----------------------------
+//
+// `length_prefixed` and `fixed_size` reject malformed knobs at
+// construction time with a panic. These tests pin that contract so a
+// future refactor of the validation path has to update them
+// deliberately. Erlang-only because the panic-detection helper spawns a
+// process; JavaScript has no matching primitive. The validation logic
+// itself is cross-target.
+
+@target(erlang)
+fn panicked(thunk: fn() -> Nil) -> Bool {
+  let done = process.new_subject()
+  let _pid =
+    process.spawn_unlinked(fn() {
+      thunk()
+      process.send(done, Nil)
+    })
+  case process.receive(from: done, within: 100) {
+    Ok(_) -> False
+    Error(_) -> True
+  }
+}
+
+@target(erlang)
+pub fn length_prefixed_panics_on_prefix_size_three_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result = binary.length_prefixed(from_list([<<>>]), prefix_size: 3)
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
+@target(erlang)
+pub fn length_prefixed_panics_on_prefix_size_sixteen_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result = binary.length_prefixed(from_list([<<>>]), prefix_size: 16)
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
+@target(erlang)
+pub fn fixed_size_panics_on_zero_size_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result = binary.fixed_size(from_list([<<>>]), size: 0)
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
+@target(erlang)
+pub fn fixed_size_panics_on_negative_size_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result = binary.fixed_size(from_list([<<>>]), size: -10)
+      Nil
+    })
+  did_panic |> should.be_true
 }


### PR DESCRIPTION
## Summary

`binary.length_prefixed` and `binary.fixed_size` reject malformed knobs at construction time with a panic, but the test suite did not verify that path. If the validation code was removed or weakened, the library would silently accept malformed arguments and produce garbage output. This PR pins the contract with four tests that mirror the pattern already used in `erlang/par_test.gleam` for analogous panics.

## Changes

- `test/datastream/binary_test.gleam`
  - Add `@target(erlang) import gleam/erlang/process`.
  - Add `@target(erlang) fn panicked(thunk)` helper copied from `par_test.gleam`: spawns `thunk` in an unlinked process and reports whether the `Nil` completion signal arrives within 100 ms.
  - Add four `@target(erlang)` tests asserting panics for `length_prefixed(_, prefix_size: 3)`, `length_prefixed(_, prefix_size: 16)`, `fixed_size(_, size: 0)`, and `fixed_size(_, size: -10)`.

## Design Decisions

- Gated on `@target(erlang)` because the `panicked` helper needs `process.spawn_unlinked` / `process.receive`, which are BEAM-only. The underlying validation logic in `src/datastream/binary.gleam` is cross-target; the panic-detection mechanism is not.
- Tests assert the boolean outcome only (panic happened / did not). The panic message stability is not pinned here — matching the choice made in `par_test.gleam`, which also only checks `did_panic |> should.be_true`.
- The helper is duplicated locally rather than extracted to a shared test helper. Two copies (par_test, binary_test) is below the threshold at which DRY clearly wins; promoting to a shared module would need its own design and is out of scope for v0.1.0.

Closes #112