### PR TITLE
docs(source): note that resource close requires open to have run first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   misleading for users who expected `gleam/yielder.range` semantics
   since `Stream(a)` is the closer analog of `Yielder(a)`. Behaviour
   unchanged. (#181)
+- **source.resource / source.try_resource** doc-comment now states
+  explicitly that `close` only runs when `open` ran first. With
+  lazy-open semantics, terminals that never trigger a pull (notably
+  `stream.take(up_to: 0)`) skip both `open` and `close`. The previous
+  wording promised `close` on every termination path including
+  `stream.take`, which was misleading for the degenerate `take(0)`
+  case. A close callback that needs to run unconditionally must be
+  arranged at a higher level than the `Stream`. Behaviour unchanged.
+  (#182)
 
 ## [0.6.0] - 2026-04-29
 

--- a/src/datastream/source.gleam
+++ b/src/datastream/source.gleam
@@ -200,12 +200,20 @@ pub type ResourceError(open_error, next_error) {
 /// begins. Each terminal call re-runs `open`: a `Stream` is a pipeline
 /// definition, not a one-shot iterator.
 ///
-/// `close` is honoured on every termination path the library controls:
-/// normal end (when `next` returns `Done`), downstream early-exit
-/// (`stream.take`, `stream.take_while`), early-exit folds (`fold.first`,
-/// `fold.find`, `fold.any`, `fold.all`, `fold.collect_result`), and
-/// `sink.try_each` failure. Termination caused by user-code panicking
-/// is best-effort.
+/// `close` is honoured on every termination path the library controls
+/// — *provided `open` has run*. With lazy-open semantics, terminals
+/// that never pull (`stream.take(up_to: 0)`, an `interrupt_when`
+/// signal that fires before the first pull, etc.) skip both `open`
+/// and `close`: there is no opened state, so there is nothing to
+/// close. A close callback that needs to run unconditionally must be
+/// arranged at a higher level than the `Stream`.
+///
+/// When `open` *has* run, the termination paths covered are: normal
+/// end (when `next` returns `Done`), downstream early-exit
+/// (`stream.take`, `stream.take_while`), early-exit folds
+/// (`fold.first`, `fold.find`, `fold.any`, `fold.all`,
+/// `fold.collect_result`), and `sink.try_each` failure. Termination
+/// caused by user-code panicking is best-effort.
 ///
 /// `close` returns `Nil`. Errors that happen at close time are not
 /// propagated through the terminal's return value; callers that must
@@ -234,7 +242,9 @@ pub fn resource(
 ///   `close(state)`.
 ///
 /// Lazy: `open` runs on the first pull, NOT at construction. Each
-/// terminal call re-attempts `open`.
+/// terminal call re-attempts `open`. As with `resource`, terminals
+/// that never trigger a pull (`stream.take(up_to: 0)` and similar)
+/// skip both `open` and `close`.
 ///
 /// Downstream sees a single `Stream(Result(a, ResourceError(o, n)))`,
 /// so `fold.collect_result` and `fold.partition_result` work without


### PR DESCRIPTION
## Summary

Update the doc-comment on `source.resource` (and `source.try_resource`) to explicitly state that `close` only runs when `open` has run first. With lazy-open semantics, terminals that never trigger a pull (notably `stream.take(up_to: 0)`) skip both `open` and `close` — the previous wording promised `close` on every termination path including `stream.take` and was misleading for the degenerate `take(0)` case.

## Changes

- `src/datastream/source.gleam`: rewrite the close-honour paragraph in `resource` to lead with the "provided `open` ran" qualifier; add a one-line aside to `try_resource` referencing the same rule
- `CHANGELOG.md`: add entry under `[Unreleased]`

## Design Decisions

Doc-only fix as the issue suggests. The current behaviour is correct (calling `close` without a prior `open` could panic if the close callback assumes the resource is open); the user-facing problem was the doc-comment promising more than the implementation guarantees. The new wording leads with the "provided `open` ran" qualifier so the lazy-open contract is impossible to miss when reading the close-side guarantees.

Closes #182
