### PR TITLE
docs(readme): add License and Contributing pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,3 +370,12 @@ pub fn main() {
   completion and on early exit
 - Errors are carried in the element type, for example
   `Stream(Result(a, e))`
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and pull
+request expectations. Bug reports and proposals via GitHub Issues.


### PR DESCRIPTION
## Summary

The README ended at the Semantics section with no pointer to LICENSE or CONTRIBUTING.md, even though both files exist at the repo root. A first-time reader had to leave the README to find them. This PR adds two short reference-style sections at the end pointing to each, with no marketing prose.

## Changes

- `README.md`: append a `## License` section (one line linking to `LICENSE`, MIT) and a `## Contributing` section (one short paragraph pointing to `CONTRIBUTING.md` for development setup and noting GitHub Issues for bug reports / proposals).

## Design Decisions

- Kept each section to one short paragraph or less. The doc style is reference, not promotional, and the actual content lives in the files being linked to.
- Placed at the very end of the README, after Semantics. This is the conventional placement for license and contributing sections in OSS Markdown READMEs.
- Did not duplicate the LICENSE text or the CONTRIBUTING setup steps inline — the README's job is to point.