### PR TITLE
test(erlang/par): pin race competitive semantics with take and 3 emitting sources

### DIFF
--- a/test/datastream/erlang/par_test.gleam
+++ b/test/datastream/erlang/par_test.gleam
@@ -156,6 +156,35 @@ pub fn race_emitting_first_and_empties_later_yields_emitting_test() {
   |> should.equal([7, 8])
 }
 
+@target(erlang)
+pub fn race_take_one_from_two_emitting_sources_yields_one_element_test() {
+  // Both sources can emit. Downstream `take(1)` must terminate the
+  // pipeline after exactly one element regardless of which source
+  // won the race.
+  par.race(streams: [
+    source.from_list([1, 2, 3]),
+    source.from_list([10, 20, 30]),
+  ])
+  |> stream.take(up_to: 1)
+  |> fold.count
+  |> should.equal(1)
+}
+
+@target(erlang)
+pub fn race_three_emitting_sources_yields_one_winners_cardinality_test() {
+  // Three sources, each emitting two elements. Exactly one wins; the
+  // winner's full tail comes through. Because the winner is
+  // non-deterministic, the stable assertion is cardinality: the
+  // output length equals the losing choice's emit count (2).
+  par.race(streams: [
+    source.from_list([10, 20]),
+    source.from_list([30, 40]),
+    source.from_list([50, 60]),
+  ])
+  |> fold.count
+  |> should.equal(2)
+}
+
 // --- close contract ------------------------------------------------------
 
 @target(erlang)


### PR DESCRIPTION
## Summary

Existing `par.race` tests covered empty inputs, a single source, and all-empty contenders with one emitter. Two load-bearing behaviours for a real race combinator were still unpinned: a downstream `take(1)` must terminate cleanly when multiple sources can emit, and racing three or more sources each capable of emitting must yield exactly one source's full continuation. This PR adds a test for each.

## Changes

- `test/datastream/erlang/par_test.gleam` (two new `@target(erlang)` tests):
  - `race_take_one_from_two_emitting_sources_yields_one_element_test` — two sources each with three elements, `stream.take(up_to: 1)` downstream; cardinality is pinned to 1.
  - `race_three_emitting_sources_yields_one_winners_cardinality_test` — three sources each with two elements, run to completion; output cardinality is pinned to 2 (the losing choice's emit count), sidestepping the non-deterministic winner identity while still catching regressions that would drop or interleave elements.

## Design Decisions

- Used cardinality assertions rather than element-identity assertions because the winner of a race is inherently non-deterministic on the BEAM. Asserting cardinality catches the classes of regression the test is meant to catch (dropped elements, interleaving from losers, premature halt) without making the test flaky.
- Did not add a "loser external-resource cleanup" test. The module docstring (`par.gleam:691-698`) already documents loser cleanup as best-effort, and the existing `race_winner_take_full_consumption_closes_winner_test` already pins the winner-side close contract. Pinning loser *leakage* would codify a specific race timing rather than a contract.
- Placed both tests immediately after the existing `race_emitting_first_and_empties_later` test so the whole race block stays grouped.

Closes #110