### PR TITLE
release: prepare 0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         run: gleam build
 
       - name: Publish to Hex
-        run: gleam publish -y
+        run: echo 'I am not using semantic versioning' | gleam publish -y
         env:
           HEXPM_API_KEY: ${{ secrets.HEXPM_API_KEY }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 _No changes yet._
 
+## [0.1.1] - 2026-04-25
+
+### Changed
+
+- Release workflow pipes `I am not using semantic versioning` into
+  `gleam publish -y` so the publish step does not stall on the
+  interactive confirmation that Hex requires for non-semver releases.
+- README adds Hex version, Hex download count, and CI status badges.
+
 ## [0.1.0] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # datastream
 
+[![Hex](https://img.shields.io/hexpm/v/datastream)](https://hex.pm/packages/datastream)
+[![Hex Downloads](https://img.shields.io/hexpm/dt/datastream)](https://hex.pm/packages/datastream)
+[![CI](https://github.com/nao1215/datastream/actions/workflows/ci.yml/badge.svg)](https://github.com/nao1215/datastream/actions/workflows/ci.yml)
+
 `datastream` is a pull-based stream library for Gleam.
 
 It is meant for pipelines that should stay lazy, repeatable, and explicit

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "datastream"
-version = "0.1.0"
+version = "0.1.1"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }


### PR DESCRIPTION
## Summary
- Bump `gleam.toml` to `0.1.1` and add a `[0.1.1]` entry to `CHANGELOG.md`.
- Pipe `I am not using semantic versioning` into `gleam publish -y` in the release workflow so the publish step does not stall on the interactive confirmation Hex requires for non-semver releases.
- Add Hex version, Hex download count, and CI status badges to `README.md`.

## Test plan
- [ ] CI passes on this PR (format / typecheck / lint / build / test on both Erlang and JavaScript targets).
- [ ] After merge, pushing `v0.1.1` triggers the release workflow and Hex publishes successfully without prompting.
- [ ] GitHub Release for `v0.1.1` is created with the changelog body.