### PR TITLE
fix(stream)!: panic on invalid take/drop/chunks_of arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   framed protocol that must reject partial messages. The
   `Stream(Result(_, _))` shape mirrors `text.utf8_decode`. (#147)
 
+- **BREAKING**: `stream.take`, `stream.drop`, and `stream.chunks_of`
+  now panic at construction time on programmer-error arguments
+  instead of silently normalising. Specifically: `take(_, n)` and
+  `drop(_, n)` panic when `n < 0` (the `0` case still yields the
+  empty stream / the identity respectively, since both are
+  mathematically natural); `chunks_of(_, size)` panics when
+  `size < 1` (the previous "normalised to 1" behaviour was hiding
+  the real bug). This unifies the library's invalid-argument policy
+  with `binary.fixed_size` / `binary.length_prefixed` so a user who
+  learns the rule for one function can predict the rest. The new
+  contract is documented in the `datastream` module-level
+  docstring. (#145)
+
 ### Added
 
 - `binary.IncompleteFrame(expected:, got:)` type, surfaced by
   `binary.length_prefixed` on truncated input.
+- `datastream` module-level "Invalid-argument policy" section
+  documenting the unified `panic`-on-bad-arg contract referenced
+  from per-function docstrings.
 
 ## [0.1.1] - 2026-04-25
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -87,6 +87,14 @@ thrown_away_error = "off"
 "src/datastream/source.gleam" = [
   "avoid_panic",
 ]
+# `stream.take`, `stream.drop`, and `stream.chunks_of` reject
+# nonsensical count / size arguments with `panic` per the
+# datastream module-level invalid-argument policy unified in #145
+# (negative counts, sub-1 chunk sizes). Silent normalisation hides
+# programmer error behind plausible-looking output.
+"src/datastream/stream.gleam" = [
+  "avoid_panic",
+]
 # `par.map_*` reject `max_workers < 1`, `max_buffer < 1`, and
 # `max_buffer < max_workers` for `map_ordered` with `panic` per
 # spec #20: the only sensible response to a programmer error like

--- a/src/datastream.gleam
+++ b/src/datastream.gleam
@@ -8,6 +8,30 @@
 //// This module defines the foundational types every later module builds
 //// on: the opaque pipeline value `Stream(a)` and the pull-result enum
 //// `Step(a, state)`.
+////
+//// ## Invalid-argument policy
+////
+//// Across the library, any `size` / `count` / `prefix_size`
+//// argument that cannot have a meaningful interpretation is rejected
+//// at construction time with a `panic` rather than silently
+//// normalised — silent normalisation produces results that look
+//// plausible but lose information the caller cannot recover. The
+//// per-function docstring states the exact accepted range; the
+//// general rule is:
+////
+//// - A "size" argument that controls how many elements form one
+////   chunk / frame (`stream.chunks_of`, `binary.fixed_size`,
+////   `binary.length_prefixed`'s `prefix_size`) MUST be `>= 1`
+////   (and `prefix_size` is further restricted to `{1, 2, 4, 8}`).
+//// - A "count" argument that says how many elements to take or
+////   drop (`stream.take`, `stream.drop`) MUST be `>= 0`. The `0`
+////   case has a single mathematically natural answer
+////   (the empty stream / the identity respectively) and is
+////   accepted; negative counts are programmer error.
+////
+//// Every violation is a programmer error: the only sensible response
+//// is to crash so a bogus value cannot quietly produce surprising
+//// data downstream.
 
 /// A lazy, pull-based pipeline that yields elements of type `a`.
 ///

--- a/src/datastream/binary.gleam
+++ b/src/datastream/binary.gleam
@@ -79,7 +79,8 @@ pub type IncompleteFrame {
 /// the next `length` bytes as a frame, wrapped in `Ok`.
 ///
 /// `prefix_size` MUST be one of `{1, 2, 4, 8}`. Other values are
-/// rejected at construction time with a panic.
+/// rejected at construction time with a panic per the `datastream`
+/// module-level invalid-argument policy.
 ///
 /// If the input ends mid-frame (the prefix is shorter than
 /// `prefix_size` bytes, or the payload is shorter than the declared
@@ -360,7 +361,8 @@ fn find_delimiter(
 /// framing combinator cannot emit a frame of fewer than `size` bytes.
 ///
 /// `size` MUST be `>= 1`. Other values are rejected at construction
-/// time with a panic.
+/// time with a panic per the `datastream` module-level
+/// invalid-argument policy.
 pub fn fixed_size(
   over stream: Stream(BitArray),
   size size: Int,

--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -67,22 +67,34 @@ fn filter_pull(
   }
 }
 
-/// Yield at most the first `n` elements; `n <= 0` yields the empty stream.
+/// Yield at most the first `n` elements; `n == 0` yields the empty
+/// stream.
+///
+/// `n` MUST be `>= 0`. A negative `n` is rejected at construction
+/// time with a panic per the `datastream` module-level
+/// invalid-argument policy.
 ///
 /// Stops pulling upstream the moment the `n`th element has been
 /// emitted, and closes the upstream on that early exit. This is what
 /// makes `take` safe on infinite resource-backed sources.
 pub fn take(from stream: Stream(a), up_to n: Int) -> Stream(a) {
+  case n < 0 {
+    True -> panic as "datastream/stream.take: count must be >= 0"
+    False -> take_active(stream, n)
+  }
+}
+
+fn take_active(stream: Stream(a), n: Int) -> Stream(a) {
   datastream.make(
     pull: fn() {
-      case n <= 0 {
-        True -> {
+      case n {
+        0 -> {
           datastream.close(stream)
           Done
         }
-        False ->
+        _ ->
           case datastream.pull(stream) {
-            Next(element, rest) -> Next(element, take(from: rest, up_to: n - 1))
+            Next(element, rest) -> Next(element, take_active(rest, n - 1))
             Done -> Done
           }
       }
@@ -91,21 +103,32 @@ pub fn take(from stream: Stream(a), up_to n: Int) -> Stream(a) {
   )
 }
 
-/// Discard the first `n` elements; `n <= 0` is the identity.
+/// Discard the first `n` elements; `n == 0` is the identity.
+///
+/// `n` MUST be `>= 0`. A negative `n` is rejected at construction
+/// time with a panic per the `datastream` module-level
+/// invalid-argument policy.
 pub fn drop(from stream: Stream(a), up_to n: Int) -> Stream(a) {
+  case n < 0 {
+    True -> panic as "datastream/stream.drop: count must be >= 0"
+    False -> drop_active(stream, n)
+  }
+}
+
+fn drop_active(stream: Stream(a), n: Int) -> Stream(a) {
   datastream.make(pull: fn() { drop_pull(stream, n) }, close: fn() {
     datastream.close(stream)
   })
 }
 
 fn drop_pull(stream: Stream(a), n: Int) -> Step(a, Stream(a)) {
-  case n <= 0 {
-    True ->
+  case n {
+    0 ->
       case datastream.pull(stream) {
-        Next(element, rest) -> Next(element, drop(from: rest, up_to: 0))
+        Next(element, rest) -> Next(element, drop_active(rest, 0))
         Done -> Done
       }
-    False ->
+    _ ->
       case datastream.pull(stream) {
         Next(_, rest) -> drop_pull(rest, n - 1)
         Done -> Done
@@ -487,14 +510,17 @@ fn dedupe_pull(stream: Stream(a), last: Option(a)) -> Step(a, Stream(a)) {
 
 /// Group adjacent elements into fixed-size chunks.
 ///
-/// `size < 1` is normalised to `1`. The trailing chunk may be smaller
-/// than `size` when the source length is not divisible.
+/// `size` MUST be `>= 1`. A `size < 1` is rejected at construction
+/// time with a panic per the `datastream` module-level
+/// invalid-argument policy.
+///
+/// The trailing chunk may be smaller than `size` when the source
+/// length is not divisible.
 pub fn chunks_of(over stream: Stream(a), into size: Int) -> Stream(Chunk(a)) {
-  let normalised = case size < 1 {
-    True -> 1
-    False -> size
+  case size < 1 {
+    True -> panic as "datastream/stream.chunks_of: size must be >= 1"
+    False -> chunks_active(stream, [], 0, size)
   }
-  chunks_active(stream, [], 0, normalised)
 }
 
 fn chunks_active(

--- a/test/datastream/stream_test.gleam
+++ b/test/datastream/stream_test.gleam
@@ -9,6 +9,9 @@ import gleam/string
 import gleeunit
 import gleeunit/should
 
+@target(erlang)
+import gleam/erlang/process
+
 pub fn main() -> Nil {
   gleeunit.main()
 }
@@ -72,11 +75,16 @@ pub fn take_zero_yields_empty_test() {
   |> should.equal([])
 }
 
-pub fn take_negative_yields_empty_test() {
-  from_list([1, 2, 3])
-  |> stream.take(up_to: -5)
-  |> fold.to_list
-  |> should.equal([])
+@target(erlang)
+pub fn take_negative_panics_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result =
+        from_list([1, 2, 3])
+        |> stream.take(up_to: -5)
+      Nil
+    })
+  did_panic |> should.be_true
 }
 
 pub fn take_more_than_available_yields_all_test() {
@@ -107,11 +115,16 @@ pub fn drop_zero_is_identity_test() {
   |> should.equal([1, 2, 3])
 }
 
-pub fn drop_negative_is_identity_test() {
-  from_list([1, 2, 3])
-  |> stream.drop(up_to: -5)
-  |> fold.to_list
-  |> should.equal([1, 2, 3])
+@target(erlang)
+pub fn drop_negative_panics_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result =
+        from_list([1, 2, 3])
+        |> stream.drop(up_to: -5)
+      Nil
+    })
+  did_panic |> should.be_true
 }
 
 pub fn drop_more_than_available_yields_empty_test() {
@@ -392,18 +405,28 @@ pub fn chunks_of_size_larger_than_source_test() {
   |> should.equal([[1, 2, 3]])
 }
 
-pub fn chunks_of_zero_normalises_to_one_test() {
-  from_list([1, 2, 3])
-  |> stream.chunks_of(into: 0)
-  |> chunks_to_lists
-  |> should.equal([[1], [2], [3]])
+@target(erlang)
+pub fn chunks_of_zero_panics_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result =
+        from_list([1, 2, 3])
+        |> stream.chunks_of(into: 0)
+      Nil
+    })
+  did_panic |> should.be_true
 }
 
-pub fn chunks_of_negative_normalises_to_one_test() {
-  from_list([1, 2, 3])
-  |> stream.chunks_of(into: -5)
-  |> chunks_to_lists
-  |> should.equal([[1], [2], [3]])
+@target(erlang)
+pub fn chunks_of_negative_panics_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result =
+        from_list([1, 2, 3])
+        |> stream.chunks_of(into: -5)
+      Nil
+    })
+  did_panic |> should.be_true
 }
 
 pub fn chunks_of_terminates_on_infinite_source_test() {
@@ -451,4 +474,27 @@ pub fn group_adjacent_does_not_merge_non_adjacent_duplicates_test() {
   |> stream.group_adjacent(by: fn(x) { x })
   |> groups_to_pairs
   |> should.equal([#(1, [1]), #(2, [2]), #(1, [1])])
+}
+
+// --- construction-time panics (Erlang target) ----------------------------
+//
+// `take`, `drop`, and `chunks_of` reject nonsensical count / size
+// arguments at construction time with a panic per the datastream
+// module-level invalid-argument policy unified in #145. These tests
+// pin that contract. Erlang-only because the panic-detection helper
+// spawns a process; JavaScript has no matching primitive. The
+// validation logic itself is cross-target.
+
+@target(erlang)
+fn panicked(thunk: fn() -> Nil) -> Bool {
+  let done = process.new_subject()
+  let _pid =
+    process.spawn_unlinked(fn() {
+      thunk()
+      process.send(done, Nil)
+    })
+  case process.receive(from: done, within: 100) {
+    Ok(_) -> False
+    Error(_) -> True
+  }
 }


### PR DESCRIPTION
## Summary

The library used four different policies for handling invalid
size / count arguments across `stream.chunks_of` / `stream.take` /
`stream.drop` / `binary.fixed_size` / `binary.length_prefixed`.
A user who learned the rule for one function could not predict the
others — every wrong call produced a different brand of surprising
data (silent normalisation to 1, silent empty stream, silent
identity, or panic).

This change unifies the policy on **panic-on-bad-arg**, matching
the pre-existing stance of the `binary.*` modules and of
`erlang/par.gleam`. `stream.take` / `stream.drop` panic on negative
counts (the `0` case still has the natural mathematical answer and
is accepted); `stream.chunks_of` panics on `size < 1`. The unified
contract is documented once at the `datastream` module top, and
each affected function's docstring cites it.

## Changes

- `src/datastream.gleam`: add an "Invalid-argument policy" section
  to the module-level docstring stating the unified rule once.
- `src/datastream/stream.gleam`:
  - `take`: panic when `n < 0`; the `0` case still yields the empty
    stream. Split the recursive driver into `take_active` so the
    validation runs only at the public entry, not on every internal
    re-call with `n - 1`.
  - `drop`: panic when `n < 0`; the `0` case is still the identity.
    Mirror the `take` split with a `drop_active` helper.
  - `chunks_of`: panic when `size < 1` instead of normalising to 1.
- `src/datastream/binary.gleam`: docstring-only — point
  `fixed_size` and `length_prefixed` at the new module-level
  policy paragraph so the contract is stated once and cross-
  referenced everywhere.
- `gleam.toml`: add `src/datastream/stream.gleam` to the glinter
  `avoid_panic` ignore list with a comment naming this Issue,
  alongside the existing entries for `binary.gleam`, `source.gleam`,
  and `erlang/par.gleam`.
- `test/datastream/stream_test.gleam`: replace
  `take_negative_yields_empty_test`,
  `drop_negative_is_identity_test`,
  `chunks_of_zero_normalises_to_one_test`, and
  `chunks_of_negative_normalises_to_one_test` with `_panics_test`
  variants. The `take_zero_yields_empty_test` and
  `drop_zero_is_identity_test` cases stay since the new contract
  explicitly accepts `0` for those. Add a Erlang-target \`panicked\`
  helper mirroring the one in \`binary_test.gleam\` /
  \`source_test.gleam\`.
- `CHANGELOG.md`: note the breaking change and the new module-level
  policy section under \`[Unreleased]\`.

## Design Decisions

- Picked panic-on-bad-arg over "document one normalisation rule
  uniformly" because the `binary.*` and `erlang/par` modules
  already crash on programmer error, and the existing `gleam.toml`
  glinter comment explicitly endorses the rule \"the only sensible
  response to a programmer error like \`prefix_size = 3\` is to
  crash, so callers can't quietly trust a bogus framing.\" Picking
  normalisation would have required moving the existing panickers
  in the opposite direction.
- Kept `take(_, 0)` as the empty stream and `drop(_, 0)` as the
  identity even under the strict policy. Both are
  mathematically the unambiguous answer for the operation
  (\"take zero elements\" = nothing, \"drop zero elements\" = unchanged)
  and exist in every comparable streams library; rejecting them
  would force callers to wrap a trivial \`if n == 0\`. Negative
  counts have no such natural answer and are programmer error.
- Validation runs once at the public function entry, not inside the
  pull driver, so the steady-state per-element cost is unchanged.

## Limitations

- Breaking change for any caller that relied on the previous silent
  behaviour of `chunks_of(_, 0)` / `chunks_of(_, n<0)` /
  `take(_, n<0)` / `drop(_, n<0)`. The CHANGELOG flags it; in-tree
  tests have been updated.

Closes #145