### PR TITLE
test(erlang/source): pin timeout periodic-pass-through and post-deadline halt

### DIFF
--- a/test/datastream/erlang/source_test.gleam
+++ b/test/datastream/erlang/source_test.gleam
@@ -125,3 +125,47 @@ pub fn timeout_take_early_exit_closes_upstream_test() {
   event_log.count_opens(events) |> should.equal(1)
   event_log.count_closes(events) |> should.equal(1)
 }
+
+@target(erlang)
+pub fn timeout_passes_periodic_fast_elements_through_test() {
+  // Upstream emits three elements, 20ms apart. A 500ms deadline
+  // never trips, so every element comes through as Ok and the stream
+  // ends normally with Done.
+  source.unfold(from: 0, with: fn(s) {
+    case s >= 3 {
+      True -> datastream.Done
+      False -> {
+        process.sleep(20)
+        datastream.Next(element: s, state: s + 1)
+      }
+    }
+  })
+  |> beam_source.timeout(within: 500)
+  |> fold.to_list
+  |> should.equal([Ok(0), Ok(1), Ok(2)])
+}
+
+@target(erlang)
+pub fn timeout_halts_stream_after_deadline_trip_test() {
+  // A slow upstream takes 200ms to produce one element. With a 50ms
+  // deadline, the first pull trips the deadline. The stream must
+  // halt — the abandoned worker is not retried, even if downstream
+  // requests more elements. `take(up_to: 5)` is satisfied by exactly
+  // one Error(Nil), proving the single-shot halt contract.
+  let slow =
+    source.unfold(from: 0, with: fn(s) {
+      case s {
+        0 -> {
+          process.sleep(200)
+          datastream.Next(element: 99, state: 1)
+        }
+        _ -> datastream.Done
+      }
+    })
+
+  slow
+  |> beam_source.timeout(within: 50)
+  |> stream.take(up_to: 5)
+  |> fold.to_list
+  |> should.equal([Error(Nil)])
+}


### PR DESCRIPTION
## Summary

`erlang/source.timeout` already had three tests (fast pass-through via `from_list`, deadline trip on a slow `Done`, and `take` early-exit close contract). Two load-bearing contracts were still unpinned: (1) a real periodic upstream — one that actually sleeps between emits — should flow through a timeout that never trips; (2) once the deadline trips, the stream halts for good, even if the user keeps pulling. This PR adds one test for each.

## Changes

- `test/datastream/erlang/source_test.gleam`
  - `timeout_passes_periodic_fast_elements_through_test`: upstream emits three values 20 ms apart; `timeout(within: 500)` never trips; every element comes through as `Ok` and the stream ends with `Done`.
  - `timeout_halts_stream_after_deadline_trip_test`: a slow upstream (sleeps 200 ms) tripped by a 50 ms deadline. Downstream `stream.take(up_to: 5)` receives exactly one `Error(Nil)`, proving the halt contract is single-shot rather than per-pull-retry.

## Design Decisions

- Did not add a test asserting `close` is called on deadline trip, because the implementation deliberately abandons the worker rather than waiting on it (see `erlang/source.gleam:110-113`). Testing what the implementation says it does NOT do would mis-pin the contract. The existing `timeout_take_early_exit_closes_upstream_test` already covers the close contract for the downstream-early-exit path.
- Chose explicit `source.unfold` + `process.sleep` to build the timed upstreams — same pattern already used by the existing slow-upstream test, no new helper needed.
- Both tests are `@target(erlang)` because the `timeout` combinator itself is BEAM-only.

Closes #111