### PR TITLE
docs(readme): add 'Use with dataprep' example for error-accumulating folds

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,50 @@ pub fn main() {
 }
 ```
 
+### Use with dataprep
+
+`datastream` does not depend on `dataprep`. Adding it (`gleam add
+dataprep`) and combining `fold.fold` with a small applicative
+`combine` step accumulates every per-element error in a single pass —
+the right tool when reporting all failures matters more than stopping
+on the first one.
+
+```gleam
+import dataprep/non_empty_list
+import dataprep/validated.{type Validated, Invalid, Valid}
+import datastream/fold
+import datastream/source
+import gleam/io
+
+pub fn main() {
+  source.from_list([
+    Valid(1),
+    Invalid(non_empty_list.single("row 2 bad")),
+    Valid(3),
+    Invalid(non_empty_list.single("row 4 bad")),
+  ])
+  |> fold.fold(from: Valid([]), with: combine)
+  |> io.debug
+  // Invalid(NonEmptyList("row 2 bad", ["row 4 bad"]))
+}
+
+fn combine(
+  acc: Validated(List(Int), String),
+  next: Validated(Int, String),
+) -> Validated(List(Int), String) {
+  case acc, next {
+    Valid(xs), Valid(x) -> Valid([x, ..xs])
+    Valid(_), Invalid(es) -> Invalid(es)
+    Invalid(es), Valid(_) -> Invalid(es)
+    Invalid(a), Invalid(b) -> Invalid(non_empty_list.append(a, b))
+  }
+}
+```
+
+For the simpler short-circuit case use `fold.collect_result` /
+`fold.partition_result` on `Stream(Result(a, e))` instead — `Validated`
+is for accumulating every error, not stopping on the first.
+
 ### Resource-backed stream
 
 `source.resource` opens once on the first pull, calls `next` for each


### PR DESCRIPTION
## Summary

After dropping `dataprep` as a hard dependency in #138, the README still showed nothing about how to combine `datastream` with `dataprep` when callers want it. This PR fills that gap with a small example that pairs `fold.fold` with an applicative `combine` step over `Validated`, accumulating every per-element error in one pass.

## Changes

- `README.md`: add a "Use with dataprep" section between "Result-shaped streams" and "Resource-backed stream". Two short paragraphs explain the policy (no hard dependency, add `dataprep` separately) and the use case (accumulate every error vs. stop on the first), followed by a runnable `pub fn main()` example. A trailing one-sentence note points back to `fold.collect_result` / `fold.partition_result` for the simpler `Result`-shaped case.

## Design Decisions

- Kept the example out of the dependency graph: the snippet shows the integration shape but the project itself does not gain a dependency on `dataprep`. Verified locally by adding `dataprep` as a temporary `[dev-dependencies]` entry and pasting the snippet into a test module — `gleam check` passes against the published `dataprep 0.2.0` API. Both the temp dep and the temp test module are removed from this PR.
- The `combine` function is the same applicative shape that `datastream/dataprep.collect_validated` previously embedded in the library (now externalised so callers wire it themselves). Two `Invalid` paths still concatenate via `non_empty_list.append`; semantics match the deleted helper.
- Used `io.debug` to match the surrounding examples' style; the trailing comment shows the expected output.
- Kept the prose terse per the project doc style — no marketing framing, no second-person.

Refs #121