### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-25
+
 ### Changed
 
 - **BREAKING**: `source.from_bit_array` now panics at construction
@@ -47,6 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `datastream` module-level "Invalid-argument policy" section
   documenting the unified `panic`-on-bad-arg contract referenced
   from per-function docstrings.
+
+### Documentation
+
+- `text.lines` opening sentence now lists `\n`, `\r\n`, and lone
+  `\r` as terminators (matching the actual behaviour and Python's
+  `str.splitlines()`). The chunk-boundary paragraph already
+  described this; only the opening summary was out of date. (#146)
 
 ## [0.1.1] - 2026-04-25
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "datastream"
-version = "0.1.1"
+version = "0.2.0"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }


### PR DESCRIPTION
### Changed

- **BREAKING**: `source.from_bit_array` now panics at construction
  time when the input `BitArray` is not byte-aligned (its bit length
  is not a multiple of 8) instead of silently dropping the trailing
  sub-byte tail. This matches the existing
  `binary.length_prefixed` / `binary.fixed_size` policy of crashing
  on programmer error so callers cannot quietly trust corrupted
  input. (#144)
- **BREAKING**: `binary.length_prefixed` now returns
  `Stream(Result(BitArray, IncompleteFrame))` instead of
  `Stream(BitArray)`. Well-formed frames surface as `Ok(frame)`. When
  the input ends mid-frame (short prefix or short payload), the
  stream emits exactly one
  `Error(IncompleteFrame(expected:, got:))` element before halting
  so callers can distinguish "no more frames" from "truncated final
  frame" — the previous silent-halt behaviour was unsafe for any
  framed protocol that must reject partial messages. The
  `Stream(Result(_, _))` shape mirrors `text.utf8_decode`. (#147)
- **BREAKING**: `stream.take`, `stream.drop`, and `stream.chunks_of`
  now panic at construction time on programmer-error arguments
  instead of silently normalising. Specifically: `take(_, n)` and
  `drop(_, n)` panic when `n < 0` (the `0` case still yields the
  empty stream / the identity respectively, since both are
  mathematically natural); `chunks_of(_, size)` panics when
  `size < 1` (the previous "normalised to 1" behaviour was hiding
  the real bug). This unifies the library's invalid-argument policy
  with `binary.fixed_size` / `binary.length_prefixed` so a user who
  learns the rule for one function can predict the rest. The new
  contract is documented in the `datastream` module-level
  docstring. (#145)

### Added

- `binary.IncompleteFrame(expected:, got:)` type, surfaced by
  `binary.length_prefixed` on truncated input.
- `datastream` module-level "Invalid-argument policy" section
  documenting the unified `panic`-on-bad-arg contract referenced
  from per-function docstrings.

### Documentation

- `text.lines` opening sentence now lists `\n`, `\r\n`, and lone
  `\r` as terminators (matching the actual behaviour and Python's
  `str.splitlines()`). The chunk-boundary paragraph already
  described this; only the opening summary was out of date. (#146)
