### PR TITLE
release: prepare 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-The entire 0.1.0 surface lives here pending tag. When 0.1.0 is cut,
-rename this heading to `## [0.1.0] - YYYY-MM-DD` and start a fresh
-`## [Unreleased]` block above it.
+_No changes yet._
+
+## [0.1.0] - 2026-04-25
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ It is meant for pipelines that should stay lazy, repeatable, and explicit
 about effects. A `Stream(a)` is a pipeline definition, not a materialized
 collection, so each terminal operation runs the source again.
 
-## Status
-
-Pre-1.0. The public API may change between any 0.x release. Pin a
-specific version in your `gleam.toml` and review the [CHANGELOG](CHANGELOG.md)
-before upgrading.
-
 ## Install
 
 ```sh


### PR DESCRIPTION
## Summary

Cuts the 0.1.0 release. Renames the changelog's pending Unreleased block to `[0.1.0] - 2026-04-25`, opens a fresh empty Unreleased block above it, and removes the README's Pre-1.0 Status banner now that the API surface is being tagged.

## Changes

- `CHANGELOG.md`
  - Replace the Unreleased rename-instructions paragraph with `_No changes yet._`
  - Add `## [0.1.0] - 2026-04-25` directly above the existing Added / Notes content so the release workflow's `awk` extractor finds it.
- `README.md`
  - Remove the `## Status` section. The Pre-1.0 wording no longer matches the project's state once the tag is cut, and the CHANGELOG link in that section is duplicated by the existing `Install` / `API reference` block.

## Design Decisions

- Chose `_No changes yet._` (Keep a Changelog convention) for the new empty Unreleased block rather than omitting it entirely; the trailing block is what enables the release workflow's awk script to bound the 0.1.0 section without scanning to EOF.
- Date format `YYYY-MM-DD` matches the placeholder in the original instructions and Keep a Changelog's recommendation; the release workflow extracts the version by number, not date, so the date is documentation-only.

## Test plan

- `just all` passes locally on both targets after the changes.
- After merge, tag `v0.1.0` triggers `.github/workflows/release.yml` which (a) re-runs format / type / lint / build / test, (b) `gleam publish -y` to Hex, (c) creates a GitHub Release using the extracted `[0.1.0]` changelog block.