### PR TITLE
fix(source)!: panic on non-byte-aligned from_bit_array input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-_No changes yet._
+### Changed
+
+- **BREAKING**: `source.from_bit_array` now panics at construction
+  time when the input `BitArray` is not byte-aligned (its bit length
+  is not a multiple of 8) instead of silently dropping the trailing
+  sub-byte tail. This matches the existing
+  `binary.length_prefixed` / `binary.fixed_size` policy of crashing
+  on programmer error so callers cannot quietly trust corrupted
+  input. (#144)
 
 ## [0.1.1] - 2026-04-25
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -80,6 +80,13 @@ thrown_away_error = "off"
 "src/datastream/binary.gleam" = [
   "avoid_panic",
 ]
+# `source.from_bit_array` rejects non-byte-aligned input at
+# construction time with `panic` per #144: silently dropping the
+# trailing sub-byte tail would be data loss the caller could not
+# observe, so a programmer error here must crash.
+"src/datastream/source.gleam" = [
+  "avoid_panic",
+]
 # `par.map_*` reject `max_workers < 1`, `max_buffer < 1`, and
 # `max_buffer < max_workers` for `map_ordered` with `panic` per
 # spec #20: the only sensible response to a programmer error like

--- a/src/datastream/source.gleam
+++ b/src/datastream/source.gleam
@@ -16,6 +16,7 @@
 //// on every terminal call: there is no implicit caching.
 
 import datastream.{type Step, type Stream, Done, Next}
+import gleam/bit_array
 import gleam/dict.{type Dict}
 import gleam/option.{type Option, None, Some}
 
@@ -121,13 +122,24 @@ pub fn from_dict(d: Dict(k, v)) -> Stream(#(k, v)) {
 ///
 /// An empty `BitArray` produces the empty stream. This is the natural
 /// shape for the upcoming `binary` and `text.utf8_decode` work.
+///
+/// The input MUST be byte-aligned (its bit length MUST be a multiple
+/// of 8). A non-byte-aligned input is rejected at construction time
+/// with a panic, matching the policy `binary.length_prefixed` and
+/// `binary.fixed_size` already use for invalid arguments — silently
+/// dropping the trailing sub-byte tail would be data loss the caller
+/// could not observe.
 pub fn from_bit_array(bytes: BitArray) -> Stream(Int) {
-  unfold(from: bytes, with: fn(remaining) {
-    case remaining {
-      <<byte:size(8), rest:bits>> -> Next(element: byte, state: rest)
-      _ -> Done
-    }
-  })
+  case bit_array.bit_size(bytes) % 8 {
+    0 ->
+      unfold(from: bytes, with: fn(remaining) {
+        case remaining {
+          <<byte:size(8), rest:bits>> -> Next(element: byte, state: rest)
+          _ -> Done
+        }
+      })
+    _ -> panic as "datastream/source.from_bit_array: input must be byte-aligned"
+  }
 }
 
 /// Build a stream from an initial state and a step function.

--- a/test/datastream/source_test.gleam
+++ b/test/datastream/source_test.gleam
@@ -9,6 +9,9 @@ import gleam/string
 import gleeunit
 import gleeunit/should
 
+@target(erlang)
+import gleam/erlang/process
+
 pub fn main() -> Nil {
   gleeunit.main()
 }
@@ -182,4 +185,47 @@ pub fn from_bit_array_is_repeatable_test() {
   let s = source.from_bit_array(<<10, 20>>)
   fold.to_list(s) |> should.equal([10, 20])
   fold.to_list(s) |> should.equal([10, 20])
+}
+
+// --- construction-time panics (Erlang target) ----------------------------
+//
+// `from_bit_array` rejects non-byte-aligned input at construction time
+// with a panic per #144. These tests pin that contract so a future
+// refactor of the validation path has to update them deliberately.
+// Erlang-only because the panic-detection helper spawns a process;
+// JavaScript has no matching primitive. The validation logic itself is
+// cross-target.
+
+@target(erlang)
+fn panicked(thunk: fn() -> Nil) -> Bool {
+  let done = process.new_subject()
+  let _pid =
+    process.spawn_unlinked(fn() {
+      thunk()
+      process.send(done, Nil)
+    })
+  case process.receive(from: done, within: 100) {
+    Ok(_) -> False
+    Error(_) -> True
+  }
+}
+
+@target(erlang)
+pub fn from_bit_array_panics_on_sub_byte_input_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result = source.from_bit_array(<<7:size(3)>>)
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
+@target(erlang)
+pub fn from_bit_array_panics_on_partial_trailing_bits_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result = source.from_bit_array(<<5:size(11)>>)
+      Nil
+    })
+  did_panic |> should.be_true
 }


### PR DESCRIPTION
## Summary

`source.from_bit_array` silently produced an empty stream (or
truncated data) when the input `BitArray` was not byte-aligned: a
7-bit input yielded `[]`, an 11-bit input yielded the first byte and
silently dropped the trailing 3 bits. Callers had no way to observe
the data loss.

This change rejects non-byte-aligned input at construction time with
a panic, matching the existing
`binary.length_prefixed` / `binary.fixed_size` policy of crashing
loudly on programmer error so a malformed input cannot be quietly
trusted.

## Changes

- `src/datastream/source.gleam`: gate `from_bit_array` on
  `bit_array.bit_size(bytes) % 8 == 0`; panic otherwise. Update the
  docstring to document the byte-aligned contract.
- `gleam.toml`: add `src/datastream/source.gleam` to the glinter
  `avoid_panic` ignore list with a comment explaining the rationale,
  mirroring the existing entry for `binary.gleam`.
- `test/datastream/source_test.gleam`: add Erlang-target panic tests
  covering the sub-byte (`<<7:size(3)>>`) and partial-trailing
  (`<<5:size(11)>>`) cases. The `panicked` helper mirrors the one in
  `binary_test.gleam`.
- `CHANGELOG.md`: note the breaking change under `[Unreleased]`.

## Design Decisions

- Picked Option 2 from the Issue (panic on programmer error) over
  Option 1 (docs only) or Option 3 (Result return type) because:
  - The whole `binary.*` module already crashes on invalid size
    arguments with the same justification
    (see the `gleam.toml` ignore-list comment on `binary.gleam`).
  - Returning `Result(Stream(Int), TrailingBitsError)` would force
    every caller to handle a case that only fires on malformed input
    a programmer constructed.
  - Documentation alone leaves a footgun: the silent-drop behaviour
    is observationally indistinguishable from a legitimately empty
    input.
- Validation runs once at construction, not per element, so the
  steady-state cost is unchanged.
- The panic test is Erlang-only because the panic-detection helper
  spawns a process; JavaScript has no matching primitive. The
  validation logic itself is cross-target.

## Limitations

- This is a breaking change for any caller that was relying on the
  previous silent-truncation behaviour. The CHANGELOG entry flags it
  as such; no in-tree caller existed.

Closes #144