### PR TITLE
feat(stream): add interrupt_when async-cancellation combinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Pure-functional pull-state implementation with no `gleam_erlang`
   / process / FFI dependency, so it runs on both the Erlang and
   JavaScript targets. First sub-task of the Roadmap in #171. (#172)
+- **stream.interrupt_when(stream, signal:)** is a new combinator
+  that terminates `stream` on the first `True` element from
+  `signal`. The signal is `Stream(Bool)` (not `Stream(Nil)` as the
+  Roadmap originally proposed) — the boolean carries the
+  not-yet / fire-now distinction that `Done` cannot in a pull-based
+  model where `Done` is terminal. On every consumer pull the signal
+  is checked first: a `True` element closes both the rest of the
+  signal and `stream` and yields `Done`; a `False` element is
+  consumed and the pull descends into `stream`; a `Done` from the
+  signal switches the combinator into a pass-through over `stream`
+  (the signal is never re-pulled, matching the `Step` contract).
+  Counterpart of `take_while` for *external* termination signals
+  (timer expiry, parent-shutdown probe, cancel-token bridge) where
+  the decision to stop doesn't depend on the pulled element.
+  Cross-target: pure-functional pull-state, no `gleam_erlang` /
+  process / FFI dependency. Second sub-task of the Roadmap in
+  #171. (#174)
 
 ## [0.5.0] - 2026-04-28
 

--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -592,6 +592,84 @@ fn buffer_fill(
   }
 }
 
+/// Terminate `stream` on the first `True` element from `signal`.
+///
+/// `interrupt_when` is the *external* counterpart of `take_while`:
+/// `take_while` ends a stream when a *pulled* element fails a
+/// predicate; `interrupt_when` ends it when an *unrelated* stream
+/// produces a fire signal — typically a timer expiry, a parent-
+/// shutdown probe, or a cancel-token bridge built with
+/// `from_subject`.
+///
+/// On every consumer pull, `signal` is checked first:
+///
+/// - `signal` yields `True` → both `stream` and the rest of
+///   `signal` are closed and the consumer sees `Done` immediately.
+/// - `signal` yields `False` → that signal element is consumed; the
+///   pull descends into `stream` and yields its next element.
+///   Subsequent consumer pulls see the rest of `signal`.
+/// - `signal` returns `Done` → the consumer pull descends into
+///   `stream`. `signal` is then ignored on subsequent pulls; a
+///   `Done` producer is never re-pulled per the `Step` contract.
+///
+/// The `Stream(Bool)` shape (rather than `Stream(Nil)`) is what
+/// makes counted / time-based signals representable in the pull
+/// model — `Done` cannot mean "not yet, ask again later" because
+/// `Done` is terminal, so a "fire after N consumer pulls" signal
+/// is built as `False`-stream-of-length-N followed by `True`.
+///
+/// **Close ordering:** on consumer-side early termination `signal`
+/// is closed first, then `stream` — right-before-left, matching
+/// `zip` and `flat_map`.
+pub fn interrupt_when(
+  in stream: Stream(a),
+  signal signal: Stream(Bool),
+) -> Stream(a) {
+  interrupt_active(stream, Some(signal))
+}
+
+fn interrupt_active(
+  stream: Stream(a),
+  signal: Option(Stream(Bool)),
+) -> Stream(a) {
+  datastream.make(pull: fn() { interrupt_pull(stream, signal) }, close: fn() {
+    case signal {
+      Some(sig) -> datastream.close(sig)
+      None -> Nil
+    }
+    datastream.close(stream)
+  })
+}
+
+fn interrupt_pull(
+  stream: Stream(a),
+  signal: Option(Stream(Bool)),
+) -> Step(a, Stream(a)) {
+  case signal {
+    None -> interrupt_pull_stream(stream, None)
+    Some(sig) ->
+      case datastream.pull(sig) {
+        Next(True, sig_rest) -> {
+          datastream.close(sig_rest)
+          datastream.close(stream)
+          Done
+        }
+        Next(False, sig_rest) -> interrupt_pull_stream(stream, Some(sig_rest))
+        Done -> interrupt_pull_stream(stream, None)
+      }
+  }
+}
+
+fn interrupt_pull_stream(
+  stream: Stream(a),
+  signal: Option(Stream(Bool)),
+) -> Step(a, Stream(a)) {
+  case datastream.pull(stream) {
+    Next(element, rest) -> Next(element, interrupt_active(rest, signal))
+    Done -> Done
+  }
+}
+
 // --- chunked operations -----------------------------------------------------
 
 /// Group adjacent elements into fixed-size chunks.

--- a/test/datastream/stream_test.gleam
+++ b/test/datastream/stream_test.gleam
@@ -436,6 +436,82 @@ pub fn buffer_negative_panics_test() {
   did_panic |> should.be_true
 }
 
