### PR TITLE
docs(text): align lines docstring with lone CR behaviour

### DIFF
--- a/src/datastream/text.gleam
+++ b/src/datastream/text.gleam
@@ -15,8 +15,9 @@ import gleam/bit_array
 import gleam/list
 import gleam/string
 
-/// Split a stream of strings into a stream of lines, treating both
-/// `\n` and `\r\n` as terminators.
+/// Split a stream of strings into a stream of lines, treating `\n`,
+/// `\r\n`, and lone `\r` as terminators (matching Python's
+/// `str.splitlines()`).
 ///
 /// The terminator is NOT included in emitted lines. A trailing partial
 /// line (input that does not end with a terminator) is emitted as a


### PR DESCRIPTION
## Summary

The opening sentence of `text.lines`'s docstring claimed only `\n` and
`\r\n` were treated as terminators, but the chunk-boundary paragraph
just below already documented that a lone `\r` is also a terminator.
Update the opening sentence so a reader skimming the first line walks
away with the right mental model.

## Changes

- `src/datastream/text.gleam`: rewrite the first sentence of the
  `lines` docstring to list `\n`, `\r\n`, and lone `\r` as terminators
  and reference Python's `str.splitlines()` for the equivalent
  semantics.

## Design Decisions

- Documentation-only change. The runtime behaviour was already correct
  and matches the new wording; no production code or tests needed to
  move.
- Kept the existing chunk-boundary paragraph intact since it still
  describes the cross-chunk `\r` resolution accurately and adds detail
  the opening sentence intentionally omits.

Closes #146