### PR TITLE
fix(par): detect worker panics via process monitors to prevent deadlock

### DIFF
--- a/src/datastream/erlang/par.gleam
+++ b/src/datastream/erlang/par.gleam
@@ -49,8 +49,9 @@
 ////
 //// ## Notes
 ////
-//// - A `f(x)` that `panic`s leaves the pipeline blocked; this is a
-////   known limitation across all `par.*` combinators.
+//// - A `f(x)` that `panic`s terminates the stream with `Done`.
+////   The crashed worker is detected via `process.monitor`, so the
+////   pipeline does not deadlock.
 //// - `merge` workers poll for a coordinator-liveness signal every
 ////   `merge_worker_liveness_check_ms` ms. If the caller of
 ////   `merge` / `merge_with` drops the returned stream without
@@ -217,14 +218,50 @@ fn map_unordered_step(
   case state.workers_busy {
     0 -> Done
     _ -> {
-      let result = process.receive_forever(from: state.result_subject)
+      map_unordered_receive(state)
+    }
+  }
+}
+
+@target(erlang)
+fn map_unordered_receive(
+  state: MapUnordered(a, b),
+) -> datastream.Step(b, Stream(b)) {
+  let selector =
+    process.new_selector()
+    |> process.select_map(state.result_subject, fn(msg) { Ok(msg) })
+    |> process.select_monitors(fn(down) {
+      case down {
+        process.ProcessDown(reason: process.Normal, ..) -> Error(False)
+        _ -> Error(True)
+      }
+    })
+  case process.selector_receive_forever(from: selector) {
+    Ok(result) ->
       Next(
         result,
         build_map_unordered_stream(
           MapUnordered(..state, workers_busy: state.workers_busy - 1),
         ),
       )
-    }
+    Error(True) ->
+      // Abnormal exit. The worker may have sent its result before
+      // crashing — check the subject with a brief timeout.
+      case process.receive(from: state.result_subject, within: 10) {
+        Ok(result) ->
+          Next(
+            result,
+            build_map_unordered_stream(
+              MapUnordered(..state, workers_busy: state.workers_busy - 1),
+            ),
+          )
+        Error(_) ->
+          // No result — genuine crash. Halt.
+          Done
+      }
+    Error(False) ->
+      // Normal exit DOWN — skip and wait for the actual result.
+      map_unordered_receive(state)
   }
 }
 
