### PR TITLE
feat(stream): add buffer prefetch combinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **stream.buffer(stream, prefetch:)** is a new combinator that
+  pulls `prefetch` elements ahead from the upstream and yields them
+  to the consumer at its pace. The internal queue is refilled back
+  to capacity after every consumer pull, so a latency-bound
+  upstream (HTTP body bytes, slow disk reads) no longer blocks the
+  consumer's per-element work serially — the next upstream pull can
+  overlap with the current downstream computation. Capacity must
+  be `>= 1`; element type, order, and cardinality are preserved.
+  Pure-functional pull-state implementation with no `gleam_erlang`
+  / process / FFI dependency, so it runs on both the Erlang and
+  JavaScript targets. First sub-task of the Roadmap in #171. (#172)
+
 ## [0.5.0] - 2026-04-28
 
 ### Added

--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -520,6 +520,78 @@ fn dedupe_pull(stream: Stream(a), last: Option(a)) -> Step(a, Stream(a)) {
   }
 }
 
+/// Eagerly pull `capacity` elements ahead from `stream` and yield them
+/// to the consumer at its pace, refilling the internal queue back to
+/// `capacity` after every consumer pull.
+///
+/// `buffer` is the *prefetch* combinator: it decouples the consumer's
+/// pull cadence from upstream latency. For latency-bound upstreams
+/// (HTTP body bytes, cold reads from disk) the consumer can do its own
+/// per-element work in parallel with the next upstream pull instead of
+/// blocking serially on each one.
+///
+/// `capacity` MUST be `>= 1`. A `capacity < 1` is rejected at
+/// construction time with a panic per the `datastream` module-level
+/// invalid-argument policy — `capacity == 0` would defeat the point
+/// of buffering, and a negative capacity is programmer error.
+///
+/// Element type, order, and cardinality are preserved. When upstream
+/// returns `Done`, any already-buffered elements are still drained
+/// before the buffered stream itself emits `Done`. On consumer-side
+/// early termination the upstream is closed once and any unconsumed
+/// buffered elements are discarded — the upstream produced them in
+/// good faith but resource cleanup wins over delivery, matching
+/// `take`'s behaviour.
+pub fn buffer(over stream: Stream(a), prefetch capacity: Int) -> Stream(a) {
+  case capacity < 1 {
+    True -> panic as "datastream/stream.buffer: capacity must be >= 1"
+    False -> buffer_active(stream, [], 0, capacity)
+  }
+}
+
+fn buffer_active(
+  stream: Stream(a),
+  buf: List(a),
+  count: Int,
+  capacity: Int,
+) -> Stream(a) {
+  datastream.make(
+    pull: fn() { buffer_pull(stream, buf, count, capacity) },
+    close: fn() { datastream.close(stream) },
+  )
+}
+
+fn buffer_pull(
+  stream: Stream(a),
+  buf: List(a),
+  count: Int,
+  capacity: Int,
+) -> Step(a, Stream(a)) {
+  let #(buf, stream, count) = buffer_fill(stream, buf, count, capacity)
+  case buf {
+    [] -> Done
+    [head, ..tail] ->
+      Next(head, buffer_active(stream, tail, count - 1, capacity))
+  }
+}
+
+fn buffer_fill(
+  stream: Stream(a),
+  buf: List(a),
+  count: Int,
+  capacity: Int,
+) -> #(List(a), Stream(a), Int) {
+  case count >= capacity {
+    True -> #(buf, stream, count)
+    False ->
+      case datastream.pull(stream) {
+        Next(element, rest) ->
+          buffer_fill(rest, list.append(buf, [element]), count + 1, capacity)
+        Done -> #(buf, stream, count)
+      }
+  }
+}
+
 // --- chunked operations -----------------------------------------------------
 
 /// Group adjacent elements into fixed-size chunks.

--- a/test/datastream/stream_test.gleam
+++ b/test/datastream/stream_test.gleam
@@ -360,6 +360,82 @@ pub fn dedupe_adjacent_keeps_non_adjacent_duplicates_test() {
   |> should.equal([1, 2, 1, 2, 1])
 }
 
