### PR TITLE
docs: document self-close-on-Done contract for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,31 @@ pub fn main() {
 - Errors are carried in the element type, for example
   `Stream(Result(a, e))`
 
+### Close contract
+
+`source.resource` calls `close(state)` automatically when `next` returns
+`Done`. Combinators such as `flat_map` and `append` rely on this
+**self-close-on-Done** convention: they do NOT call `close` on an upstream
+that has already returned `Done`, because the source has already released
+its resources at that point.
+
+This means:
+
+- **`source.resource`** — safe. Resources are released on every
+  termination path (normal end, early exit, `take`, `sink.try_each`
+  error).
+- **`source.from_list`**, **`source.iterate`**, etc. — no resources to
+  close, so the convention is a no-op.
+- **Custom streams built with the internal `make` function** — `close` is
+  only called on early exit, NOT on natural exhaustion. If your custom
+  stream holds a resource, release it inside `next` when you return `Done`
+  (the same pattern `source.resource` uses internally).
+
+Combinators that hold multiple upstreams (`flat_map`, `zip`, `append`)
+close their upstreams in a documented order on early exit. On normal
+completion the self-close convention applies to each upstream
+independently.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -194,6 +194,13 @@ fn drop_while_pull(
 /// Honours the spec close ordering: `second` is opened only after
 /// `first` returns `Done` (and so has already closed itself); on early
 /// exit before `first` finishes, `second` is never opened.
+///
+/// **Close contract:** `first` self-closes when it returns `Done`;
+/// `append` does not call `close` on it again. After `first` is
+/// exhausted, `second`'s elements are yielded directly — when `second`
+/// itself returns `Done`, it self-closes in the same way. On early
+/// exit mid-`second`, the downstream's `close` call propagates to the
+/// active `second` node.
 pub fn append(first: Stream(a), second: Stream(a)) -> Stream(a) {
   datastream.make(pull: fn() { append_pull(first, second) }, close: fn() {
     datastream.close(first)
@@ -247,6 +254,13 @@ fn filter_map_pull(
 /// constructed until the previous one is exhausted. On early exit
 /// before the outer is `Done`, the active inner is closed first, then
 /// the outer.
+///
+/// **Close contract:** when an inner stream returns `Done`, `flat_map`
+/// does NOT call `close` on it — the source is expected to have
+/// released its resources when it returned `Done` (the self-close
+/// convention followed by `source.resource`). Custom streams built
+/// with `make` must release resources inside `next` on the `Done`
+/// path if they hold any.
 pub fn flat_map(over stream: Stream(a), with f: fn(a) -> Stream(b)) -> Stream(b) {
   flat_map_outer(stream, f)
 }


### PR DESCRIPTION
## Summary

Document the self-close-on-Done contract so users understand when `close` is and isn't called on streams.

## Changes

- Add "Close contract" subsection to README Semantics section explaining:
  - `source.resource` calls `close(state)` automatically when `next` returns `Done`
  - Combinators (`flat_map`, `append`, `zip`) do NOT call `close` on an upstream that returned `Done`
  - Custom streams built with `make` must release resources inside `next` on the `Done` path
- Add `Close contract` notes to `flat_map` and `append` doc comments so hexdocs readers see the behavior

## Context

Issues #154 and #155 reported apparent resource leaks in `flat_map` and `append`. Investigation showed these are by design (the self-close convention), but this contract was only documented in the internal `stream.gleam` module header comment — not visible to users via hexdocs or the README.
