### PR TITLE
fix(binary)!: surface length_prefixed truncation as IncompleteFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `binary.length_prefixed` / `binary.fixed_size` policy of crashing
   on programmer error so callers cannot quietly trust corrupted
   input. (#144)
+- **BREAKING**: `binary.length_prefixed` now returns
+  `Stream(Result(BitArray, IncompleteFrame))` instead of
+  `Stream(BitArray)`. Well-formed frames surface as `Ok(frame)`. When
+  the input ends mid-frame (short prefix or short payload), the
+  stream emits exactly one
+  `Error(IncompleteFrame(expected:, got:))` element before halting
+  so callers can distinguish "no more frames" from "truncated final
+  frame" — the previous silent-halt behaviour was unsafe for any
+  framed protocol that must reject partial messages. The
+  `Stream(Result(_, _))` shape mirrors `text.utf8_decode`. (#147)
+
+### Added
+
+- `binary.IncompleteFrame(expected:, got:)` type, surfaced by
+  `binary.length_prefixed` on truncated input.
 
 ## [0.1.1] - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,10 @@ pub fn main() {
     |> binary.length_prefixed(prefix_size: 1)
     |> fold.to_list
   io.debug(frames)
-  // [<<65, 66>>, <<67>>]
+  // [Ok(<<65, 66>>), Ok(<<67>>)]
+  // A truncated trailing frame surfaces as one
+  // Error(IncompleteFrame(expected:, got:)) before the stream halts,
+  // so callers can react instead of silently losing data.
 }
 ```
 

--- a/src/datastream/binary.gleam
+++ b/src/datastream/binary.gleam
@@ -63,18 +63,37 @@ fn bytes_pull(
 
 // --- length-prefixed -----------------------------------------------------
 
+/// Truncation surfaced by `length_prefixed` when the input ends
+/// mid-frame.
+///
+/// `expected` is the number of bytes the combinator was waiting for —
+/// either `prefix_size` (when the prefix itself was short) or the
+/// declared payload length (when the prefix was complete but the
+/// payload was short). `got` is the number of bytes the stream
+/// actually delivered toward that requirement (always `< expected`).
+pub type IncompleteFrame {
+  IncompleteFrame(expected: Int, got: Int)
+}
+
 /// Read a `prefix_size` byte big-endian unsigned length, then yield
-/// the next `length` bytes as a frame.
+/// the next `length` bytes as a frame, wrapped in `Ok`.
 ///
 /// `prefix_size` MUST be one of `{1, 2, 4, 8}`. Other values are
 /// rejected at construction time with a panic.
 ///
-/// Incomplete frames at end-of-input (short prefix or short payload)
-/// are NOT emitted; the stream simply halts.
+/// If the input ends mid-frame (the prefix is shorter than
+/// `prefix_size` bytes, or the payload is shorter than the declared
+/// length), the stream emits exactly one
+/// `Error(IncompleteFrame(expected:, got:))` element before halting,
+/// so callers can distinguish "no more frames" from "truncated final
+/// frame". The `Stream(Result(_, _))` shape mirrors `text.utf8_decode`;
+/// chain `fold.collect_result` to stop on the first truncation, or
+/// `fold.partition_result` to drive the stream to completion and split
+/// well-formed frames from the incomplete tail.
 pub fn length_prefixed(
   over stream: Stream(BitArray),
   prefix_size prefix_size: Int,
-) -> Stream(BitArray) {
+) -> Stream(Result(BitArray, IncompleteFrame)) {
   case prefix_size {
     1 | 2 | 4 | 8 -> length_prefixed_active(stream, <<>>, prefix_size, False)
     _ ->
@@ -87,7 +106,7 @@ fn length_prefixed_active(
   buffer: BitArray,
   prefix_size: Int,
   source_drained: Bool,
-) -> Stream(BitArray) {
+) -> Stream(Result(BitArray, IncompleteFrame)) {
   datastream.make(
     pull: fn() {
       length_prefixed_pull(source, buffer, prefix_size, source_drained)
@@ -101,12 +120,24 @@ fn length_prefixed_pull(
   buffer: BitArray,
   prefix_size: Int,
   source_drained: Bool,
-) -> Step(BitArray, Stream(BitArray)) {
+) -> Step(
+  Result(BitArray, IncompleteFrame),
+  Stream(Result(BitArray, IncompleteFrame)),
+) {
   case bit_array.byte_size(buffer) >= prefix_size {
     False ->
-      ensure_more(source, buffer, source_drained, fn(s, b, d) {
-        length_prefixed_pull(s, b, prefix_size, d)
-      })
+      case source_drained {
+        True ->
+          case bit_array.byte_size(buffer) {
+            0 -> Done
+            got ->
+              Next(
+                Error(IncompleteFrame(expected: prefix_size, got: got)),
+                length_prefixed_active(source, <<>>, prefix_size, True),
+              )
+          }
+        False -> length_prefixed_pull_more(source, buffer, prefix_size)
+      }
     True ->
       length_prefixed_with_prefix(source, buffer, prefix_size, source_drained)
   }
@@ -117,7 +148,10 @@ fn length_prefixed_with_prefix(
   buffer: BitArray,
   prefix_size: Int,
   source_drained: Bool,
-) -> Step(BitArray, Stream(BitArray)) {
+) -> Step(
+  Result(BitArray, IncompleteFrame),
+  Stream(Result(BitArray, IncompleteFrame)),
+) {
   let length = read_prefix(buffer, prefix_size)
   let total_needed = prefix_size + length
   case bit_array.byte_size(buffer) >= total_needed {
@@ -132,15 +166,43 @@ fn length_prefixed_with_prefix(
       {
         Ok(frame), Ok(rest) ->
           Next(
-            frame,
+            Ok(frame),
             length_prefixed_active(source, rest, prefix_size, source_drained),
           )
         _, _ -> Done
       }
     False ->
-      ensure_more(source, buffer, source_drained, fn(s, b, d) {
-        length_prefixed_pull(s, b, prefix_size, d)
-      })
+      case source_drained {
+        True ->
+          Next(
+            Error(IncompleteFrame(
+              expected: length,
+              got: bit_array.byte_size(buffer) - prefix_size,
+            )),
+            length_prefixed_active(source, <<>>, prefix_size, True),
+          )
+        False -> length_prefixed_pull_more(source, buffer, prefix_size)
+      }
+  }
+}
+
+fn length_prefixed_pull_more(
+  source: Stream(BitArray),
+  buffer: BitArray,
+  prefix_size: Int,
+) -> Step(
+  Result(BitArray, IncompleteFrame),
+  Stream(Result(BitArray, IncompleteFrame)),
+) {
+  case datastream.pull(source) {
+    Next(chunk, source_rest) ->
+      length_prefixed_pull(
+        source_rest,
+        bit_array.append(buffer, chunk),
+        prefix_size,
+        False,
+      )
+    Done -> length_prefixed_pull(source, buffer, prefix_size, True)
   }
 }
 
@@ -351,26 +413,6 @@ fn fixed_size_pull(
               )
             Done -> fixed_size_pull(source, buffer, size, True)
           }
-      }
-  }
-}
-
-// --- internal helpers ----------------------------------------------------
-
-fn ensure_more(
-  source: Stream(BitArray),
-  buffer: BitArray,
-  source_drained: Bool,
-  retry: fn(Stream(BitArray), BitArray, Bool) ->
-    Step(BitArray, Stream(BitArray)),
-) -> Step(BitArray, Stream(BitArray)) {
-  case source_drained {
-    True -> Done
-    False ->
-      case datastream.pull(source) {
-        Next(chunk, source_rest) ->
-          retry(source_rest, bit_array.append(buffer, chunk), False)
-        Done -> retry(source, buffer, True)
       }
   }
 }

--- a/test/datastream/binary_test.gleam
+++ b/test/datastream/binary_test.gleam
@@ -51,49 +51,71 @@ pub fn length_prefixed_one_byte_prefix_two_frames_test() {
   from_list([<<2, 65, 66, 1, 67>>])
   |> binary.length_prefixed(prefix_size: 1)
   |> fold.to_list
-  |> should.equal([<<65, 66>>, <<67>>])
+  |> should.equal([Ok(<<65, 66>>), Ok(<<67>>)])
 }
 
 pub fn length_prefixed_chunk_boundary_inside_payload_test() {
   from_list([<<2, 65>>, <<66>>])
   |> binary.length_prefixed(prefix_size: 1)
   |> fold.to_list
-  |> should.equal([<<65, 66>>])
+  |> should.equal([Ok(<<65, 66>>)])
 }
 
 pub fn length_prefixed_chunk_boundary_between_prefix_and_payload_test() {
   from_list([<<2>>, <<65, 66>>])
   |> binary.length_prefixed(prefix_size: 1)
   |> fold.to_list
-  |> should.equal([<<65, 66>>])
+  |> should.equal([Ok(<<65, 66>>)])
 }
 
 pub fn length_prefixed_zero_length_frame_test() {
   from_list([<<0>>])
   |> binary.length_prefixed(prefix_size: 1)
   |> fold.to_list
-  |> should.equal([<<>>])
+  |> should.equal([Ok(<<>>)])
 }
 
-pub fn length_prefixed_incomplete_payload_drops_frame_test() {
+pub fn length_prefixed_incomplete_payload_emits_error_test() {
   from_list([<<2, 65>>])
   |> binary.length_prefixed(prefix_size: 1)
   |> fold.to_list
-  |> should.equal([])
+  |> should.equal([Error(binary.IncompleteFrame(expected: 2, got: 1))])
 }
 
-pub fn length_prefixed_incomplete_prefix_drops_frame_test() {
+pub fn length_prefixed_incomplete_prefix_emits_error_test() {
   from_list([<<2>>])
   |> binary.length_prefixed(prefix_size: 2)
   |> fold.to_list
-  |> should.equal([])
+  |> should.equal([Error(binary.IncompleteFrame(expected: 2, got: 1))])
+}
+
+pub fn length_prefixed_short_payload_after_full_frame_test() {
+  // First frame is well-formed (length 1, payload 65); second prefix
+  // declares 200 bytes but only 5 follow, so the truncation surfaces
+  // after the well-formed frame.
+  from_list([<<1, 65, 200, 1, 2, 3, 4, 5>>])
+  |> binary.length_prefixed(prefix_size: 1)
+  |> fold.to_list
+  |> should.equal([
+    Ok(<<65>>),
+    Error(binary.IncompleteFrame(expected: 200, got: 5)),
+  ])
+}
+
+pub fn length_prefixed_zero_byte_payload_at_eof_is_ok_test() {
+  // Prefix says "zero bytes follow"; that frame is well-formed and
+  // the stream ends cleanly with no trailing IncompleteFrame.
+  from_list([<<0>>])
+  |> binary.length_prefixed(prefix_size: 1)
+  |> fold.to_list
+  |> should.equal([Ok(<<>>)])
 }
 
 pub fn length_prefixed_four_byte_big_endian_prefix_test() {
   from_list([<<0, 0, 0, 1, 99>>])
   |> binary.length_prefixed(prefix_size: 4)
   |> fold.to_list
-  |> should.equal([<<99>>])
+  |> should.equal([Ok(<<99>>)])
 }
 
 pub fn length_prefixed_two_byte_prefix_decodes_big_endian_test() {
@@ -103,14 +125,14 @@ pub fn length_prefixed_two_byte_prefix_decodes_big_endian_test() {
   from_list([<<<<1, 1>>:bits, payload_bits:bits>>])
   |> binary.length_prefixed(prefix_size: 2)
   |> fold.to_list
-  |> should.equal([payload_bits])
+  |> should.equal([Ok(payload_bits)])
 }
 
 pub fn length_prefixed_eight_byte_prefix_small_frame_test() {
   from_list([<<0, 0, 0, 0, 0, 0, 0, 2, 65, 66>>])
   |> binary.length_prefixed(prefix_size: 8)
   |> fold.to_list
-  |> should.equal([<<65, 66>>])
+  |> should.equal([Ok(<<65, 66>>)])
 }
 
 pub fn length_prefixed_prefix_split_across_chunks_test() {
@@ -119,7 +141,7 @@ pub fn length_prefixed_prefix_split_across_chunks_test() {
   from_list([<<0, 0>>, <<0, 1, 99>>])
   |> binary.length_prefixed(prefix_size: 4)
   |> fold.to_list
-  |> should.equal([<<99>>])
+  |> should.equal([Ok(<<99>>)])
 }
 
 pub fn length_prefixed_multiple_frames_back_to_back_two_byte_prefix_test() {
@@ -128,7 +150,7 @@ pub fn length_prefixed_multiple_frames_back_to_back_two_byte_prefix_test() {
   from_list([<<0, 1, 65, 0, 2, 66, 67, 0, 3, 68, 69, 70>>])
   |> binary.length_prefixed(prefix_size: 2)
   |> fold.to_list
-  |> should.equal([<<65>>, <<66, 67>>, <<68, 69, 70>>])
+  |> should.equal([Ok(<<65>>), Ok(<<66, 67>>), Ok(<<68, 69, 70>>)])
 }
 
 // --- delimited ----------------------------------------------------------

--- a/test/datastream/resource_test.gleam
+++ b/test/datastream/resource_test.gleam
@@ -622,7 +622,7 @@ pub fn length_prefixed_over_resource_take_one_closes_once_test() {
   |> binary.length_prefixed(prefix_size: 1)
   |> stream.take(up_to: 1)
   |> fold.to_list
-  |> should.equal([<<65, 66>>])
+  |> should.equal([Ok(<<65, 66>>)])
   get_dict("c14_open_lp") |> should.equal(1)
   get_dict("c14_close_lp") |> should.equal(1)
 }


### PR DESCRIPTION
## Summary

`binary.length_prefixed` previously halted silently when the input
ended mid-frame (short prefix or short payload). A caller could not
distinguish "no frames in input" from "truncated final frame", which
made the combinator unsafe as the receive-side of any framed
protocol where partial messages must be rejected.

This change switches the return type to
`Stream(Result(BitArray, IncompleteFrame))`. Well-formed frames
surface as `Ok(frame)`; if the input ends mid-frame, exactly one
`Error(IncompleteFrame(expected:, got:))` element is emitted before
the stream halts, matching the shape `text.utf8_decode` already uses.

## Changes

- `src/datastream/binary.gleam`: introduce
  `pub type IncompleteFrame { IncompleteFrame(expected: Int, got: Int) }`,
  rewrite `length_prefixed` (and its `_active` / `_pull` /
  `_with_prefix` helpers) to return
  `Stream(Result(BitArray, IncompleteFrame))`, and add a small
  `length_prefixed_pull_more` helper that replaces the per-call use
  of the now-unused generic `ensure_more` helper. Update the
  docstring to describe the new contract.
- `test/datastream/binary_test.gleam`: wrap every existing
  `length_prefixed` expectation in `Ok(...)`; replace the two
  silent-drop tests with `_emits_error_test` variants asserting the
  exact `IncompleteFrame(expected:, got:)` shape; add a new
  `length_prefixed_short_payload_after_full_frame_test` covering the
  Issue's reproduction (well-formed frame followed by a truncated
  trailing frame).
- `test/datastream/resource_test.gleam`: update the resource-backed
  `length_prefixed` test to expect `[Ok(<<65, 66>>)]` so the
  resource-close accounting still holds under the new shape.
- `README.md`: update the binary-framing example so its output
  comment matches the new `Result`-wrapped output and notes the
  truncation surfacing.
- `CHANGELOG.md`: note the breaking change and the new
  `IncompleteFrame` type under \`[Unreleased]\`.

## Design Decisions

- Chose Option 1 from the Issue (return-type change) over Option 2
  (sibling \`length_prefixed_strict\`) because:
  - The \`Stream(Result(_, _))\` shape is already idiomatic in this
    library (\`text.utf8_decode\`, \`source.try_resource\`), so callers
    who already deal with one of those have a familiar pattern.
  - A sibling combinator would leave the silent variant as a footgun
    that exists only for backward compatibility, which feels worse
    than the one-time migration cost at 0.x.
- Modelled \`IncompleteFrame\` as a record with named fields
  (\`expected\` / \`got\`) rather than separate
  \`ShortPrefix\` / \`ShortPayload\` constructors, because callers
  almost always want to log "we lost N bytes of an expected M-byte
  frame" rather than branch on the shape — a flat record keeps the
  call-site simpler and pattern matches stay total.
- Removed the unused generic \`ensure_more\` helper rather than
  retrofitting it to be polymorphic over the element type. The
  \`bytes\` combinator does its own pull-more inline; \`delimited\` /
  \`fixed_size\` similarly do not share the helper. Keeping a
  single-call helper just for \`length_prefixed\` did not justify the
  generic-over-\`a\` complexity.

## Limitations

- Breaking change for any caller that consumed
  \`Stream(BitArray)\` from \`length_prefixed\` directly. The
  CHANGELOG entry flags it; in-tree call sites (the README example,
  binary tests, the resource-backed test) have all been migrated.
- The same silent-truncation shape exists in \`binary.delimited\` for
  trailing partial frames, but the Issue itself notes that case is
  more defensible (line-delimited text often legitimately ends
  without a final delimiter), so this PR leaves \`delimited\` alone
  and addresses only \`length_prefixed\`. A uniform
  \`Stream(Result(_, _))\` story across the \`binary.*\` module could
  follow as a separate change if desired.

Closes #147