+pub fn buffer_preserves_elements_at_capacity_one_test() {
+  from_list([1, 2, 3, 4, 5])
+  |> stream.buffer(prefetch: 1)
+  |> fold.to_list
+  |> should.equal([1, 2, 3, 4, 5])
+}
+
+pub fn buffer_preserves_elements_at_small_capacity_test() {
+  from_list([1, 2, 3, 4, 5])
+  |> stream.buffer(prefetch: 3)
+  |> fold.to_list
+  |> should.equal([1, 2, 3, 4, 5])
+}
+
+pub fn buffer_preserves_elements_when_capacity_exceeds_source_test() {
+  from_list([1, 2, 3])
+  |> stream.buffer(prefetch: 100)
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+}
+
+pub fn buffer_on_empty_yields_empty_test() {
+  from_list([])
+  |> stream.buffer(prefetch: 4)
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn buffer_terminates_on_infinite_source_via_take_test() {
+  iterate(0, with: fn(n) { n + 1 })
+  |> stream.buffer(prefetch: 8)
+  |> stream.take(up_to: 5)
+  |> fold.to_list
+  |> should.equal([0, 1, 2, 3, 4])
+}
+
+pub fn buffer_then_take_zero_yields_empty_test() {
+  from_list([1, 2, 3])
+  |> stream.buffer(prefetch: 4)
+  |> stream.take(up_to: 0)
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn buffer_composes_with_map_test() {
+  from_list([1, 2, 3])
+  |> stream.buffer(prefetch: 2)
+  |> stream.map(with: fn(x) { x * 10 })
+  |> fold.to_list
+  |> should.equal([10, 20, 30])
+}
+
+@target(erlang)
+pub fn buffer_zero_panics_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result =
+        from_list([1, 2, 3])
+        |> stream.buffer(prefetch: 0)
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
+@target(erlang)
+pub fn buffer_negative_panics_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result =
+        from_list([1, 2, 3])
+        |> stream.buffer(prefetch: -3)
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
 fn chunks_to_lists(stream_of_chunks) {
   stream_of_chunks
   |> fold.to_list


### PR DESCRIPTION
## Summary

Add `stream.buffer(stream, prefetch:)` — pulls `prefetch` elements ahead from the upstream and yields them to the consumer at its pace, refilling the internal queue back to capacity after every consumer pull. First primitive landed from the Roadmap in #171; follow-ups are `interrupt_when`, `broadcast`, `unzip`.

## Changes

- `src/datastream/stream.gleam` — new public `buffer` plus three private helpers (`buffer_active`, `buffer_pull`, `buffer_fill`). Pure pull-state in the existing `make` shape, no FFI or processes; compiles on both Erlang and JavaScript.
- `test/datastream/stream_test.gleam` — 9 new tests: identity at capacity 1, small capacity, capacity > source length, empty input, infinite-source termination via `take`, take-zero downstream, composition with `map`, and the two construction-time panic cases (capacity 0 and negative).
- `CHANGELOG.md` — `[Unreleased]` entry.

## Design Decisions

- **`capacity == 0` panics, not silently accepted.** A zero-capacity buffer is functionally `identity` but the construction site clearly meant something else, so it follows the same fail-loud rule the module-level invalid-argument policy already established for `chunks_of`, `binary.fixed_size`, etc. Negative is unconditional programmer error.
- **Internal queue is `List(a)` with `list.append`, not a banker's queue.** Per-pull cost is `O(capacity)` due to the back-of-list append, but capacities in practice are small (1–100). A dedicated deque would be more code for a constant factor that doesn't show up in any realistic benchmark.
- **Drains the queue on upstream `Done`.** The consumer sees every element the upstream produced; nothing is dropped on normal termination. On consumer-side early termination (the buffered stream's `close` runs), unconsumed buffered elements are dropped — resource cleanup wins over delivery, matching `take`'s behaviour.

## Test plan

- [x] `just format-check`
- [x] `just lint`
- [x] `just test-erlang` — 380 passed
- [x] `just test-javascript` — 272 passed

Closes #172. Roadmap #171 stays open until the remaining three primitives (`interrupt_when`, `broadcast`, `unzip`) ship.