@@ -242,8 +279,9 @@ fn dispatch_unordered(state: MapUnordered(a, b)) -> MapUnordered(a, b) {
         Next(element, rest) -> {
           let subj = state.result_subject
           let func = state.f
-          let _pid =
+          let pid =
             process.spawn_unlinked(fn() { process.send(subj, func(element)) })
+          let _monitor = process.monitor(pid)
           dispatch_unordered(
             MapUnordered(
               ..state,
@@ -356,8 +394,36 @@ fn map_ordered_step(state: MapOrdered(a, b)) -> datastream.Step(b, Stream(b)) {
       case state.workers_busy {
         0 -> Done
         _ -> {
-          let #(idx, value) =
-            process.receive_forever(from: state.result_subject)
+          map_ordered_receive(state)
+        }
+      }
+  }
+}
+
+@target(erlang)
+fn map_ordered_receive(state: MapOrdered(a, b)) -> datastream.Step(b, Stream(b)) {
+  let selector =
+    process.new_selector()
+    |> process.select_map(state.result_subject, fn(msg) { Ok(msg) })
+    |> process.select_monitors(fn(down) {
+      case down {
+        process.ProcessDown(reason: process.Normal, ..) -> Error(False)
+        _ -> Error(True)
+      }
+    })
+  case process.selector_receive_forever(from: selector) {
+    Ok(#(idx, value)) ->
+      map_ordered_step(
+        MapOrdered(
+          ..state,
+          workers_busy: state.workers_busy - 1,
+          pending: dict.insert(state.pending, idx, value),
+        ),
+      )
+    Error(True) ->
+      // Abnormal exit. Check subject briefly before halting.
+      case process.receive(from: state.result_subject, within: 10) {
+        Ok(#(idx, value)) ->
           map_ordered_step(
             MapOrdered(
               ..state,
@@ -365,8 +431,11 @@ fn map_ordered_step(state: MapOrdered(a, b)) -> datastream.Step(b, Stream(b)) {
               pending: dict.insert(state.pending, idx, value),
             ),
           )
-        }
+        Error(_) -> Done
       }
+    Error(False) ->
+      // Normal exit DOWN — skip and wait for the actual result.
+      map_ordered_receive(state)
   }
 }
 
@@ -385,10 +454,11 @@ fn dispatch_ordered(state: MapOrdered(a, b)) -> MapOrdered(a, b) {
           let subj = state.result_subject
           let func = state.f
           let position = state.next_dispatch_index
-          let _pid =
+          let pid =
             process.spawn_unlinked(fn() {
               process.send(subj, #(position, func(element)))
             })
+          let _monitor = process.monitor(pid)
           dispatch_ordered(
             MapOrdered(
               ..state,

--- a/test/datastream/erlang/par_test.gleam
+++ b/test/datastream/erlang/par_test.gleam
@@ -546,62 +546,62 @@ pub fn merge_with_panics_on_zero_max_buffer_test() {
   did_panic |> should.be_true
 }
 
-// --- panic-in-f leaves the pipeline blocked (pinned behaviour) -----------
+// --- panic-in-f terminates the stream with Done (#156) -------------------
 //
-// Module-level docs already warn that a panicking `f(x)` leaves the
-// pipeline blocked. These tests pin that contract so a future
-// "trap worker exits" change has to update them deliberately. We
-// spawn the failing terminal in an unlinked process and assert it
-// does NOT complete within a generous timeout.
-//
-// The unlinked spawnee leaks one BEAM process per test; this is
-// acceptable because the leak is bounded (one per test) and isolated
-// from the test runner.
+// Worker panics are detected via process monitors. When a worker
+// crashes, the coordinator receives a DOWN message and halts the
+// stream instead of deadlocking.
 
 @target(erlang)
-fn does_not_complete(thunk: fn() -> Nil) -> Bool {
+fn completes_within(thunk: fn() -> Nil, timeout_ms: Int) -> Bool {
   let done = process.new_subject()
   let _pid =
     process.spawn_unlinked(fn() {
       thunk()
       process.send(done, Nil)
     })
-  case process.receive(from: done, within: 200) {
-    Ok(_) -> False
-    Error(_) -> True
+  case process.receive(from: done, within: timeout_ms) {
+    Ok(_) -> True
+    Error(_) -> False
   }
 }
 
 @target(erlang)
-pub fn map_unordered_with_hangs_when_f_panics_test() {
-  let hung =
-    does_not_complete(fn() {
-      let _result =
-        source.from_list([1, 2, 3])
-        |> par.map_unordered_with(
-          with: fn(_x) { panic as "boom" },
-          max_workers: 2,
-          max_buffer: 4,
-        )
-        |> fold.to_list
-      Nil
-    })
-  hung |> should.be_true
+pub fn map_unordered_with_halts_when_f_panics_test() {
+  let completed =
+    completes_within(
+      fn() {
+        let _result =
+          source.from_list([1, 2, 3])
+          |> par.map_unordered_with(
+            with: fn(_x) { panic as "boom" },
+            max_workers: 2,
+            max_buffer: 4,
+          )
+          |> fold.to_list
+        Nil
+      },
+      2000,
+    )
+  completed |> should.be_true
 }
 
 @target(erlang)
-pub fn map_ordered_with_hangs_when_f_panics_test() {
-  let hung =
-    does_not_complete(fn() {
-      let _result =
-        source.from_list([1, 2, 3])
-        |> par.map_ordered_with(
-          with: fn(_x) { panic as "boom" },
-          max_workers: 2,
-          max_buffer: 4,
-        )
-        |> fold.to_list
-      Nil
-    })
-  hung |> should.be_true
+pub fn map_ordered_with_halts_when_f_panics_test() {
+  let completed =
+    completes_within(
+      fn() {
+        let _result =
+          source.from_list([1, 2, 3])
+          |> par.map_ordered_with(
+            with: fn(_x) { panic as "boom" },
+            max_workers: 2,
+            max_buffer: 4,
+          )
+          |> fold.to_list
+        Nil
+      },
+      2000,
+    )
+  completed |> should.be_true
 }


### PR DESCRIPTION
## Summary

Detect worker panics via `process.monitor` in `par.map_unordered` and `par.map_ordered` to prevent permanent deadlock when a user function crashes.

## Changes

- Add `process.monitor(pid)` after spawning each worker in `dispatch_unordered` and `dispatch_ordered`
- Replace `process.receive_forever(from: result_subject)` with selector-based receive that handles both worker results and DOWN messages
- Normal exits (worker completed successfully): skip the DOWN and wait for the result
- Abnormal exits (worker panicked): attempt to retrieve any result sent before the crash; if none, halt the stream with `Done`
- Update module-level docs to reflect the new behavior
- Update tests: `hangs_when_f_panics` → `halts_when_f_panics` with a `completes_within` helper

## Design Decisions

- Normal DOWN messages from successfully completed workers are skipped (the result is already in the Subject mailbox)
- On abnormal DOWN, a brief `receive(within: 10)` check handles the race where the worker sent its result just before crashing
- The stream halts with `Done` on a genuine crash rather than propagating an error element, keeping the `Stream(b)` type unchanged

Closes #156
