### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-28
+
 ### Added
 
 - **text.records** groups a `Stream(String)` of lines into a

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "datastream"
-version = "0.3.0"
+version = "0.4.0"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }


### PR DESCRIPTION
## Release v0.4.0

One additive feature: `text.records`, the missing primitive for
blank-line-separated framing (SSE / NDJSON-with-record-boundaries
/ mbox / RFC 822 envelopes / ad-hoc text wire formats).

### Highlights — non-breaking

- **`text.records` groups a `Stream(String)` of lines into a
  `Stream(List(String))` of records separated by blank lines
  (#165).** The natural composition

  ```gleam
  stream
  |> text.lines
  |> text.records
  |> stream.map(parse_event)
  ```

  decodes records incrementally from any chunked source. Multiple
  consecutive blank lines collapse to a single separator (no
  empty records emitted, no spurious leading record), and a
  trailing record without a terminating blank line is still
  emitted so the last record is never silently dropped. The
  previous user-side workaround (`string.split("\n\n")` over a
  buffered `String`) required the entire payload up front; this
  primitive runs streaming.

### Coverage

- 362 unit tests (up from 353 on v0.3.0), 9 new for #165.
- `gleam format --check src/ test/`, `gleam test`, and `gleam run -m glinter`
  all green on the release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
