### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-29
+
 ### Changed
 
 - **source.range** doc-comment now spells out that the function is

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "datastream"
-version = "0.6.0"
+version = "0.7.0"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }


### PR DESCRIPTION
### Changed

- **source.range** doc-comment now spells out that the function is
  stop-EXCLUSIVE and explicitly contrasts it with `gleam/yielder.range`
  which is stop-INCLUSIVE. Adds runnable examples and a note on the
  off-by-one when porting from `gleam/yielder`. The previous wording
  ("keeping `range` aligned with the surrounding stdlib's `range`")
  was true for `gleam/int.range` (fold-style, stop-exclusive) but
  misleading for users who expected `gleam/yielder.range` semantics
  since `Stream(a)` is the closer analog of `Yielder(a)`. Behaviour
  unchanged. (#181)
- **source.resource / source.try_resource** doc-comment now states
  explicitly that `close` only runs when `open` ran first. With
  lazy-open semantics, terminals that never trigger a pull (notably
  `stream.take(up_to: 0)`) skip both `open` and `close`. The previous
  wording promised `close` on every termination path including
  `stream.take`, which was misleading for the degenerate `take(0)`
  case. A close callback that needs to run unconditionally must be
  arranged at a higher level than the `Stream`. Behaviour unchanged.
  (#182)
