### PR TITLE
docs(source): clarify that range is stop-exclusive, contrast with yielder.range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **source.range** doc-comment now spells out that the function is
+  stop-EXCLUSIVE and explicitly contrasts it with `gleam/yielder.range`
+  which is stop-INCLUSIVE. Adds runnable examples and a note on the
+  off-by-one when porting from `gleam/yielder`. The previous wording
+  ("keeping `range` aligned with the surrounding stdlib's `range`")
+  was true for `gleam/int.range` (fold-style, stop-exclusive) but
+  misleading for users who expected `gleam/yielder.range` semantics
+  since `Stream(a)` is the closer analog of `Yielder(a)`. Behaviour
+  unchanged. (#181)
+
 ## [0.6.0] - 2026-04-29
 
 ### Added

--- a/src/datastream/source.gleam
+++ b/src/datastream/source.gleam
@@ -45,12 +45,33 @@ pub fn from_list(list: List(a)) -> Stream(a) {
   })
 }
 
-/// Stop-exclusive integer range.
+/// Stop-EXCLUSIVE integer range.
 ///
 /// Counts up by 1 when `start < stop`, down by 1 when `start > stop`,
 /// and is empty when `start == stop`. Step-by-`n` sequences belong in
-/// `iterate` or `unfold`, keeping `range` aligned with the surrounding
-/// stdlib's `range`.
+/// `iterate` or `unfold`.
+///
+/// Examples:
+///
+/// ```gleam
+/// source.range(from: 1, to: 5) |> fold.to_list  // [1, 2, 3, 4]
+/// source.range(from: 0, to: 0) |> fold.to_list  // []
+/// source.range(from: 5, to: 1) |> fold.to_list  // [5, 4, 3, 2]
+/// ```
+///
+/// Stdlib has two `range` shapes with different conventions:
+///
+/// - `gleam/int.range` (fold form) is **stop-EXCLUSIVE**, matching this
+///   function.
+/// - `gleam/yielder.range` (pull-based stream form) is
+///   **stop-INCLUSIVE** — `yielder.range(from: 1, to: 5)` yields
+///   `[1, 2, 3, 4, 5]` and `yielder.range(from: 0, to: 0)` yields
+///   `[0]`, not the empty list.
+///
+/// `Stream(a)` is the closer analog of `Yielder(a)`, so be aware of
+/// the off-by-one when porting code between the two. Add `+ 1` to
+/// `to:` (or use `iterate` / `unfold` for full control) when you want
+/// inclusive semantics.
 pub fn range(from start: Int, to stop: Int) -> Stream(Int) {
   case start == stop {
     True -> empty()


### PR DESCRIPTION
## Summary

Update the doc-comment on `source.range` to spell out its stop-EXCLUSIVE semantics and explicitly contrast with `gleam/yielder.range` (stop-INCLUSIVE), which is the closer analog of `Stream(a)` and the most likely point of confusion for users porting code.

## Changes

- `src/datastream/source.gleam`: rewrite `range` doc-comment with examples and a note on the off-by-one when porting from `gleam/yielder`
- `CHANGELOG.md`: add entry under `[Unreleased]`

## Design Decisions

The issue offered two options: (1) flip the behaviour to stop-INCLUSIVE to match `yielder.range`, or (2) keep behaviour and clarify the docs. Picked option 2 because:

- Behaviour change would be breaking for any caller relying on the current stop-exclusive count (e.g., `range(from: 0, to: n)` to iterate `n` elements).
- The stop-exclusive convention itself is consistent with `gleam/int.range` (the fold-form stdlib peer), so it's not wrong, just one of two valid choices.
- The actual user-facing problem was the misleading "aligned with the surrounding stdlib's `range`" line in the doc-comment, which the rewrite addresses directly.

The new doc-comment now mentions both stdlib `range` shapes by name so readers can quickly orient themselves regardless of which background they bring.

Closes #181