+fn signal_after(n: Int) -> Stream(Bool) {
+  // Yields False for the first `n` pulls, then True forever.
+  datastream.unfold(from: 0, with: fn(count) {
+    case count >= n {
+      True -> Next(element: True, state: count + 1)
+      False -> Next(element: False, state: count + 1)
+    }
+  })
+}
+
+fn signal_never() -> Stream(Bool) {
+  datastream.unfold(from: Nil, with: fn(_) { Done })
+}
+
+fn signal_immediate() -> Stream(Bool) {
+  signal_after(0)
+}
+
+pub fn interrupt_when_immediate_signal_yields_empty_test() {
+  from_list([1, 2, 3])
+  |> stream.interrupt_when(signal: signal_immediate())
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn interrupt_when_signal_never_is_identity_test() {
+  from_list([1, 2, 3])
+  |> stream.interrupt_when(signal: signal_never())
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+}
+
+pub fn interrupt_when_signal_fires_after_one_pull_test() {
+  iterate(0, with: fn(n) { n + 1 })
+  |> stream.interrupt_when(signal: signal_after(1))
+  |> fold.to_list
+  |> should.equal([0])
+}
+
+pub fn interrupt_when_signal_fires_after_three_pulls_test() {
+  iterate(0, with: fn(n) { n + 1 })
+  |> stream.interrupt_when(signal: signal_after(3))
+  |> fold.to_list
+  |> should.equal([0, 1, 2])
+}
+
+pub fn interrupt_when_on_empty_stream_yields_empty_test() {
+  from_list([])
+  |> stream.interrupt_when(signal: signal_immediate())
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn interrupt_when_on_empty_stream_with_dead_signal_yields_empty_test() {
+  from_list([])
+  |> stream.interrupt_when(signal: signal_never())
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn interrupt_when_composes_with_take_test() {
+  iterate(0, with: fn(n) { n + 1 })
+  |> stream.interrupt_when(signal: signal_after(10))
+  |> stream.take(up_to: 4)
+  |> fold.to_list
+  |> should.equal([0, 1, 2, 3])
+}
+
+pub fn interrupt_when_signal_wins_over_take_test() {
+  iterate(0, with: fn(n) { n + 1 })
+  |> stream.interrupt_when(signal: signal_after(2))
+  |> stream.take(up_to: 100)
+  |> fold.to_list
+  |> should.equal([0, 1])
+}
+
 fn chunks_to_lists(stream_of_chunks) {
   stream_of_chunks
   |> fold.to_list


### PR DESCRIPTION
## Summary

Add `stream.interrupt_when(stream, signal:)` — terminate `stream` on the first `True` element from `signal`. Counterpart of `take_while` for *external* termination signals (timer expiry, parent-shutdown probe, cancel-token bridge) where the decision to stop doesn't depend on the pulled element. Second primitive landed from the Roadmap in #171.

## Changes

- `src/datastream/stream.gleam` — new public `interrupt_when` plus three private helpers (`interrupt_active`, `interrupt_pull`, `interrupt_pull_stream`). Pure pull-state in the existing `make` shape, no FFI or processes; compiles on both Erlang and JavaScript.
- `test/datastream/stream_test.gleam` — 8 new tests covering immediate fire, never-fires (Done signal), fire after N pulls, both-targets empty cases, composition with downstream `take`, and signal-wins-over-take. Plus three signal-builder helpers (`signal_after`, `signal_never`, `signal_immediate`).
- `CHANGELOG.md` — `[Unreleased]` entry documenting the `Stream(Bool)` API choice.

## Design Decisions

- **`signal: Stream(Bool)`, not `Stream(Nil)`.** The Roadmap in #171 sketched `Stream(Nil)` where each `Next` would mean *fire*. That works for *immediate* signals but is unrepresentable for any *delayed* signal: the only other state in the `Step(Nil, _)` enum is `Done`, and `Done` is terminal — the spec contract is that a `Done` producer must not be re-pulled. So a 'fire after the consumer has pulled 3 times' signal cannot be `Done, Done, Done, Next, …` because each `Done` ends the producer. The `Stream(Bool)` shape carries the not-yet / fire-now distinction explicitly in the element. fs2's `Stream[F, Boolean]` has the same shape for the same reason.
- **`Done` from signal switches to a pass-through over `stream`.** Once signal is exhausted, the combinator behaves as identity on `stream`. We do not re-pull the signal — that would violate the `Step` contract.
- **Close ordering on early termination: signal first, stream second.** Right-before-left, matching `zip` and `flat_map`.

## Test plan

- [x] `just format-check`
- [x] `just lint`
- [x] `just test-erlang` — 388 passed
- [x] `just test-javascript` — 280 passed

Closes #174. Roadmap #171 stays open until `broadcast` and `unzip` ship.