### PR TITLE
feat(text): add records primitive for blank-line-separated framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **text.records** groups a `Stream(String)` of lines into a
+  `Stream(List(String))` of records separated by blank lines —
+  the framing used by Server-Sent Events (SSE), blank-line-separated
+  NDJSON variants, mbox / RFC 822 envelopes, and ad-hoc text wire
+  formats. Pair with `text.lines` for an end-to-end record decoder
+  (`stream |> text.lines |> text.records |> stream.map(parse_event)`).
+  Multiple consecutive blank lines collapse to a single separator
+  (no empty records, no spurious leading record), and a trailing
+  record without a terminating blank line is still emitted so the
+  last record is never silently dropped. The previous workaround —
+  `string.split("\n\n")` over a buffered `String` — required the
+  entire payload up-front; this primitive runs incrementally over
+  any chunked source. (#165)
+
 ## [0.3.0] - 2026-04-27
 
 ### Fixed

--- a/src/datastream/text.gleam
+++ b/src/datastream/text.gleam
@@ -154,6 +154,86 @@ fn reverse_concat(reversed_graphemes: List(String)) -> String {
   string.concat(list.reverse(reversed_graphemes))
 }
 
+/// Group a stream of lines into records separated by blank lines.
+///
+/// Each emitted `List(String)` carries the lines of one record in
+/// source order. Blank lines act as record separators and are not
+/// included in any record. Multiple consecutive blank lines collapse
+/// (no empty records are emitted, no spurious record at the start of
+/// the stream when the input begins with a blank line). A trailing
+/// record without a terminating blank line is still emitted so the
+/// last record is not silently dropped.
+///
+/// Pair with `text.lines` for SSE (Server-Sent Events),
+/// blank-line-separated NDJSON variants, mbox / RFC 822-style
+/// envelopes, and similar wire formats:
+///
+/// ```gleam
+/// stream
+/// |> text.lines
+/// |> text.records
+/// |> stream.map(parse_event)
+/// ```
+///
+/// Chunk-boundary handling: this operator runs entirely on the line
+/// stream, so it inherits the chunk-boundary correctness of `lines`
+/// — a record terminator that lands across two chunks is still
+/// recognised because `lines` already absorbed the boundary before
+/// emitting.
+pub fn records(over stream: Stream(String)) -> Stream(List(String)) {
+  records_active(stream, [], False)
+}
+
+fn records_active(
+  source: Stream(String),
+  acc_rev: List(String),
+  source_drained: Bool,
+) -> Stream(List(String)) {
+  datastream.make(
+    pull: fn() { records_pull(source, acc_rev, source_drained) },
+    close: fn() { maybe_close(source, source_drained) },
+  )
+}
+
+fn records_pull(
+  source: Stream(String),
+  acc_rev: List(String),
+  source_drained: Bool,
+) -> Step(List(String), Stream(List(String))) {
+  case source_drained {
+    True -> finish_records(source, acc_rev)
+    False ->
+      case datastream.pull(source) {
+        Done -> finish_records(source, acc_rev)
+        Next("", source_rest) ->
+          case acc_rev {
+            // Leading blank or back-to-back separator: skip without
+            // emitting an empty record and keep pulling. The recursive
+            // call only happens after the source has advanced, so this
+            // cannot loop on a single value.
+            [] -> records_pull(source_rest, [], False)
+            _ ->
+              Next(
+                list.reverse(acc_rev),
+                records_active(source_rest, [], False),
+              )
+          }
+        Next(line, source_rest) ->
+          records_pull(source_rest, [line, ..acc_rev], False)
+      }
+  }
+}
+
+fn finish_records(
+  source: Stream(String),
+  acc_rev: List(String),
+) -> Step(List(String), Stream(List(String))) {
+  case acc_rev {
+    [] -> Done
+    _ -> Next(list.reverse(acc_rev), records_active(source, [], True))
+  }
+}
+
 /// Split a stream of strings on `delimiter`, emitting every separated
 /// piece including the empty pieces between consecutive delimiters and
 /// at the start / end of the input.

--- a/test/datastream/text_test.gleam
+++ b/test/datastream/text_test.gleam
@@ -101,6 +101,86 @@ pub fn lines_cr_at_end_followed_by_all_empty_chunks_test() {
   |> should.equal(["hello"])
 }
 
+// --- records ---------------------------------------------------------------
+
+pub fn records_two_single_line_records_test() {
+  from_list(["a", "", "b"])
+  |> text.records
+  |> fold.to_list
+  |> should.equal([["a"], ["b"]])
+}
+
+pub fn records_multiline_records_test() {
+  from_list(["a", "b", "", "c"])
+  |> text.records
+  |> fold.to_list
+  |> should.equal([["a", "b"], ["c"]])
+}
+
+pub fn records_trailing_blank_does_not_emit_empty_record_test() {
+  from_list(["a", "", "b", ""])
+  |> text.records
+  |> fold.to_list
+  |> should.equal([["a"], ["b"]])
+}
+
+pub fn records_leading_blank_is_ignored_test() {
+  from_list(["", "a"])
+  |> text.records
+  |> fold.to_list
+  |> should.equal([["a"]])
+}
+
+pub fn records_consecutive_blanks_collapse_test() {
+  from_list(["a", "", "", "b"])
+  |> text.records
+  |> fold.to_list
+  |> should.equal([["a"], ["b"]])
+}
+
+pub fn records_only_blanks_yields_no_records_test() {
+  from_list(["", "", ""]) |> text.records |> fold.to_list |> should.equal([])
+}
+
+pub fn records_empty_source_yields_no_records_test() {
+  from_list([]) |> text.records |> fold.to_list |> should.equal([])
+}
+
+pub fn records_single_blank_yields_no_records_test() {
+  from_list([""]) |> text.records |> fold.to_list |> should.equal([])
+}
+
+pub fn records_no_terminating_blank_emits_trailing_record_test() {
+  from_list(["a", "b"])
+  |> text.records
+  |> fold.to_list
+  |> should.equal([["a", "b"]])
+}
+
+/// Issue #165 reproduction: SSE-style framing where each event is a
+/// block of `field: value` lines separated from the next event by a
+/// blank line. The previous user-supplied `string.split("\n\n")`
+/// workaround required the entire payload buffered up front; with
+/// `text.records` an SSE consumer composes with `text.lines` and
+/// streams record-by-record.
+pub fn records_sse_style_framing_test() {
+  from_list([
+    "event: heartbeat\n",
+    "data: 1\n",
+    "\n",
+    "event: post\n",
+    "data: hello\n",
+    "data: world\n",
+  ])
+  |> text.lines
+  |> text.records
+  |> fold.to_list
+  |> should.equal([
+    ["event: heartbeat", "data: 1"],
+    ["event: post", "data: hello", "data: world"],
+  ])
+}
+
 // --- split -----------------------------------------------------------------
 
 pub fn split_on_comma_yields_pieces_test() {


### PR DESCRIPTION
## Summary

Fixes Issue #165. datastream had `text.lines` (line framing) and
`binary.length_prefixed` (length-prefixed framing), but nothing for
the equally common "line records separated by a blank line"
framing used by Server-Sent Events, blank-line-separated NDJSON,
mbox / RFC 822 envelopes, and ad-hoc text wire formats. Every
consumer ended up writing the same `take_while_not_empty` + emit +
`drop_while_empty` loop, and the user-supplied `string.split
("\n\n")` workaround in the issue requires the entire payload
buffered up front.

This PR adds `text.records` so the natural composition

```gleam
stream
|> text.lines
|> text.records
|> stream.map(parse_event)
```

decodes records incrementally from any chunked source.

## Semantics

- Each emitted `List(String)` carries the lines of one record in
  source order.
- A blank line acts as a record separator and is **not** included
  in any record.
- Multiple consecutive blank lines collapse to a single separator
  (no empty records emitted, no spurious leading record when the
  input begins with a blank line).
- A trailing record without a terminating blank line is still
  emitted so the last record is never silently dropped.

## Changes

- `src/datastream/text.gleam`: new `records/1` plus the supporting
  active/pull pair (`records_active`, `records_pull`,
  `finish_records`). Implementation is parallel to the existing
  `lines` shape — same `datastream.make` constructor, same
  `maybe_close` reuse, same accumulator-in-reverse pattern. The
  recursive `records_pull` only re-enters after the source has
  advanced, so consecutive blank lines cannot loop on a single
  value.
- `test/datastream/text_test.gleam`: nine new tests covering:
  - two single-line records (`["a","","b"] → [["a"],["b"]]`),
  - multi-line records (`["a","b","","c"] → [["a","b"],["c"]]`),
  - trailing blank does not emit an empty record,
  - leading blank is ignored,
  - consecutive blanks collapse,
  - all-blank input → no records,
  - empty source → no records,
  - single blank → no records,
  - no terminating blank → trailing record still emitted,
  - issue-#165 SSE-style reproduction (`text.lines |> text.records`
    over a chunked event stream produces the expected event
    blocks).
- `CHANGELOG.md`: documents the new primitive under `### Added` in
  the Unreleased section, including the SSE composition example
  and the chunk-boundary correctness story.

## Design Decisions

- **Operate on `Stream(String)` of lines, not raw text chunks.**
  The issue suggested both shapes; the line-stream variant
  composes cleanly with the existing `text.lines` (which already
  owns the chunk-boundary correctness for `\r`/`\n`/`\r\n`), so
  `text.records` inherits that correctness for free. Adding a
  second variant that re-derives line scanning would duplicate
  the boundary logic.
- **Skip empty records, don't emit them.** SSE / mbox / RFC 822
  treat consecutive blank lines as a single separator; emitting
  empty records would surprise consumers and force every caller
  to filter them out. The issue's described use case (SSE
  parser) explicitly wants no-op handling for keep-alive lines.
- **Keep the trailing record.** Mirrors `text.lines`'s "partial
  trailing line emitted" behaviour — silently dropping the last
  record on EOF would be a footgun on real network sources where
  the closing blank is often absent.

## Test Plan

- [x] `gleam format --check src/ test/` — clean.
- [x] `gleam test` — 362 passes (9 new for #165).
- [x] `gleam run -m glinter` — no issues.
- [x] Hand-checked the SSE round-trip test against the issue's
  reproduction shape: chunked `["event: …\n", "data: …\n", "\n",
  "event: …\n", "data: …\n", "data: …\n"]` becomes the expected
  two-record list, no payload buffering required.

Closes #165
