### PR TITLE
feat(fold): add to_string, to_string_tree, and to_bit_array terminal folds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **fold.to_string**, **fold.to_string_tree**, and **fold.to_bit_array**
+  are new terminal folds that materialise a `Stream(String)` /
+  `Stream(BitArray)` into a single concatenated value without going
+  through `to_list |> string.concat`. They accumulate into a
+  `StringTree` / `BytesTree` internally (Erlang `iolist_to_binary`
+  on the BEAM, incremental string concatenation on JavaScript), so
+  cost is `O(total length)` rather than the `O(n²)` shape of
+  `to_list`-then-concat. The shape is the natural completion of a
+  text- or byte-output pipeline (NDJSON / CSV export, log
+  aggregation, HTTP response bodies). `to_string_tree` is provided
+  for callers who want to keep building the tree before producing
+  the final `String`. (#168)
+
 ## [0.4.0] - 2026-04-28
 
 ### Added

--- a/src/datastream/fold.gleam
+++ b/src/datastream/fold.gleam
@@ -10,8 +10,10 @@
 //// implicit caching.
 
 import datastream.{type Stream, Done, Next}
+import gleam/bytes_tree
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/string_tree.{type StringTree}
 
 /// Materialise the stream into a list, preserving source order.
 ///
@@ -21,6 +23,46 @@ pub fn to_list(stream: Stream(a)) -> List(a) {
   stream
   |> fold(from: [], with: fn(acc, element) { [element, ..acc] })
   |> list.reverse
+}
+
+/// Materialise a `Stream(String)` into a single concatenated `String`.
+///
+/// Internally accumulates into a `StringTree`, so concatenation is
+/// `O(total length)` rather than the `O(n²)` shape that
+/// `to_list |> string.concat` produces on long streams. Pulls every
+/// element; for terminating streams only. Returns `""` on an empty stream.
+pub fn to_string(stream: Stream(String)) -> String {
+  stream
+  |> to_string_tree
+  |> string_tree.to_string
+}
+
+/// Materialise a `Stream(String)` into a `StringTree`, preserving source
+/// order without flattening.
+///
+/// Useful when the caller wants to keep building the tree — prepending a
+/// header, joining with another tree — before producing the final
+/// `String`. Returns the empty tree on an empty stream.
+pub fn to_string_tree(stream: Stream(String)) -> StringTree {
+  stream
+  |> fold(from: string_tree.new(), with: fn(acc, chunk) {
+    string_tree.append(acc, chunk)
+  })
+}
+
+/// Materialise a `Stream(BitArray)` into a single concatenated `BitArray`.
+///
+/// Internally accumulates into a `BytesTree`, which bridges to Erlang's
+/// `iolist_to_binary` on the BEAM and concatenates incrementally on
+/// JavaScript — both avoid the quadratic cost of materialising into a
+/// list and concatenating after the fact. Pulls every element; for
+/// terminating streams only. Returns `<<>>` on an empty stream.
+pub fn to_bit_array(stream: Stream(BitArray)) -> BitArray {
+  stream
+  |> fold(from: bytes_tree.new(), with: fn(acc, chunk) {
+    bytes_tree.append(acc, chunk)
+  })
+  |> bytes_tree.to_bit_array
 }
 
 /// Count the number of elements the stream produces.

--- a/test/datastream/fold_test.gleam
+++ b/test/datastream/fold_test.gleam
@@ -1,6 +1,7 @@
 import datastream.{Done, Next}
 import datastream/fold
 import gleam/option.{None, Some}
+import gleam/string_tree
 import gleeunit
 import gleeunit/should
 
@@ -27,6 +28,58 @@ pub fn to_list_returns_elements_in_source_order_test() {
 
 pub fn to_list_on_empty_returns_empty_test() {
   from_list([]) |> fold.to_list |> should.equal([])
+}
+
+pub fn to_string_concatenates_chunks_in_source_order_test() {
+  from_list(["a", "bc", "def"]) |> fold.to_string |> should.equal("abcdef")
+}
+
+pub fn to_string_on_empty_returns_empty_string_test() {
+  from_list([]) |> fold.to_string |> should.equal("")
+}
+
+pub fn to_string_preserves_unicode_test() {
+  from_list(["こん", "にち", "は"])
+  |> fold.to_string
+  |> should.equal("こんにちは")
+}
+
+pub fn to_string_drives_stream_to_completion_test() {
+  // Confirms `to_string` is a full-traversal reducer (not short-circuiting):
+  // every chunk must end up in the result.
+  from_list(["1", "2", "3", "4", "5"])
+  |> fold.to_string
+  |> should.equal("12345")
+}
+
+pub fn to_string_tree_preserves_source_order_test() {
+  from_list(["a", "b", "c"])
+  |> fold.to_string_tree
+  |> string_tree.to_string
+  |> should.equal("abc")
+}
+
+pub fn to_string_tree_on_empty_returns_empty_tree_test() {
+  from_list([])
+  |> fold.to_string_tree
+  |> string_tree.is_empty
+  |> should.be_true
+}
+
+pub fn to_bit_array_concatenates_chunks_in_source_order_test() {
+  from_list([<<1, 2>>, <<3>>, <<4, 5, 6>>])
+  |> fold.to_bit_array
+  |> should.equal(<<1, 2, 3, 4, 5, 6>>)
+}
+
+pub fn to_bit_array_on_empty_returns_empty_bit_array_test() {
+  from_list([]) |> fold.to_bit_array |> should.equal(<<>>)
+}
+
+pub fn to_bit_array_preserves_byte_boundaries_test() {
+  from_list([<<0xde, 0xad>>, <<0xbe, 0xef>>])
+  |> fold.to_bit_array
+  |> should.equal(<<0xde, 0xad, 0xbe, 0xef>>)
 }
 
 pub fn count_returns_number_of_elements_test() {


### PR DESCRIPTION
## Summary

Adds three new terminal folds to `datastream/fold` so a
`Stream(String)` or `Stream(BitArray)` can be materialised into a
single value without the `to_list |> string.concat` workaround
called out in #168:

- `fold.to_string(stream: Stream(String)) -> String`
- `fold.to_string_tree(stream: Stream(String)) -> StringTree`
- `fold.to_bit_array(stream: Stream(BitArray)) -> BitArray`

## Changes

- `src/datastream/fold.gleam`: implement the three folds. Both
  `to_string` and `to_bit_array` accumulate into a `string_tree` /
  `bytes_tree` via the existing `fold` helper, so cost is
  `O(total length)` instead of the `O(n²)` shape of materialising
  into a list and concatenating after the fact. `to_string_tree`
  is exposed for callers who want to keep composing the tree
  before producing the final `String`.
- `test/datastream/fold_test.gleam`: 9 new tests covering empty,
  single-element, multi-element, Unicode, byte-boundary, and
  `string_tree.is_empty` cases.
- `CHANGELOG.md`: entry under `[Unreleased]` describing the
  addition and the cost rationale.

## Design Decisions

- Internal accumulator: `string_tree` / `bytes_tree` are the
  cross-target string-builder primitives in `gleam_stdlib` and map
  onto Erlang `iolist_to_binary` on the BEAM and incremental
  string concatenation on JavaScript. They preserve the
  streaming-without-materialising contract that the README
  emphasises.
- Sink vs. fold: the issue notes `sink.println` is the only
  in-memory accumulation today, but it writes to stdout. Since
  these new folds return values, `fold` (the value-returning
  counterpart of `sink`) is their natural home.
- `to_string_tree` is included even though the issue lists it as
  optional, because it's the single allocation-friendly
  intermediate every caller of `to_string` would otherwise
  reimplement.

## Verification

- `just all` passes (format-check, glinter, build for both
  Erlang and JavaScript, `gleam test --target erlang` 371 passed,
  `gleam test --target javascript` 265 passed, docs build).

Closes #168
