### PR TITLE
test(resource): pin close contract through chunk-aware combinators

### DIFF
--- a/test/datastream/resource_test.gleam
+++ b/test/datastream/resource_test.gleam
@@ -18,6 +18,12 @@ import datastream/stream
 import gleam/option
 import gleeunit/should
 
+@target(erlang)
+import datastream/binary
+
+@target(erlang)
+import datastream/text
+
 // --- cross-target: behavioural tests ---------------------------------------
 
 fn list_resource(elements: List(a)) {
@@ -549,4 +555,87 @@ pub fn resource_fold_collect_result_closes_once_on_first_error_test() {
   |> should.equal(Error("bad"))
   get_dict("c12_open_cr") |> should.equal(1)
   get_dict("c12_close_cr") |> should.equal(1)
+}
+
+// --- Erlang-only: close contract through chunk-aware combinators --------
+//
+// Each chunk-boundary-aware combinator owns its own close callback that
+// forwards to the wrapped source. These tests catch regressions where
+// the forwarding breaks — a class of bug that per-combinator tests in
+// isolation do not reveal.
+
+@target(erlang)
+pub fn lines_over_resource_take_one_closes_once_test() {
+  reset("c14_open_lines_take")
+  reset("c14_close_lines_take")
+  counted_resource(
+    ["hel", "lo\nwor", "ld\n"],
+    "c14_open_lines_take",
+    "c14_close_lines_take",
+  )
+  |> text.lines
+  |> stream.take(up_to: 1)
+  |> fold.to_list
+  |> should.equal(["hello"])
+  get_dict("c14_open_lines_take") |> should.equal(1)
+  get_dict("c14_close_lines_take") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn lines_over_resource_fold_find_closes_once_test() {
+  reset("c14_open_lines_find")
+  reset("c14_close_lines_find")
+  counted_resource(
+    ["alpha\nbeta\n", "gamma\n"],
+    "c14_open_lines_find",
+    "c14_close_lines_find",
+  )
+  |> text.lines
+  |> fold.find(satisfying: fn(line) { line == "beta" })
+  |> should.equal(option.Some("beta"))
+  get_dict("c14_open_lines_find") |> should.equal(1)
+  get_dict("c14_close_lines_find") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn delimited_over_resource_take_one_closes_once_test() {
+  reset("c14_open_delim")
+  reset("c14_close_delim")
+  counted_resource(
+    [<<65, 0, 66, 0, 67, 0>>],
+    "c14_open_delim",
+    "c14_close_delim",
+  )
+  |> binary.delimited(on: <<0>>)
+  |> stream.take(up_to: 1)
+  |> fold.to_list
+  |> should.equal([<<65>>])
+  get_dict("c14_open_delim") |> should.equal(1)
+  get_dict("c14_close_delim") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn length_prefixed_over_resource_take_one_closes_once_test() {
+  reset("c14_open_lp")
+  reset("c14_close_lp")
+  counted_resource([<<2, 65, 66, 1, 67>>], "c14_open_lp", "c14_close_lp")
+  |> binary.length_prefixed(prefix_size: 1)
+  |> stream.take(up_to: 1)
+  |> fold.to_list
+  |> should.equal([<<65, 66>>])
+  get_dict("c14_open_lp") |> should.equal(1)
+  get_dict("c14_close_lp") |> should.equal(1)
+}
+
+@target(erlang)
+pub fn fixed_size_over_resource_take_one_closes_once_test() {
+  reset("c14_open_fs")
+  reset("c14_close_fs")
+  counted_resource([<<1, 2, 3, 4, 5, 6>>], "c14_open_fs", "c14_close_fs")
+  |> binary.fixed_size(size: 2)
+  |> stream.take(up_to: 1)
+  |> fold.to_list
+  |> should.equal([<<1, 2>>])
+  get_dict("c14_open_fs") |> should.equal(1)
+  get_dict("c14_close_fs") |> should.equal(1)
 }


### PR DESCRIPTION
## Summary

The close contract is tested per-combinator (`stream.take`, `fold.find` / `first` / `any` / `all` / `collect_result`, etc.) but not yet for the compositions that real users write most often: a resource-backed source flowing through a chunk-boundary-aware combinator (`text.lines`, `binary.delimited`, `binary.length_prefixed`, `binary.fixed_size`) and then short-circuited downstream. Those combinators own their own `close` callback that forwards to the wrapped source; a regression there would leak resources, and per-combinator unit tests would not catch it.

## Changes

- `test/datastream/resource_test.gleam`
  - Add `@target(erlang) import datastream/binary` and `@target(erlang) import datastream/text`.
  - Add five `@target(erlang)` tests covering `open == close == 1` on early-exit compositions:
    - `lines_over_resource_take_one_closes_once_test`
    - `lines_over_resource_fold_find_closes_once_test`
    - `delimited_over_resource_take_one_closes_once_test`
    - `length_prefixed_over_resource_take_one_closes_once_test`
    - `fixed_size_over_resource_take_one_closes_once_test`

## Design Decisions

- Placed in `resource_test.gleam` rather than a new integration-test file because the tests reuse the existing `counted_resource` / `reset` / `get_dict` helpers already defined there. Extracting those helpers to a shared module would be a bigger refactor than this v0.1.0 coverage gap warrants.
- `@target(erlang)` only — the counting helpers rely on the BEAM process dictionary. The chunk-aware combinators themselves are cross-target; the unit tests in `text_test` / `binary_test` already cover their output on the JS target.
- `text.split` is not covered here because it shares the same chunk-buffer scaffolding as `text.lines` and is proven to forward `close` by inspection; adding a test for it would duplicate the `lines` test without catching a distinct regression.
- Used `fold.find` for the `text.lines` second test to exercise a different short-circuit path than `stream.take`.

Closes #114