### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-29
+
 ### Added
 
 - **stream.buffer(stream, prefetch:)** is a new combinator that

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "datastream"
-version = "0.5.0"
+version = "0.6.0"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }


### PR DESCRIPTION
### Added

- **stream.buffer(stream, prefetch:)** is a new combinator that
  pulls `prefetch` elements ahead from the upstream and yields them
  to the consumer at its pace. The internal queue is refilled back
  to capacity after every consumer pull, so a latency-bound
  upstream (HTTP body bytes, slow disk reads) no longer blocks the
  consumer's per-element work serially — the next upstream pull can
  overlap with the current downstream computation. Capacity must
  be `>= 1`; element type, order, and cardinality are preserved.
  Pure-functional pull-state implementation with no `gleam_erlang`
  / process / FFI dependency, so it runs on both the Erlang and
  JavaScript targets. First sub-task of the Roadmap in #171. (#172)
- **stream.interrupt_when(stream, signal:)** is a new combinator
  that terminates `stream` on the first `True` element from
  `signal`. The signal is `Stream(Bool)` (not `Stream(Nil)` as the
  Roadmap originally proposed) — the boolean carries the
  not-yet / fire-now distinction that `Done` cannot in a pull-based
  model where `Done` is terminal. On every consumer pull the signal
  is checked first: a `True` element closes both the rest of the
  signal and `stream` and yields `Done`; a `False` element is
  consumed and the pull descends into `stream`; a `Done` from the
  signal switches the combinator into a pass-through over `stream`
  (the signal is never re-pulled, matching the `Step` contract).
  Counterpart of `take_while` for *external* termination signals
  (timer expiry, parent-shutdown probe, cancel-token bridge) where
  the decision to stop doesn't depend on the pulled element.
  Cross-target: pure-functional pull-state, no `gleam_erlang` /
  process / FFI dependency. Second sub-task of the Roadmap in
  #171. (#174)
- **stream.broadcast(stream, n)** is a new fan-out combinator: it
  splits a `Stream(a)` into `n` independent consumer streams that
  share a single underlying source. Each consumer pulls at its own
  pace; an element produced by the source is observed by every
  still-alive consumer in order. Use it for the observability-tap
  shape (one consumer drives the main pipeline, another writes
  metrics or logs) without forcing the source to be re-evaluated,
  which matters for resource-backed and otherwise non-replayable
  sources. `n` must be `>= 1`; per-consumer queue is currently
  unbounded — bounded variant with an explicit drop policy is
  follow-up work. Cross-target via the new `internal/ref` mutable
  cell (process-dictionary on Erlang, plain object on JavaScript).
  Third sub-task of the Roadmap in #171. (#176)
- **stream.unzip(stream)** splits a `Stream(#(a, b))` into a pair
  `#(Stream(a), Stream(b))`, the counterpart of `stream.zip`. Built
  on `broadcast` under the hood, so the same per-consumer
  unbounded-queue caveat applies (a pipeline that drives one half
  to completion while the other half lags accumulates the lagging
  half's queue). Cross-target. Fourth sub-task of the Roadmap
  in #171. (#177)
- **datastream/erlang/source.bridge_subject_stream** is a
  workaround helper for the `from_subject` × `par.*` / `time.*` /
  `source.timeout` incompatibility documented on `from_subject`.
  Materialises the upstream into a `List(a)` inside the calling
  (subject-owning) process and reopens it as a process-safe
  list-backed stream, which can then be composed with `par.*` /
  `time.timeout` / `source.timeout` without triggering the BEAM
  owner-only receive constraint. Caveat: buffers the entire
  upstream in memory, so only suitable for bounded subjects.
  BEAM-only. Closes the last open Roadmap follow-up in #171. (#178)

### Internal

- **datastream/internal/ref** is a small cross-target mutable cell
  (`new(value)` / `get(ref)` / `set(ref, value)`). Process-
  dictionary-backed on Erlang via `src/datastream_ref_ffi.erl` and
  one-field-object-backed on JavaScript via
  `src/datastream/internal/ref_ffi.mjs`. Internal to the library
  — `internal_modules = ["datastream/internal/**"]` keeps it out
  of the public surface and the generated docs. Required by
  `broadcast` and `unzip` to share upstream and per-consumer queue
  state across multiple consumer streams; pure-functional pull-
  state cannot express that observation across separate stream
  values without a mutable bridge.

Closes #171.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release version 0.6.0 with updated changelog entry dated 2026-04-29

<!-- end of auto-generated comment: release notes by coderabbit.ai -->