### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-30
+
 ### Added
 
 - **stream**: `stream.take_checked` and `stream.drop_checked` return

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "datastream"
-version = "0.7.0"
+version = "0.8.0"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }


### PR DESCRIPTION
### Added

- **stream**: `stream.take_checked` and `stream.drop_checked` return
  `Result(Stream(a), StreamArgError)` instead of panicking on a
  negative count. Use these for the dynamic-input path (CLI, config,
  request parameters); the panicking `stream.take` and `stream.drop`
  remain the right tool for trusted constants. `StreamArgError` is
  exposed as a public type with the `NegativeCount(function:, given:)`
  variant so callers can route many checked constructors through a
  single handler with meaningful diagnostics. (#189)
