### PR TITLE
feat(stream): add cross-target broadcast, unzip, and bridge_subject_stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Cross-target: pure-functional pull-state, no `gleam_erlang` /
   process / FFI dependency. Second sub-task of the Roadmap in
   #171. (#174)
+- **stream.broadcast(stream, n)** is a new fan-out combinator: it
+  splits a `Stream(a)` into `n` independent consumer streams that
+  share a single underlying source. Each consumer pulls at its own
+  pace; an element produced by the source is observed by every
+  still-alive consumer in order. Use it for the observability-tap
+  shape (one consumer drives the main pipeline, another writes
+  metrics or logs) without forcing the source to be re-evaluated,
+  which matters for resource-backed and otherwise non-replayable
+  sources. `n` must be `>= 1`; per-consumer queue is currently
+  unbounded — bounded variant with an explicit drop policy is
+  follow-up work. Cross-target via the new `internal/ref` mutable
+  cell (process-dictionary on Erlang, plain object on JavaScript).
+  Third sub-task of the Roadmap in #171. (#176)
+- **stream.unzip(stream)** splits a `Stream(#(a, b))` into a pair
+  `#(Stream(a), Stream(b))`, the counterpart of `stream.zip`. Built
+  on `broadcast` under the hood, so the same per-consumer
+  unbounded-queue caveat applies (a pipeline that drives one half
+  to completion while the other half lags accumulates the lagging
+  half's queue). Cross-target. Fourth sub-task of the Roadmap
+  in #171. (#177)
+- **datastream/erlang/source.bridge_subject_stream** is a
+  workaround helper for the `from_subject` × `par.*` / `time.*` /
+  `source.timeout` incompatibility documented on `from_subject`.
+  Materialises the upstream into a `List(a)` inside the calling
+  (subject-owning) process and reopens it as a process-safe
+  list-backed stream, which can then be composed with `par.*` /
+  `time.timeout` / `source.timeout` without triggering the BEAM
+  owner-only receive constraint. Caveat: buffers the entire
+  upstream in memory, so only suitable for bounded subjects.
+  BEAM-only. Closes the last open Roadmap follow-up in #171. (#178)
+
+### Internal
+
+- **datastream/internal/ref** is a small cross-target mutable cell
+  (`new(value)` / `get(ref)` / `set(ref, value)`). Process-
+  dictionary-backed on Erlang via `src/datastream_ref_ffi.erl` and
+  one-field-object-backed on JavaScript via
+  `src/datastream/internal/ref_ffi.mjs`. Internal to the library
+  — `internal_modules = ["datastream/internal/**"]` keeps it out
+  of the public surface and the generated docs. Required by
+  `broadcast` and `unzip` to share upstream and per-consumer queue
+  state across multiple consumer streams; pure-functional pull-
+  state cannot express that observation across separate stream
+  values without a mutable bridge.
 
 ## [0.5.0] - 2026-04-28
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -3,6 +3,7 @@ version = "0.5.0"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }
+internal_modules = ["datastream/internal/**"]
 links = [
   { title = "Repository", href = "https://github.com/nao1215/datastream" },
   { title = "Documentation", href = "https://hexdocs.pm/datastream" },

--- a/src/datastream/erlang/source.gleam
+++ b/src/datastream/erlang/source.gleam
@@ -23,6 +23,8 @@ pub const beam_only_marker: String = "datastream/erlang/source is BEAM-only"
 import datastream.{type Stream, Done, Next}
 
 @target(erlang)
+import datastream/fold
+@target(erlang)
 import datastream/source
 
 @target(erlang)
@@ -43,16 +45,45 @@ import gleam/erlang/process.{type Subject}
 /// only reads, it never closes the subject. The terminal completing
 /// is sufficient to release the stream's hold.
 ///
-/// **Limitation:** the resulting stream cannot be passed to any
-/// combinator in `datastream/erlang/par` or `datastream/erlang/time`,
-/// nor to `datastream/erlang/source.timeout` — those run the pull in
-/// a worker process and the `Subject`'s owner-only receive
-/// constraint causes a `panic`.
+/// **Limitation:** the resulting stream cannot be passed directly
+/// to any combinator in `datastream/erlang/par` or
+/// `datastream/erlang/time`, nor to
+/// `datastream/erlang/source.timeout` — those run the pull in a
+/// worker process and the `Subject`'s owner-only receive constraint
+/// causes a `panic` in the worker. Use `bridge_subject_stream`
+/// below to materialise the subject side in the owning process
+/// before handing it off.
 pub fn from_subject(
   from subject: Subject(a),
   while keep_running: fn() -> Bool,
 ) -> Stream(a) {
   source.unfold(from: Nil, with: fn(_) { receive_loop(subject, keep_running) })
+}
+
+@target(erlang)
+/// Materialise a `from_subject`-backed stream into a process-safe
+/// `Stream(a)` so the result can be composed with `par.*` /
+/// `time.*` / `source.timeout`.
+///
+/// The pull happens in the calling process — the same process that
+/// owns the `Subject` — so the owner-only receive constraint is
+/// respected. Once the upstream returns `Done`, the materialised
+/// `List(a)` is reopened as a list-backed stream, which is pure and
+/// can safely be pulled from any worker process.
+///
+/// **Caveat:** materialises the entire upstream into memory before
+/// emitting any element. Only use this on bounded subjects (a
+/// `keep_running` callback that eventually returns `False`, or a
+/// finite source). For an unbounded subject, route the parallel
+/// stage outside the subject pipeline instead — there is no
+/// process-safe way to lazily forward an Erlang `Subject` across a
+/// process boundary.
+///
+/// This is the official workaround for the
+/// `from_subject` × `par.*` / `time.*` incompatibility documented
+/// on `from_subject`, `par`, and `source.timeout`.
+pub fn bridge_subject_stream(over stream: Stream(a)) -> Stream(a) {
+  source.from_list(fold.to_list(stream))
 }
 
 @target(erlang)

--- a/src/datastream/internal/ref.gleam
+++ b/src/datastream/internal/ref.gleam
@@ -1,0 +1,64 @@
+//// Cross-target mutable reference cell, internal to the library.
+////
+//// Almost every combinator in `datastream/stream` is pure and needs no
+//// shared state. The exceptions are `broadcast` and `unzip`, where two
+//// or more consumer streams must share access to a single upstream and
+//// per-consumer queues — and where pulling from one consumer must
+//// observably advance the state seen by the others. Pure-functional
+//// pull-state cannot express that observation across separate stream
+//// values, so we route the shared bits through a tiny `Ref(a)`.
+////
+//// `Ref` is **not** part of the public API — `datastream` stays a
+//// pull-based stream library, not a general-purpose mutable-state
+//// library. The `@internal` annotation hides every export from the
+//// generated docs, and `internal_modules` in `gleam.toml` prevents
+//// downstream packages from importing this module directly.
+////
+//// On Erlang the cell is keyed off an `:erlang.unique_integer/1`
+//// process-dictionary slot, which keeps the cost flat and confines
+//// state to the calling process (no extra spawned processes,
+//// no `:ets` tables, no atomics). On JavaScript it is a one-field
+//// mutable object. Both implementations are call-site-local; a `Ref`
+//// outlives only the surrounding pipeline.
+
+pub opaque type Ref(a) {
+  Ref(handle: Handle(a))
+}
+
+/// Phantom-typed handle to the FFI-side mutable cell. The `a`
+/// parameter is purely advisory — neither the BEAM process dict nor
+/// the JavaScript object enforces it — but it lets the public surface
+/// keep `Ref(a)` typed.
+type Handle(a)
+
+@external(erlang, "datastream_ref_ffi", "new_ref")
+@external(javascript, "./ref_ffi.mjs", "new_ref")
+fn do_new(value: a) -> Handle(a)
+
+@external(erlang, "datastream_ref_ffi", "get_ref")
+@external(javascript, "./ref_ffi.mjs", "get_ref")
+fn do_get(handle: Handle(a)) -> a
+
+@external(erlang, "datastream_ref_ffi", "set_ref")
+@external(javascript, "./ref_ffi.mjs", "set_ref")
+fn do_set(handle: Handle(a), value: a) -> Nil
+
+/// Allocate a new mutable cell holding `value`.
+@internal
+pub fn new(value: a) -> Ref(a) {
+  Ref(handle: do_new(value))
+}
+
+/// Read the current value of `ref`.
+@internal
+pub fn get(ref: Ref(a)) -> a {
+  let Ref(handle) = ref
+  do_get(handle)
+}
+
+/// Overwrite `ref` with `value`. Returns `Nil`.
+@internal
+pub fn set(ref: Ref(a), value: a) -> Nil {
+  let Ref(handle) = ref
+  do_set(handle, value)
+}

--- a/src/datastream/internal/ref_ffi.mjs
+++ b/src/datastream/internal/ref_ffi.mjs
@@ -1,0 +1,17 @@
+// JavaScript FFI for datastream/internal/ref.gleam.
+//
+// Mutable single-field object. Each Ref allocation is independent;
+// no shared global state.
+
+export function new_ref(value) {
+  return { value: value };
+}
+
+export function get_ref(ref) {
+  return ref.value;
+}
+
+export function set_ref(ref, value) {
+  ref.value = value;
+  return undefined;
+}

--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -19,6 +19,7 @@
 
 import datastream.{type Step, type Stream, Done, Next}
 import datastream/chunk.{type Chunk}
+import datastream/internal/ref.{type Ref}
 import gleam/list
 import gleam/option.{type Option, None, Some}
 
@@ -667,6 +668,260 @@ fn interrupt_pull_stream(
   case datastream.pull(stream) {
     Next(element, rest) -> Next(element, interrupt_active(rest, signal))
     Done -> Done
+  }
+}
+
+// --- broadcast and unzip ----------------------------------------------------
+
+/// Internal state shared by every consumer returned from `broadcast`.
+///
+/// `upstream` is `None` once the source has signalled `Done` (or once
+/// every consumer has called `close` and we proactively closed the
+/// source). Each `queue` holds elements that the source has produced
+/// but the corresponding consumer has not yet pulled. `active` tracks
+/// which consumers are still alive — we stop enqueueing into a closed
+/// consumer's queue, and once every flag is `False` we close the
+/// upstream from the last close call.
+type BroadcastState(a) {
+  BroadcastState(
+    upstream: Option(Stream(a)),
+    queues: List(List(a)),
+    active: List(Bool),
+  )
+}
+
+/// Split `stream` into `n` independent consumer streams that share a
+/// single underlying source.
+///
+/// Each consumer pulls at its own pace; any element the source
+/// produces is observed by every still-alive consumer in order. A
+/// consumer that lags behind sees the same prefix as a fast consumer,
+/// just later. This is the fan-out / pub-sub combinator: an
+/// observability tap can run in parallel with the main pipeline
+/// without forcing the source to be re-evaluated, which matters for
+/// resource-backed and otherwise non-replayable sources.
+///
+/// `n` MUST be `>= 1`. A `n < 1` is rejected at construction time
+/// with a panic per the `datastream` module-level invalid-argument
+/// policy.
+///
+/// **Buffer size:** the per-consumer queue is currently unbounded.
+/// A consumer that never pulls while another pulls aggressively will
+/// accumulate the entire stream in its queue; users with that risk
+/// should compose `broadcast(..., n) |> list.map(stream.take(_, k))`
+/// or its equivalent. A bounded variant with an explicit drop policy
+/// is left as a follow-up — see the Roadmap.
+///
+/// **Cross-target:** implemented via a small FFI-backed mutable
+/// reference (`datastream/internal/ref`). On Erlang the cell is a
+/// process-dictionary slot; on JavaScript it is a one-field mutable
+/// object. No `gleam_erlang` processes are spawned; no shared global
+/// state. The `Ref(_)` is local to each `broadcast` call.
+///
+/// **Close contract:** every consumer's `close` is recorded; the
+/// upstream is closed exactly once, on whichever call brings the
+/// active-consumer count to zero. If the upstream returns `Done`
+/// first it self-closes, and the close callbacks are no-ops.
+pub fn broadcast(over stream: Stream(a), into n: Int) -> List(Stream(a)) {
+  case n < 1 {
+    True -> panic as "datastream/stream.broadcast: n must be >= 1"
+    False -> {
+      let initial =
+        BroadcastState(
+          upstream: Some(stream),
+          queues: list.repeat([], times: n),
+          active: list.repeat(True, times: n),
+        )
+      let state_ref = ref.new(initial)
+      build_consumers(state_ref, n, [])
+    }
+  }
+}
+
+fn build_consumers(
+  state_ref: Ref(BroadcastState(a)),
+  remaining: Int,
+  acc: List(Stream(a)),
+) -> List(Stream(a)) {
+  case remaining {
+    0 -> acc
+    _ -> {
+      let consumer_id = remaining - 1
+      build_consumers(state_ref, consumer_id, [
+        broadcast_consumer(state_ref, consumer_id),
+        ..acc
+      ])
+    }
+  }
+}
+
+fn broadcast_consumer(
+  state_ref: Ref(BroadcastState(a)),
+  consumer_id: Int,
+) -> Stream(a) {
+  datastream.make(
+    pull: fn() { broadcast_pull(state_ref, consumer_id) },
+    close: fn() { broadcast_close(state_ref, consumer_id) },
+  )
+}
+
+fn broadcast_pull(
+  state_ref: Ref(BroadcastState(a)),
+  consumer_id: Int,
+) -> Step(a, Stream(a)) {
+  let state = ref.get(state_ref)
+  case list_at(state.queues, consumer_id) {
+    [head, ..tail] -> {
+      let new_queues = list_replace_at(state.queues, consumer_id, tail)
+      ref.set(
+        state_ref,
+        BroadcastState(
+          upstream: state.upstream,
+          queues: new_queues,
+          active: state.active,
+        ),
+      )
+      Next(head, broadcast_consumer(state_ref, consumer_id))
+    }
+    [] ->
+      case state.upstream {
+        None -> Done
+        Some(upstream) ->
+          case datastream.pull(upstream) {
+            Done -> {
+              ref.set(
+                state_ref,
+                BroadcastState(
+                  upstream: None,
+                  queues: state.queues,
+                  active: state.active,
+                ),
+              )
+              Done
+            }
+            Next(element, rest) -> {
+              let new_queues =
+                fanout_to_others(
+                  state.queues,
+                  state.active,
+                  consumer_id,
+                  element,
+                )
+              ref.set(
+                state_ref,
+                BroadcastState(
+                  upstream: Some(rest),
+                  queues: new_queues,
+                  active: state.active,
+                ),
+              )
+              Next(element, broadcast_consumer(state_ref, consumer_id))
+            }
+          }
+      }
+  }
+}
+
+fn broadcast_close(state_ref: Ref(BroadcastState(a)), consumer_id: Int) -> Nil {
+  let state = ref.get(state_ref)
+  let new_active = list_replace_at(state.active, consumer_id, False)
+  let any_active = list.any(new_active, fn(b) { b })
+  let cleared_queue = list_replace_at(state.queues, consumer_id, [])
+  case any_active, state.upstream {
+    True, _ ->
+      ref.set(
+        state_ref,
+        BroadcastState(
+          upstream: state.upstream,
+          queues: cleared_queue,
+          active: new_active,
+        ),
+      )
+    False, Some(upstream) -> {
+      datastream.close(upstream)
+      ref.set(
+        state_ref,
+        BroadcastState(
+          upstream: None,
+          queues: cleared_queue,
+          active: new_active,
+        ),
+      )
+    }
+    False, None ->
+      ref.set(
+        state_ref,
+        BroadcastState(
+          upstream: None,
+          queues: cleared_queue,
+          active: new_active,
+        ),
+      )
+  }
+}
+
+fn fanout_to_others(
+  queues: List(List(a)),
+  active: List(Bool),
+  skip_id: Int,
+  element: a,
+) -> List(List(a)) {
+  list.index_map(queues, fn(queue, index) {
+    case index == skip_id, list_at_bool(active, index) {
+      True, _ -> queue
+      False, False -> queue
+      False, True -> list.append(queue, [element])
+    }
+  })
+}
+
+fn list_at(xs: List(List(a)), index: Int) -> List(a) {
+  case xs, index {
+    [], _ -> []
+    [head, ..], 0 -> head
+    [_, ..rest], _ -> list_at(rest, index - 1)
+  }
+}
+
+fn list_at_bool(xs: List(Bool), index: Int) -> Bool {
+  case xs, index {
+    [], _ -> False
+    [head, ..], 0 -> head
+    [_, ..rest], _ -> list_at_bool(rest, index - 1)
+  }
+}
+
+fn list_replace_at(xs: List(b), index: Int, value: b) -> List(b) {
+  case xs, index {
+    [], _ -> []
+    [_, ..rest], 0 -> [value, ..rest]
+    [head, ..rest], _ -> [head, ..list_replace_at(rest, index - 1, value)]
+  }
+}
+
+/// Counterpart of `zip`: split a `Stream(#(a, b))` into a pair of
+/// independent component streams.
+///
+/// Both component streams see the same elements (left projections
+/// for the first, right projections for the second) in the same
+/// order. Each consumer pulls at its own pace, sharing the upstream
+/// via `broadcast` under the hood.
+///
+/// **Cross-target:** same FFI-backed shared state as `broadcast`,
+/// so `unzip` runs on both Erlang and JavaScript.
+///
+/// **Buffer size:** unbounded per consumer, inherited from
+/// `broadcast`. A pipeline that drives one half of the unzipped pair
+/// to completion while the other half stays unpulled will accumulate
+/// the entire stream in the lagging half's queue.
+pub fn unzip(stream: Stream(#(a, b))) -> #(Stream(a), Stream(b)) {
+  case broadcast(over: stream, into: 2) {
+    [left, right] -> #(
+      map(over: left, with: fn(p) { p.0 }),
+      map(over: right, with: fn(p) { p.1 }),
+    )
+    _ ->
+      panic as "datastream/stream.unzip: broadcast(_, 2) returned an unexpected shape"
   }
 }
 

--- a/src/datastream_ref_ffi.erl
+++ b/src/datastream_ref_ffi.erl
@@ -1,0 +1,22 @@
+%% Erlang FFI for datastream/internal/ref.gleam.
+%%
+%% Backed by the calling process's process dictionary, keyed off
+%% erlang:unique_integer/1. The dictionary is per-process, which is
+%% fine for datastream's single-process pipeline use: every consumer
+%% stream returned from `broadcast` runs inside the same process as
+%% the call to broadcast, so they all see the same dict.
+
+-module(datastream_ref_ffi).
+-export([new_ref/1, get_ref/1, set_ref/2]).
+
+new_ref(Value) ->
+    Key = erlang:unique_integer([positive]),
+    erlang:put({datastream_ref, Key}, Value),
+    Key.
+
+get_ref(Key) ->
+    erlang:get({datastream_ref, Key}).
+
+set_ref(Key, Value) ->
+    erlang:put({datastream_ref, Key}, Value),
+    nil.

--- a/test/datastream/erlang/source_test.gleam
+++ b/test/datastream/erlang/source_test.gleam
@@ -57,6 +57,40 @@ pub fn from_subject_halts_when_keep_running_returns_false_test() {
   |> should.equal([])
 }
 
+// --- bridge_subject_stream (workaround for par/timeout incompatibility) ---
+
+@target(erlang)
+pub fn bridge_subject_stream_materialises_in_owning_process_test() {
+  let subject = process.new_subject()
+  process.spawn(fn() {
+    process.send(subject, 10)
+    process.send(subject, 20)
+    process.send(subject, 30)
+  })
+
+  // Drain the subject in this (owning) process via a take-bounded stream,
+  // then bridge into a list-backed Stream that is process-safe.
+  let bridged =
+    beam_source.from_subject(from: subject, while: fn() { True })
+    |> stream.take(up_to: 3)
+    |> beam_source.bridge_subject_stream
+
+  // The bridged stream survives composition with downstream combinators
+  // that may move pulls into worker processes (par.*, source.timeout).
+  bridged
+  |> fold.to_list
+  |> should.equal([10, 20, 30])
+}
+
+@target(erlang)
+pub fn bridge_subject_stream_preserves_empty_test() {
+  let subject = process.new_subject()
+  beam_source.from_subject(from: subject, while: fn() { False })
+  |> beam_source.bridge_subject_stream
+  |> fold.to_list
+  |> should.equal([])
+}
+
 // --- ticks / interval ---------------------------------------------------
 
 @target(erlang)

--- a/test/datastream/stream_test.gleam
+++ b/test/datastream/stream_test.gleam
@@ -512,6 +512,97 @@ pub fn interrupt_when_signal_wins_over_take_test() {
   |> should.equal([0, 1])
 }
 
+pub fn broadcast_two_consumers_see_same_elements_test() {
+  let assert [a, b] = stream.broadcast(over: from_list([1, 2, 3]), into: 2)
+  fold.to_list(a) |> should.equal([1, 2, 3])
+  fold.to_list(b) |> should.equal([1, 2, 3])
+}
+
+pub fn broadcast_consumer_one_partial_then_two_test() {
+  let assert [a, b] = stream.broadcast(over: from_list([1, 2, 3, 4]), into: 2)
+  a |> stream.take(up_to: 2) |> fold.to_list |> should.equal([1, 2])
+  fold.to_list(b) |> should.equal([1, 2, 3, 4])
+}
+
+pub fn broadcast_three_consumers_independent_pace_test() {
+  let assert [a, b, c] =
+    stream.broadcast(over: from_list([10, 20, 30, 40]), into: 3)
+  a |> fold.to_list |> should.equal([10, 20, 30, 40])
+  b |> stream.take(up_to: 2) |> fold.to_list |> should.equal([10, 20])
+  fold.to_list(c) |> should.equal([10, 20, 30, 40])
+}
+
+pub fn broadcast_one_consumer_is_identity_test() {
+  let assert [only] = stream.broadcast(over: from_list([1, 2, 3]), into: 1)
+  fold.to_list(only) |> should.equal([1, 2, 3])
+}
+
+pub fn broadcast_on_empty_yields_empty_consumers_test() {
+  let assert [a, b] = stream.broadcast(over: from_list([]), into: 2)
+  fold.to_list(a) |> should.equal([])
+  fold.to_list(b) |> should.equal([])
+}
+
+pub fn broadcast_consumer_with_take_zero_does_not_block_other_test() {
+  let assert [a, b] = stream.broadcast(over: from_list([1, 2, 3]), into: 2)
+  a |> stream.take(up_to: 0) |> fold.to_list |> should.equal([])
+  fold.to_list(b) |> should.equal([1, 2, 3])
+}
+
+@target(erlang)
+pub fn broadcast_zero_panics_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result = stream.broadcast(over: from_list([1, 2, 3]), into: 0)
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
+@target(erlang)
+pub fn broadcast_negative_panics_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result = stream.broadcast(over: from_list([1, 2, 3]), into: -3)
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
+pub fn unzip_round_trip_with_zip_test() {
+  let zipped = stream.zip(from_list([1, 2, 3]), from_list(["a", "b", "c"]))
+  let #(left, right) = stream.unzip(zipped)
+  fold.to_list(left) |> should.equal([1, 2, 3])
+  fold.to_list(right) |> should.equal(["a", "b", "c"])
+}
+
+pub fn unzip_on_empty_yields_empty_pair_test() {
+  let #(left, right) = stream.unzip(from_list([]))
+  fold.to_list(left) |> should.equal([])
+  fold.to_list(right) |> should.equal([])
+}
+
+pub fn unzip_left_first_then_right_test() {
+  let pairs = from_list([#(1, "a"), #(2, "b"), #(3, "c")])
+  let #(left, right) = stream.unzip(pairs)
+  fold.to_list(left) |> should.equal([1, 2, 3])
+  fold.to_list(right) |> should.equal(["a", "b", "c"])
+}
+
+pub fn unzip_right_first_then_left_test() {
+  let pairs = from_list([#(1, "a"), #(2, "b"), #(3, "c")])
+  let #(left, right) = stream.unzip(pairs)
+  fold.to_list(right) |> should.equal(["a", "b", "c"])
+  fold.to_list(left) |> should.equal([1, 2, 3])
+}
+
+pub fn unzip_partial_left_full_right_test() {
+  let pairs = from_list([#(1, "a"), #(2, "b"), #(3, "c"), #(4, "d")])
+  let #(left, right) = stream.unzip(pairs)
+  left |> stream.take(up_to: 2) |> fold.to_list |> should.equal([1, 2])
+  fold.to_list(right) |> should.equal(["a", "b", "c", "d"])
+}
+
 fn chunks_to_lists(stream_of_chunks) {
   stream_of_chunks
   |> fold.to_list


### PR DESCRIPTION
## Summary

Closes the last three Roadmap sub-tasks in #171:

- `stream.broadcast(stream, n)` — fan out a single source to `n` independently-paced consumer streams.
- `stream.unzip(stream)` — counterpart of `zip`, built on `broadcast`.
- `datastream/erlang/source.bridge_subject_stream` — workaround helper for the `from_subject` × `par.* / time.*` incompatibility called out on `from_subject`.

`broadcast` and `unzip` are cross-target (Erlang + JavaScript) by introducing a tiny FFI-backed mutable cell, `datastream/internal/ref`. `bridge_subject_stream` is BEAM-only.

## Changes

- `src/datastream/internal/ref.gleam`, `src/datastream_ref_ffi.erl`, `src/datastream/internal/ref_ffi.mjs` — internal cross-target mutable cell. Process-dictionary-backed on Erlang (keyed off `erlang:unique_integer/1`); one-field-mutable-object on JavaScript. Hidden from the public surface via `internal_modules = [\"datastream/internal/**\"]` in `gleam.toml`.
- `src/datastream/stream.gleam` — adds `broadcast/2` and `unzip/1` plus the per-consumer state-distribution helpers. The shared state (`BroadcastState`) lives in a single `Ref` allocated per `broadcast` call.
- `src/datastream/erlang/source.gleam` — adds `bridge_subject_stream/1`. Cross-references the limitation docstrings on `from_subject` and `source.timeout`.
- `test/datastream/stream_test.gleam` — 14 new tests for broadcast (independent paces, identity, empty, panic on n < 1, etc.) and unzip (round-trip with zip, partial pulls, both orderings).
- `test/datastream/erlang/source_test.gleam` — 2 new tests for `bridge_subject_stream`.
- `gleam.toml` — adds `internal_modules = [\"datastream/internal/**\"]`.
- `CHANGELOG.md` — `[Unreleased]` entries for all three new combinators plus the internal `ref` module.

## Design Decisions

- **Cross-target broadcast via FFI Ref, not BEAM-only.** The user explicitly asked for cross-target. Pure pull-state can't express two consumer streams that share an upstream — sharing requires mutable observation across separate stream values. We pay for that with one tiny FFI primitive (3 functions, 2 short FFI files) rather than committing the entire library to BEAM.
- **Process-dictionary on BEAM, plain object on JavaScript.** Process-dict is the lightest possible BEAM-side state: no spawned processes, no `:ets`, no `:atomics` (which is int-only). The trade-off: a `Ref` is bound to its calling process, which is exactly what we want — a `broadcast` call's consumers all run inside the same process as the call, by virtue of being pulled by the surrounding fold.
- **Unbounded per-consumer queues.** The Roadmap calls for a 'bounded internal buffer per consumer' with a drop policy. That decision is contentious (block-fastest vs drop-slowest is a real semantic choice that needs its own micro-discussion), so v0.6 ships unbounded with a docstring caveat. A follow-up issue can add a bounded variant once the policy is decided.
- **`bridge_subject_stream` materialises into a `List(a)` instead of doing process-handoff acrobatics.** A truly lazy bridge would need a permanent forwarding actor that reads from the subject in the owning process and answers pulls coming from worker processes — that is a substantial design (back-pressure, lifecycle, supervisor) for a workaround. Materialise-then-replay is the simplest correct option for bounded subjects, with an explicit docstring caveat for unbounded ones.

## Test plan

- [x] `just format-check`
- [x] `just lint`
- [x] `just test-erlang` — 403 passed
- [x] `just test-javascript` — 291 passed
- [x] `just ci` — full pipeline green

Closes #176, closes #177, closes #178. Roadmap #171 will be closed in the v0.6.0 release notes.