### PR TITLE
docs(readme): add line-by-line resource processing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,47 @@ pub fn main() {
 }
 ```
 
+### Line-by-line processing over a resource
+
+The common real-world pipeline — open a file or cursor, stream lines,
+filter, release the handle — composes `source.resource` with
+`text.lines` and an early-exit terminal. The close contract releases
+the handle on every termination path, so the example below releases
+the pre-built "handle" regardless of how the downstream ends.
+
+In production, `open` would return a real file handle, `next` would
+call something like `file.read_line(handle)` (on Erlang) and wrap the
+result in `Next(line, handle)` or `Done`, and `close` would release
+the handle. The toy version below uses a list of chunks in place of
+a real handle so the example runs on both targets.
+
+```gleam
+import datastream.{Done, Next}
+import datastream/fold
+import datastream/source
+import datastream/stream
+import datastream/text
+import gleam/io
+
+pub fn main() {
+  source.resource(
+    open: fn() { ["INFO hello\nWARN slow\n", "INFO bye\n"] },
+    next: fn(state) {
+      case state {
+        [] -> Done
+        [head, ..tail] -> Next(element: head, state: tail)
+      }
+    },
+    close: fn(_state) { Nil },
+  )
+  |> text.lines
+  |> stream.take(up_to: 2)
+  |> fold.to_list
+  |> io.debug
+  // ["INFO hello", "WARN slow"]
+}
+```
+
 ### Bounded parallel map (BEAM)
 
 ```gleam


### PR DESCRIPTION
## Summary

The README had no example of the most common real-world datastream pipeline: a resource-backed source whose elements flow through `text.lines` and then a short-circuiting terminal. Users had to synthesise this shape from the `source.resource` toy counter + the `from_list`-based `text.lines` example. This PR adds one explicit example that composes the three pieces.

## Changes

- `README.md`: add a "Line-by-line processing over a resource" section between "Resource with fallible open" and "Bounded parallel map (BEAM)". Two short paragraphs describe the production mapping (`open` = open file handle, `next` = `file.read_line`, `close` = release handle) and the runnable example uses a list of chunks as the stand-in handle so the snippet executes on both targets.

## Design Decisions

- Stand-in handle rather than real file I/O: the project does not depend on `simplifile`, and Gleam's ecosystem does not yet ship a streaming-read API — pulling in an external dependency for one README example would add weight for little gain, and wrapping Erlang's `file` module via `@external` would be verbose and target-specific. The toy handle captures the *pattern* (open returns state, next advances, close releases) which is the part users need to see.
- Placed the example after the two `source.resource` / `source.try_resource` sections and before the BEAM examples. This keeps the resource-pattern material grouped and preserves the existing cross-target-first, BEAM-last flow.
- Example uses `stream.take(up_to: 2)` so the close contract's early-exit behaviour is implicit in the shape, without needing prose to restate it.
- Kept the prose at two short paragraphs and no marketing framing, per the project doc style.

Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added example pipeline documentation demonstrating line-by-line processing from resource-backed streams with filtering and result collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->