### PR TITLE
fix(text): prevent infinite loop in lines on empty chunks with pending CR

### DIFF
--- a/src/datastream/text.gleam
+++ b/src/datastream/text.gleam
@@ -80,12 +80,30 @@ fn lines_pull(
               )
           }
         False ->
-          case datastream.pull(source) {
-            Next(chunk, source_rest) ->
-              lines_pull(source_rest, chunk, new_pending, new_cr_pending, False)
-            Done -> lines_pull(source, "", new_pending, new_cr_pending, True)
-          }
+          pull_next_nonempty_chunk(
+            source,
+            new_pending,
+            new_cr_pending,
+          )
       }
+  }
+}
+
+/// Pull chunks from the source, skipping empty strings, until we get
+/// a non-empty chunk or the source is drained. This prevents an
+/// infinite loop when cr_pending is True and the source emits
+/// consecutive empty-string chunks.
+fn pull_next_nonempty_chunk(
+  source: Stream(String),
+  pending: List(String),
+  cr_pending: Bool,
+) -> Step(String, Stream(String)) {
+  case datastream.pull(source) {
+    Next("", source_rest) ->
+      pull_next_nonempty_chunk(source_rest, pending, cr_pending)
+    Next(chunk, source_rest) ->
+      lines_pull(source_rest, chunk, pending, cr_pending, False)
+    Done -> lines_pull(source, "", pending, cr_pending, True)
   }
 }
 

--- a/src/datastream/text.gleam
+++ b/src/datastream/text.gleam
@@ -79,12 +79,7 @@ fn lines_pull(
                 lines_active(source, "", [], False, True),
               )
           }
-        False ->
-          pull_next_nonempty_chunk(
-            source,
-            new_pending,
-            new_cr_pending,
-          )
+        False -> pull_next_nonempty_chunk(source, new_pending, new_cr_pending)
       }
   }
 }

--- a/test/datastream/text_test.gleam
+++ b/test/datastream/text_test.gleam
@@ -73,6 +73,34 @@ pub fn lines_on_truly_empty_source_yields_no_lines_test() {
   from_list([]) |> text.lines |> fold.to_list |> should.equal([])
 }
 
+pub fn lines_cr_at_chunk_end_followed_by_empty_chunks_test() {
+  // Issue #157: a CR at end of a chunk followed by empty-string chunks
+  // must not loop forever. The empty chunks should be skipped and the
+  // CR treated as a line terminator when the source eventually drains.
+  from_list(["hello\r", "", "", "world"])
+  |> text.lines
+  |> fold.to_list
+  |> should.equal(["hello", "world"])
+}
+
+pub fn lines_cr_then_empty_then_lf_test() {
+  // CR at chunk end, empty chunk, then a chunk starting with LF.
+  // The \r\n pair should be treated as one terminator.
+  from_list(["hello\r", "", "\nworld"])
+  |> text.lines
+  |> fold.to_list
+  |> should.equal(["hello", "world"])
+}
+
+pub fn lines_cr_at_end_followed_by_all_empty_chunks_test() {
+  // CR at chunk end, all remaining chunks are empty, then source drains.
+  // The CR should be treated as a terminator; "hello" is emitted.
+  from_list(["hello\r", "", ""])
+  |> text.lines
+  |> fold.to_list
+  |> should.equal(["hello"])
+}
+
 // --- split -----------------------------------------------------------------
 
 pub fn split_on_comma_yields_pieces_test() {


### PR DESCRIPTION
## Summary

Fix infinite loop in `text.lines` when a source emits consecutive empty-string chunks while a `\r` is pending.

## Changes

- Add `pull_next_nonempty_chunk` helper in `text.gleam` that skips empty chunks from the source before passing control back to `lines_pull`
- Replace the inline `datastream.pull(source)` in the `LineExhausted` branch with the new helper
- Add 3 test cases covering the edge case: CR + empty chunks + more data, CR + empty + LF, CR + all empty until drain

## Design Decisions

The fix skips empty chunks iteratively via tail recursion rather than filtering them at the source level, because empty chunks are legal (a source may emit them between real data) and should only be skipped in the specific context of resolving a pending CR.

Closes #157
