### PR TITLE
test: add high-cardinality smoke tests for cross-target core and par

### DIFF
--- a/test/datastream/erlang/volume_test.gleam
+++ b/test/datastream/erlang/volume_test.gleam
@@ -1,0 +1,31 @@
+//// High-cardinality smoke tests for the BEAM-only extension.
+////
+//// Each BEAM-only combinator spawns worker processes, so "completes
+//// in bounded time on 10k+ inputs" is the load-bearing invariant
+//// rather than raw throughput. A regression that leaks workers or
+//// fails to back-pressure under load would either hang this test or
+//// OOM the BEAM node.
+
+@target(erlang)
+import datastream/erlang/par
+
+@target(erlang)
+import datastream/fold
+
+@target(erlang)
+import datastream/source
+
+@target(erlang)
+import gleeunit/should
+
+@target(javascript)
+/// Empty placeholder so this module compiles cleanly on JavaScript.
+pub const beam_only_marker: String = "datastream/erlang/volume_test is BEAM-only"
+
+@target(erlang)
+pub fn par_map_unordered_ten_thousand_test() {
+  source.range(from: 0, to: 10_000)
+  |> par.map_unordered(with: fn(x) { x * 2 })
+  |> fold.count
+  |> should.equal(10_000)
+}

--- a/test/datastream/volume_test.gleam
+++ b/test/datastream/volume_test.gleam
@@ -1,0 +1,50 @@
+//// High-cardinality smoke tests for the cross-target core.
+////
+//// These verify that the library actually streams — meaning a lazy
+//// pipeline across hundreds of thousands of elements completes
+//// without retaining the full input. If a combinator regressed to
+//// materialising its source into a list, these tests would either
+//// time out or exhaust memory; the assertion is therefore completion
+//// plus final cardinality, not a direct memory measurement.
+
+import datastream/binary
+import datastream/fold
+import datastream/source
+import datastream/stream
+import datastream/text
+import gleeunit
+import gleeunit/should
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn range_map_count_one_million_test() {
+  source.range(from: 0, to: 1_000_000)
+  |> stream.map(with: fn(x) { x + 1 })
+  |> fold.count
+  |> should.equal(1_000_000)
+}
+
+pub fn chunks_of_on_one_hundred_thousand_test() {
+  source.range(from: 0, to: 100_000)
+  |> stream.chunks_of(into: 100)
+  |> fold.count
+  |> should.equal(1000)
+}
+
+pub fn text_lines_on_one_hundred_thousand_chunks_test() {
+  source.repeat("line\n")
+  |> stream.take(up_to: 100_000)
+  |> text.lines
+  |> fold.count
+  |> should.equal(100_000)
+}
+
+pub fn binary_fixed_size_on_one_hundred_thousand_chunks_test() {
+  source.repeat(<<1, 2, 3, 4>>)
+  |> stream.take(up_to: 100_000)
+  |> binary.fixed_size(size: 4)
+  |> fold.count
+  |> should.equal(100_000)
+}


### PR DESCRIPTION
## Summary

The test suite previously exercised combinators at cardinalities below 100. For a library that advertises itself as suitable for "large or unbounded" inputs, that left the central claim — pipelines actually stream in bounded memory — unverified by automation. This PR adds smoke tests at 10k–1M cardinality. If a combinator accidentally materialised its source into a list, these tests would either time out or exhaust memory; the assertion is completion plus final cardinality.

## Changes

- `test/datastream/volume_test.gleam` (new, cross-target, 4 tests):
  - `range_map_count_one_million_test` — 1M pass through `stream.map` + `fold.count`.
  - `chunks_of_on_one_hundred_thousand_test` — 100k elements into 1000 chunks.
  - `text_lines_on_one_hundred_thousand_chunks_test` — 100k short-line chunks reassembled by `text.lines`.
  - `binary_fixed_size_on_one_hundred_thousand_chunks_test` — 100k 4-byte chunks reframed by `binary.fixed_size`.
- `test/datastream/erlang/volume_test.gleam` (new, BEAM-only, 1 test):
  - `par_map_unordered_ten_thousand_test` — 10k inputs through `par.map_unordered`, stressing worker lifecycle and dispatch.

## Design Decisions

- Chose cardinalities pragmatically: 1M for the purely in-process `range → map → count` path (cheap), 100k for the chunk-boundary-aware paths (allocation-heavy), 10k for the BEAM parallel path (worker dispatch cost dominates). All of it completes inside the existing CI budget on both targets.
- `range` is `[from, to)` (exclusive upper bound), so tests use `from: 0, to: N` to land exactly `N` elements.
- The BEAM test uses the no-argument `par.map_unordered` to exercise the default `max_workers = 4` / `max_buffer = 16` configuration — the one most users will actually hit.
- Assertions are cardinality, not timing. These guard against "regression that accidentally retains the whole input" rather than micro-performance drift.
- Placed both files at the same level as the existing per-module test files; kept the existing cross-target-vs-BEAM directory split.

Closes #109