### PR TITLE
feat(api): add checked variants for invalid-argument-prone constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **stream**: `stream.buffer_checked` and `stream.chunks_of_checked`
+  return `Result(Stream(_), StreamArgError)` instead of panicking
+  on a non-positive argument. Use these when `capacity` / `size`
+  comes from dynamic input (CLI, config, request parameters); the
+  panicking `stream.buffer` and `stream.chunks_of` remain the right
+  tool for trusted constants. `StreamArgError` gains a `NotPositive`
+  variant for the new "must be `>= 1`" contract. (#189)
+- **binary**: `binary.length_prefixed_checked`,
+  `binary.length_prefixed_with_checked`, and
+  `binary.fixed_size_checked` provide non-panicking variants of the
+  framing constructors. The new `BinaryArgError` type exposes
+  `InvalidPrefixSize` (for `prefix_size ∉ {1, 2, 4, 8}`) and
+  `NotPositiveSize` (for `size < 1`). (#189)
+- **erlang/par**: `par.map_unordered_with_checked`,
+  `par.map_ordered_with_checked`, `par.each_unordered_with_checked`,
+  `par.each_ordered_with_checked`, and `par.merge_with_checked`
+  provide non-panicking variants of the parallel constructors. The
+  new `ParArgError` type exposes `InvalidMaxWorkers`,
+  `BufferLessThanWorkers`, and `InvalidMaxBuffer` so callers can
+  diagnose which side of the contract failed. (#189)
+- **README**: a "Trusted vs. untrusted constructor inputs" subsection
+  documents the split and points dynamic-input callers at the
+  `*_checked` variants. (#189)
+
 ## [0.8.0] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,6 +74,28 @@ Stick with `gleam/list` when the input already fits in memory and you
 don't need lazy pulls, repeatable runs, or resource cleanup. `List`
 is simpler and faster for the small-finite case.
 
+### Trusted vs. untrusted constructor inputs
+
+Several constructors enforce numeric invariants (`stream.take` /
+`stream.drop` require `n >= 0`; `stream.buffer` / `stream.chunks_of`
+and `binary.fixed_size` require `>= 1`; `binary.length_prefixed`
+requires `prefix_size ∈ {1, 2, 4, 8}`; `erlang/par.map_*_with` /
+`each_*_with` require `max_workers >= 1` and
+`max_buffer >= max_workers`; `erlang/par.merge_with` requires
+`max_buffer >= 1`).
+
+When the value is a trusted compile-time constant, use the panicking
+constructor — bad input is a programmer error and crashing loud is
+the right outcome. When the value comes from CLI flags, config
+files, request parameters, or any other dynamic source, use the
+matching `*_checked` variant: it returns
+`Result(Stream(_), <ModuleArgError>)` so argument-validation
+failures stay on the typed path instead of taking down the process.
+Each module exposes its own error type — `stream.StreamArgError`,
+`binary.BinaryArgError`, `erlang/par.ParArgError` — and every
+variant carries the constructor name so a single handler can route
+many checked constructors and still produce a meaningful diagnostic.
+
 ## Examples
 
 Each example below is a complete `src/app.gleam` you can paste in

--- a/README.md
+++ b/README.md
@@ -89,12 +89,15 @@ constructor — bad input is a programmer error and crashing loud is
 the right outcome. When the value comes from CLI flags, config
 files, request parameters, or any other dynamic source, use the
 matching `*_checked` variant: it returns
-`Result(Stream(_), <ModuleArgError>)` so argument-validation
-failures stay on the typed path instead of taking down the process.
-Each module exposes its own error type — `stream.StreamArgError`,
-`binary.BinaryArgError`, `erlang/par.ParArgError` — and every
-variant carries the constructor name so a single handler can route
-many checked constructors and still produce a meaningful diagnostic.
+`Result(payload, <ModuleArgError>)` so argument-validation failures
+stay on the typed path instead of taking down the process. The
+payload matches the unchecked function's return type — `Stream(_)`
+for the framing constructors, `Nil` for the effect-only
+`par.each_*_with_checked` variants. Each module exposes its own
+error type — `stream.StreamArgError`, `binary.BinaryArgError`,
+`erlang/par.ParArgError` — and every variant carries the
+constructor name so a single handler can route many checked
+constructors and still produce a meaningful diagnostic.
 
 ## Examples
 

--- a/src/datastream/binary.gleam
+++ b/src/datastream/binary.gleam
@@ -11,6 +11,29 @@
 import datastream.{type Step, type Stream, Done, Next}
 import gleam/bit_array
 
+// --- argument validation --------------------------------------------------
+
+/// Why a checked binary framing constructor refused its argument.
+///
+/// Returned by `length_prefixed_checked`, `length_prefixed_with_checked`,
+/// and `fixed_size_checked`. Lets the caller surface argument
+/// validation failures through `Result` instead of crashing the
+/// process — useful when the numeric argument comes from CLI flags,
+/// config files, or request parameters.
+///
+/// `function` names the constructor that rejected the value
+/// (`"length_prefixed"`, `"fixed_size"`) so a caller routing many
+/// checked constructors through the same handler can produce a
+/// meaningful error message.
+pub type BinaryArgError {
+  /// `length_prefixed` requires `prefix_size` to be one of
+  /// `{1, 2, 4, 8}`. `given` is the value the caller passed.
+  InvalidPrefixSize(function: String, given: Int)
+  /// `fixed_size` requires `size` to be `>= 1`. `given` is the value
+  /// the caller passed.
+  NotPositiveSize(function: String, given: Int)
+}
+
 // --- bytes ----------------------------------------------------------------
 
 /// Yield each byte of each chunk in order, as `Int` in `0..255`.
@@ -123,6 +146,50 @@ pub fn length_prefixed_with(
       length_prefixed_active(stream, <<>>, prefix_size, max_frame_size, False)
     _ ->
       panic as "datastream/binary.length_prefixed: prefix_size must be 1, 2, 4, or 8"
+  }
+}
+
+/// Like `length_prefixed`, but returns the argument-validation
+/// failure as a `Result` instead of panicking. Use this when
+/// `prefix_size` comes from dynamic input (CLI, config, request
+/// parameters); the panicking `length_prefixed` remains the right
+/// tool for trusted constants.
+///
+/// On success the stream behaves identically to
+/// `length_prefixed(over: stream, prefix_size: prefix_size)`.
+///
+/// The caller is responsible for closing `stream` if the
+/// constructor returns `Error`.
+pub fn length_prefixed_checked(
+  over stream: Stream(BitArray),
+  prefix_size prefix_size: Int,
+) -> Result(Stream(Result(BitArray, IncompleteFrame)), BinaryArgError) {
+  length_prefixed_with_checked(
+    over: stream,
+    prefix_size: prefix_size,
+    max_frame_size: default_max_frame_size,
+  )
+}
+
+/// Like `length_prefixed_with`, but returns the argument-validation
+/// failure as a `Result` instead of panicking. Use this when
+/// `prefix_size` comes from dynamic input.
+pub fn length_prefixed_with_checked(
+  over stream: Stream(BitArray),
+  prefix_size prefix_size: Int,
+  max_frame_size max_frame_size: Int,
+) -> Result(Stream(Result(BitArray, IncompleteFrame)), BinaryArgError) {
+  case prefix_size {
+    1 | 2 | 4 | 8 ->
+      Ok(length_prefixed_active(
+        stream,
+        <<>>,
+        prefix_size,
+        max_frame_size,
+        False,
+      ))
+    _ ->
+      Error(InvalidPrefixSize(function: "length_prefixed", given: prefix_size))
   }
 }
 
@@ -454,6 +521,26 @@ pub fn fixed_size(
   case size >= 1 {
     True -> fixed_size_active(stream, <<>>, size, False)
     False -> panic as "datastream/binary.fixed_size: size must be >= 1"
+  }
+}
+
+/// Like `fixed_size`, but returns the argument-validation failure as
+/// a `Result` instead of panicking. Use this when `size` comes from
+/// dynamic input (CLI, config, request parameters); the panicking
+/// `fixed_size` remains the right tool for trusted constants.
+///
+/// On success the stream behaves identically to
+/// `fixed_size(over: stream, size: size)`.
+///
+/// The caller is responsible for closing `stream` if the
+/// constructor returns `Error`.
+pub fn fixed_size_checked(
+  over stream: Stream(BitArray),
+  size size: Int,
+) -> Result(Stream(BitArray), BinaryArgError) {
+  case size >= 1 {
+    True -> Ok(fixed_size_active(stream, <<>>, size, False))
+    False -> Error(NotPositiveSize(function: "fixed_size", given: size))
   }
 }
 

--- a/src/datastream/erlang/par.gleam
+++ b/src/datastream/erlang/par.gleam
@@ -115,6 +115,35 @@ import gleam/option.{type Option, None, Some}
 // --- common argument validation --------------------------------------------
 
 @target(erlang)
+/// Why a checked `par.*` constructor refused its arguments.
+///
+/// Returned by `map_unordered_with_checked`,
+/// `map_ordered_with_checked`, `each_unordered_with_checked`,
+/// `each_ordered_with_checked`, and `merge_with_checked`. Lets the
+/// caller surface argument-validation failures through `Result`
+/// instead of crashing the process — useful when the numeric
+/// arguments come from CLI flags, config files, or request
+/// parameters.
+///
+/// `function` names the constructor that rejected the value
+/// (`"map_unordered_with"`, `"map_ordered_with"`,
+/// `"each_unordered_with"`, `"each_ordered_with"`, `"merge_with"`)
+/// so a caller routing many checked constructors through the same
+/// handler can produce a meaningful error message.
+pub type ParArgError {
+  /// `max_workers` was less than 1. `given` is the value the caller
+  /// passed.
+  InvalidMaxWorkers(function: String, given: Int)
+  /// `max_buffer` was less than `max_workers` for `map_*_with` /
+  /// `each_*_with`. Both values are reported so the caller can fix
+  /// either side.
+  BufferLessThanWorkers(function: String, max_workers: Int, max_buffer: Int)
+  /// `max_buffer` was less than 1 for `merge_with`. `given` is the
+  /// value the caller passed.
+  InvalidMaxBuffer(function: String, given: Int)
+}
+
+@target(erlang)
 fn validate_par_args(max_workers: Int, max_buffer: Int) -> Nil {
   case max_workers >= 1 {
     True -> Nil
@@ -127,10 +156,39 @@ fn validate_par_args(max_workers: Int, max_buffer: Int) -> Nil {
 }
 
 @target(erlang)
+fn check_par_args(
+  function: String,
+  max_workers: Int,
+  max_buffer: Int,
+) -> Result(Nil, ParArgError) {
+  case max_workers >= 1 {
+    False -> Error(InvalidMaxWorkers(function: function, given: max_workers))
+    True ->
+      case max_buffer >= max_workers {
+        False ->
+          Error(BufferLessThanWorkers(
+            function: function,
+            max_workers: max_workers,
+            max_buffer: max_buffer,
+          ))
+        True -> Ok(Nil)
+      }
+  }
+}
+
+@target(erlang)
 fn validate_buffer(max_buffer: Int) -> Nil {
   case max_buffer >= 1 {
     True -> Nil
     False -> panic as "datastream/erlang/par.merge: max_buffer must be >= 1"
+  }
+}
+
+@target(erlang)
+fn check_buffer(function: String, max_buffer: Int) -> Result(Nil, ParArgError) {
+  case max_buffer >= 1 {
+    True -> Ok(Nil)
+    False -> Error(InvalidMaxBuffer(function: function, given: max_buffer))
   }
 }
 
@@ -193,6 +251,44 @@ pub fn map_unordered_with(
     result_subject: result_subject,
     source_drained: False,
   ))
+}
+
+@target(erlang)
+/// Like `map_unordered_with`, but returns the argument-validation
+/// failure as a `Result` instead of panicking. Use this when
+/// `max_workers` or `max_buffer` come from dynamic input (CLI,
+/// config, request parameters); the panicking `map_unordered_with`
+/// remains the right tool for trusted constants.
+///
+/// On success the stream behaves identically to
+/// `map_unordered_with(over: stream, with: f, max_workers: ...,
+/// max_buffer: ...)`.
+///
+/// The caller is responsible for closing `stream` if the
+/// constructor returns `Error`.
+pub fn map_unordered_with_checked(
+  over stream: Stream(a),
+  with f: fn(a) -> b,
+  max_workers max_workers: Int,
+  max_buffer max_buffer: Int,
+) -> Result(Stream(b), ParArgError) {
+  case check_par_args("map_unordered_with", max_workers, max_buffer) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> {
+      let result_subject = process.new_subject()
+      Ok(
+        build_map_unordered_stream(MapUnordered(
+          source: stream,
+          f: f,
+          max_workers: max_workers,
+          max_buffer: max_buffer,
+          workers_busy: 0,
+          result_subject: result_subject,
+          source_drained: False,
+        )),
+      )
+    }
+  }
 }
 
 @target(erlang)
@@ -360,6 +456,48 @@ pub fn map_ordered_with(
 }
 
 @target(erlang)
+/// Like `map_ordered_with`, but returns the argument-validation
+/// failure as a `Result` instead of panicking. Use this when
+/// `max_workers` or `max_buffer` come from dynamic input (CLI,
+/// config, request parameters); the panicking `map_ordered_with`
+/// remains the right tool for trusted constants.
+///
+/// On success the stream behaves identically to
+/// `map_ordered_with(over: stream, with: f, max_workers: ...,
+/// max_buffer: ...)`.
+///
+/// The caller is responsible for closing `stream` if the
+/// constructor returns `Error`.
+pub fn map_ordered_with_checked(
+  over stream: Stream(a),
+  with f: fn(a) -> b,
+  max_workers max_workers: Int,
+  max_buffer max_buffer: Int,
+) -> Result(Stream(b), ParArgError) {
+  case check_par_args("map_ordered_with", max_workers, max_buffer) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> {
+      let result_subject = process.new_subject()
+      Ok(
+        build_map_ordered_stream(MapOrdered(
+          source: stream,
+          f: f,
+          max_workers: max_workers,
+          max_buffer: max_buffer,
+          workers_busy: 0,
+          in_flight: 0,
+          next_dispatch_index: 0,
+          next_emit_index: 0,
+          result_subject: result_subject,
+          pending: dict.new(),
+          source_drained: False,
+        )),
+      )
+    }
+  }
+}
+
+@target(erlang)
 fn build_map_ordered_stream(state: MapOrdered(a, b)) -> Stream(b) {
   datastream.make(pull: fn() { map_ordered_step(state) }, close: fn() {
     map_ordered_close(state)
@@ -508,6 +646,31 @@ pub fn each_ordered_with(
 }
 
 @target(erlang)
+/// Like `each_ordered_with`, but returns the argument-validation
+/// failure as a `Result` instead of panicking. The effect runs only
+/// when the arguments validate; on `Error` no upstream pull happens
+/// and the caller is responsible for closing `stream`.
+pub fn each_ordered_with_checked(
+  over stream: Stream(a),
+  with effect: fn(a) -> Nil,
+  max_workers max_workers: Int,
+  max_buffer max_buffer: Int,
+) -> Result(Nil, ParArgError) {
+  case check_par_args("each_ordered_with", max_workers, max_buffer) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> {
+      each_ordered_with(
+        over: stream,
+        with: effect,
+        max_workers: max_workers,
+        max_buffer: max_buffer,
+      )
+      Ok(Nil)
+    }
+  }
+}
+
+@target(erlang)
 /// Side-effect-only variant of `map_unordered`. Uses
 /// `default_max_workers` and `default_max_buffer`.
 pub fn each_unordered(over stream: Stream(a), with effect: fn(a) -> Nil) -> Nil {
@@ -537,6 +700,31 @@ pub fn each_unordered_with(
     max_buffer: max_buffer,
   )
   |> fold.drain
+}
+
+@target(erlang)
+/// Like `each_unordered_with`, but returns the argument-validation
+/// failure as a `Result` instead of panicking. The effect runs only
+/// when the arguments validate; on `Error` no upstream pull happens
+/// and the caller is responsible for closing `stream`.
+pub fn each_unordered_with_checked(
+  over stream: Stream(a),
+  with effect: fn(a) -> Nil,
+  max_workers max_workers: Int,
+  max_buffer max_buffer: Int,
+) -> Result(Nil, ParArgError) {
+  case check_par_args("each_unordered_with", max_workers, max_buffer) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> {
+      each_unordered_with(
+        over: stream,
+        with: effect,
+        max_workers: max_workers,
+        max_buffer: max_buffer,
+      )
+      Ok(Nil)
+    }
+  }
 }
 
 // --- merge ---------------------------------------------------------------
@@ -600,6 +788,33 @@ pub fn merge_with(
   max_buffer max_buffer: Int,
 ) -> Stream(a) {
   validate_buffer(max_buffer)
+  merge_with_unchecked(streams, max_buffer)
+}
+
+@target(erlang)
+/// Like `merge_with`, but returns the argument-validation failure
+/// as a `Result` instead of panicking. Use this when `max_buffer`
+/// comes from dynamic input (CLI, config, request parameters); the
+/// panicking `merge_with` remains the right tool for trusted
+/// constants.
+///
+/// On success the stream behaves identically to
+/// `merge_with(streams: streams, max_buffer: max_buffer)`.
+///
+/// The caller is responsible for closing each stream in `streams`
+/// if the constructor returns `Error`.
+pub fn merge_with_checked(
+  streams streams: List(Stream(a)),
+  max_buffer max_buffer: Int,
+) -> Result(Stream(a), ParArgError) {
+  case check_buffer("merge_with", max_buffer) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> Ok(merge_with_unchecked(streams, max_buffer))
+  }
+}
+
+@target(erlang)
+fn merge_with_unchecked(streams: List(Stream(a)), max_buffer: Int) -> Stream(a) {
   let result_subj = process.new_subject()
   let coordinator_pid = process.self()
   let all_signals =

--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -118,19 +118,26 @@ pub fn drop(from stream: Stream(a), up_to n: Int) -> Stream(a) {
 
 /// Why a checked stream constructor refused its argument.
 ///
-/// Returned by `take_checked`, `drop_checked`, and any future
-/// non-panicking variant of a constructor that would otherwise
-/// reject its argument with a `panic`. Lets the caller surface
-/// argument-validation failures through `Result` instead of
-/// crashing the process — useful when the numeric argument comes
-/// from CLI flags, config files, or request parameters.
+/// Returned by `take_checked`, `drop_checked`, `buffer_checked`,
+/// `chunks_of_checked`, and any future non-panicking variant of a
+/// constructor that would otherwise reject its argument with a
+/// `panic`. Lets the caller surface argument-validation failures
+/// through `Result` instead of crashing the process — useful when
+/// the numeric argument comes from CLI flags, config files, or
+/// request parameters.
 ///
 /// `function` names the constructor that rejected the value
-/// (`"take"`, `"drop"`, ...) so a caller routing many checked
-/// constructors through the same handler can produce a meaningful
-/// error message.
+/// (`"take"`, `"drop"`, `"buffer"`, `"chunks_of"`) so a caller
+/// routing many checked constructors through the same handler can
+/// produce a meaningful error message.
+///
+/// - `NegativeCount` covers constructors whose contract is `>= 0`
+///   (`take`, `drop`).
+/// - `NotPositive` covers constructors whose contract is `>= 1`
+///   (`buffer`, `chunks_of`).
 pub type StreamArgError {
   NegativeCount(function: String, given: Int)
+  NotPositive(function: String, given: Int)
 }
 
 /// Like `take`, but returns the argument-validation failure as a
@@ -612,6 +619,27 @@ pub fn buffer(over stream: Stream(a), prefetch capacity: Int) -> Stream(a) {
   }
 }
 
+/// Like `buffer`, but returns the argument-validation failure as a
+/// `Result` instead of panicking. Use this when `capacity` comes
+/// from dynamic input (CLI, config, request parameters); the
+/// panicking `buffer` remains the right tool for trusted constants.
+///
+/// On success the stream behaves identically to
+/// `buffer(over: stream, prefetch: capacity)`.
+///
+/// The caller is responsible for closing `stream` if the
+/// constructor returns `Error` — no upstream pull happens, but the
+/// upstream is otherwise untouched.
+pub fn buffer_checked(
+  over stream: Stream(a),
+  prefetch capacity: Int,
+) -> Result(Stream(a), StreamArgError) {
+  case capacity < 1 {
+    True -> Error(NotPositive(function: "buffer", given: capacity))
+    False -> Ok(buffer_active(stream, [], 0, capacity))
+  }
+}
+
 fn buffer_active(
   stream: Stream(a),
   buf: List(a),
@@ -1001,6 +1029,26 @@ pub fn chunks_of(over stream: Stream(a), into size: Int) -> Stream(Chunk(a)) {
   case size < 1 {
     True -> panic as "datastream/stream.chunks_of: size must be >= 1"
     False -> chunks_active(stream, [], 0, size)
+  }
+}
+
+/// Like `chunks_of`, but returns the argument-validation failure as
+/// a `Result` instead of panicking. Use this when `size` comes from
+/// dynamic input (CLI, config, request parameters); the panicking
+/// `chunks_of` remains the right tool for trusted constants.
+///
+/// On success the stream behaves identically to
+/// `chunks_of(over: stream, into: size)`.
+///
+/// The caller is responsible for closing `stream` if the
+/// constructor returns `Error`.
+pub fn chunks_of_checked(
+  over stream: Stream(a),
+  into size: Int,
+) -> Result(Stream(Chunk(a)), StreamArgError) {
+  case size < 1 {
+    True -> Error(NotPositive(function: "chunks_of", given: size))
+    False -> Ok(chunks_active(stream, [], 0, size))
   }
 }
 

--- a/test/datastream/binary_test.gleam
+++ b/test/datastream/binary_test.gleam
@@ -290,6 +290,70 @@ pub fn fixed_size_panics_on_negative_size_test() {
   did_panic |> should.be_true
 }
 
+// --- checked variants (#189) -------------------------------------------
+
+pub fn length_prefixed_checked_ok_decodes_one_byte_prefix_test() {
+  let assert Ok(s) =
+    binary.length_prefixed_checked(
+      over: from_list([<<2, 1, 2, 1, 3>>]),
+      prefix_size: 1,
+    )
+  s |> fold.to_list |> should.equal([Ok(<<1, 2>>), Ok(<<3>>)])
+}
+
+pub fn length_prefixed_checked_rejects_three_byte_prefix_test() {
+  let assert Error(binary.InvalidPrefixSize(function: name, given: g)) =
+    binary.length_prefixed_checked(over: from_list([<<>>]), prefix_size: 3)
+  name |> should.equal("length_prefixed")
+  g |> should.equal(3)
+}
+
+pub fn length_prefixed_checked_rejects_zero_prefix_test() {
+  let assert Error(binary.InvalidPrefixSize(function: _, given: g)) =
+    binary.length_prefixed_checked(over: from_list([<<>>]), prefix_size: 0)
+  g |> should.equal(0)
+}
+
+pub fn length_prefixed_with_checked_ok_decodes_one_byte_prefix_test() {
+  let assert Ok(s) =
+    binary.length_prefixed_with_checked(
+      over: from_list([<<2, 1, 2>>]),
+      prefix_size: 1,
+      max_frame_size: 64,
+    )
+  s |> fold.to_list |> should.equal([Ok(<<1, 2>>)])
+}
+
+pub fn length_prefixed_with_checked_rejects_invalid_prefix_test() {
+  let assert Error(binary.InvalidPrefixSize(function: name, given: g)) =
+    binary.length_prefixed_with_checked(
+      over: from_list([<<>>]),
+      prefix_size: 5,
+      max_frame_size: 64,
+    )
+  name |> should.equal("length_prefixed")
+  g |> should.equal(5)
+}
+
+pub fn fixed_size_checked_ok_matches_fixed_size_test() {
+  let assert Ok(s) =
+    binary.fixed_size_checked(over: from_list([<<1, 2, 3, 4, 5, 6>>]), size: 2)
+  s |> fold.to_list |> should.equal([<<1, 2>>, <<3, 4>>, <<5, 6>>])
+}
+
+pub fn fixed_size_checked_rejects_zero_test() {
+  let assert Error(binary.NotPositiveSize(function: name, given: g)) =
+    binary.fixed_size_checked(over: from_list([<<>>]), size: 0)
+  name |> should.equal("fixed_size")
+  g |> should.equal(0)
+}
+
+pub fn fixed_size_checked_rejects_negative_test() {
+  let assert Error(binary.NotPositiveSize(function: _, given: g)) =
+    binary.fixed_size_checked(over: from_list([<<>>]), size: -3)
+  g |> should.equal(-3)
+}
+
 // --- Issue #158: FrameTooLarge on oversized prefix claims ---
 
 pub fn length_prefixed_rejects_oversized_frame_claim_test() {

--- a/test/datastream/erlang/par_test.gleam
+++ b/test/datastream/erlang/par_test.gleam
@@ -546,6 +546,186 @@ pub fn merge_with_panics_on_zero_max_buffer_test() {
   did_panic |> should.be_true
 }
 
+// --- checked variants (#189) -------------------------------------------
+
+@target(erlang)
+pub fn map_unordered_with_checked_ok_matches_unchecked_test() {
+  let assert Ok(s) =
+    par.map_unordered_with_checked(
+      source.from_list([1, 2, 3]),
+      with: fn(x) { x * 2 },
+      max_workers: 2,
+      max_buffer: 4,
+    )
+  let result = s |> fold.to_list
+  list.sort(result, by: int_compare) |> should.equal([2, 4, 6])
+}
+
+@target(erlang)
+pub fn map_unordered_with_checked_rejects_zero_max_workers_test() {
+  let assert Error(par.InvalidMaxWorkers(function: name, given: g)) =
+    par.map_unordered_with_checked(
+      source.from_list([1]),
+      with: fn(x) { x },
+      max_workers: 0,
+      max_buffer: 4,
+    )
+  name |> should.equal("map_unordered_with")
+  g |> should.equal(0)
+}
+
+@target(erlang)
+pub fn map_unordered_with_checked_rejects_buffer_below_workers_test() {
+  let assert Error(par.BufferLessThanWorkers(
+    function: name,
+    max_workers: w,
+    max_buffer: b,
+  )) =
+    par.map_unordered_with_checked(
+      source.from_list([1]),
+      with: fn(x) { x },
+      max_workers: 4,
+      max_buffer: 2,
+    )
+  name |> should.equal("map_unordered_with")
+  w |> should.equal(4)
+  b |> should.equal(2)
+}
+
+@target(erlang)
+pub fn map_ordered_with_checked_ok_matches_unchecked_test() {
+  let assert Ok(s) =
+    par.map_ordered_with_checked(
+      source.from_list([1, 2, 3]),
+      with: fn(x) { x * 10 },
+      max_workers: 2,
+      max_buffer: 4,
+    )
+  s |> fold.to_list |> should.equal([10, 20, 30])
+}
+
+@target(erlang)
+pub fn map_ordered_with_checked_rejects_negative_max_workers_test() {
+  let assert Error(par.InvalidMaxWorkers(function: name, given: g)) =
+    par.map_ordered_with_checked(
+      source.from_list([1]),
+      with: fn(x) { x },
+      max_workers: -1,
+      max_buffer: 4,
+    )
+  name |> should.equal("map_ordered_with")
+  g |> should.equal(-1)
+}
+
+@target(erlang)
+pub fn map_ordered_with_checked_rejects_buffer_below_workers_test() {
+  let assert Error(par.BufferLessThanWorkers(
+    function: _,
+    max_workers: w,
+    max_buffer: b,
+  )) =
+    par.map_ordered_with_checked(
+      source.from_list([1]),
+      with: fn(x) { x },
+      max_workers: 4,
+      max_buffer: 1,
+    )
+  w |> should.equal(4)
+  b |> should.equal(1)
+}
+
+@target(erlang)
+pub fn merge_with_checked_ok_matches_unchecked_test() {
+  let assert Ok(s) =
+    par.merge_with_checked(
+      streams: [source.from_list([1, 2]), source.from_list([3, 4])],
+      max_buffer: 4,
+    )
+  let result = s |> fold.to_list
+  list.sort(result, by: int_compare) |> should.equal([1, 2, 3, 4])
+}
+
+@target(erlang)
+pub fn merge_with_checked_rejects_zero_max_buffer_test() {
+  let assert Error(par.InvalidMaxBuffer(function: name, given: g)) =
+    par.merge_with_checked(streams: [source.from_list([1])], max_buffer: 0)
+  name |> should.equal("merge_with")
+  g |> should.equal(0)
+}
+
+@target(erlang)
+pub fn each_unordered_with_checked_ok_runs_effect_test() {
+  let collector = process.new_subject()
+  let assert Ok(Nil) =
+    par.each_unordered_with_checked(
+      over: source.from_list([1, 2, 3]),
+      with: fn(x) { process.send(collector, x) },
+      max_workers: 2,
+      max_buffer: 4,
+    )
+  let received = collect_three(collector, [])
+  list.sort(received, by: int_compare) |> should.equal([1, 2, 3])
+}
+
+@target(erlang)
+pub fn each_unordered_with_checked_rejects_zero_max_workers_test() {
+  let assert Error(par.InvalidMaxWorkers(function: name, given: g)) =
+    par.each_unordered_with_checked(
+      over: source.from_list([1]),
+      with: fn(_) { Nil },
+      max_workers: 0,
+      max_buffer: 4,
+    )
+  name |> should.equal("each_unordered_with")
+  g |> should.equal(0)
+}
+
+@target(erlang)
+pub fn each_ordered_with_checked_ok_runs_effect_in_order_test() {
+  let collector = process.new_subject()
+  let assert Ok(Nil) =
+    par.each_ordered_with_checked(
+      over: source.from_list([1, 2, 3]),
+      with: fn(x) { process.send(collector, x) },
+      max_workers: 2,
+      max_buffer: 4,
+    )
+  let received = collect_three(collector, [])
+  // each_ordered_with preserves input order, so reversal of accumulator
+  // gives [1, 2, 3].
+  list.reverse(received) |> should.equal([1, 2, 3])
+}
+
+@target(erlang)
+pub fn each_ordered_with_checked_rejects_buffer_below_workers_test() {
+  let assert Error(par.BufferLessThanWorkers(
+    function: name,
+    max_workers: w,
+    max_buffer: b,
+  )) =
+    par.each_ordered_with_checked(
+      over: source.from_list([1]),
+      with: fn(_) { Nil },
+      max_workers: 3,
+      max_buffer: 1,
+    )
+  name |> should.equal("each_ordered_with")
+  w |> should.equal(3)
+  b |> should.equal(1)
+}
+
+@target(erlang)
+fn collect_three(subj: process.Subject(Int), acc: List(Int)) -> List(Int) {
+  case list.length(acc) >= 3 {
+    True -> acc
+    False ->
+      case process.receive(from: subj, within: 1000) {
+        Ok(x) -> collect_three(subj, [x, ..acc])
+        Error(_) -> acc
+      }
+  }
+}
+
 // --- panic-in-f terminates the stream with Done (#156) -------------------
 //
 // Worker panics are detected via process monitors. When a worker

--- a/test/datastream/stream_test.gleam
+++ b/test/datastream/stream_test.gleam
@@ -145,13 +145,10 @@ pub fn take_checked_zero_yields_empty_test() {
 }
 
 pub fn take_checked_negative_returns_error_test() {
-  case stream.take_checked(from: from_list([1, 2, 3]), up_to: -5) {
-    Ok(_) -> should.fail()
-    Error(stream.NegativeCount(function: name, given: g)) -> {
-      name |> should.equal("take")
-      g |> should.equal(-5)
-    }
-  }
+  let assert Error(stream.NegativeCount(function: name, given: g)) =
+    stream.take_checked(from: from_list([1, 2, 3]), up_to: -5)
+  name |> should.equal("take")
+  g |> should.equal(-5)
 }
 
 pub fn drop_checked_ok_matches_drop_test() {
@@ -160,13 +157,10 @@ pub fn drop_checked_ok_matches_drop_test() {
 }
 
 pub fn drop_checked_negative_returns_error_test() {
-  case stream.drop_checked(from: from_list([1, 2, 3]), up_to: -3) {
-    Ok(_) -> should.fail()
-    Error(stream.NegativeCount(function: name, given: g)) -> {
-      name |> should.equal("drop")
-      g |> should.equal(-3)
-    }
-  }
+  let assert Error(stream.NegativeCount(function: name, given: g)) =
+    stream.drop_checked(from: from_list([1, 2, 3]), up_to: -3)
+  name |> should.equal("drop")
+  g |> should.equal(-3)
 }
 
 pub fn take_while_yields_longest_passing_prefix_test() {
@@ -471,6 +465,26 @@ pub fn buffer_negative_panics_test() {
   did_panic |> should.be_true
 }
 
+pub fn buffer_checked_ok_matches_buffer_test() {
+  let assert Ok(s) =
+    stream.buffer_checked(over: from_list([1, 2, 3, 4]), prefetch: 2)
+  s |> fold.to_list |> should.equal([1, 2, 3, 4])
+}
+
+pub fn buffer_checked_zero_returns_error_test() {
+  let assert Error(stream.NotPositive(function: name, given: g)) =
+    stream.buffer_checked(over: from_list([1, 2, 3]), prefetch: 0)
+  name |> should.equal("buffer")
+  g |> should.equal(0)
+}
+
+pub fn buffer_checked_negative_returns_error_test() {
+  let assert Error(stream.NotPositive(function: name, given: g)) =
+    stream.buffer_checked(over: from_list([1, 2, 3]), prefetch: -4)
+  name |> should.equal("buffer")
+  g |> should.equal(-4)
+}
+
 fn signal_after(n: Int) -> Stream(Bool) {
   // Yields False for the first `n` pulls, then True forever.
   datastream.unfold(from: 0, with: fn(count) {
@@ -713,6 +727,26 @@ pub fn chunks_of_terminates_on_infinite_source_test() {
   |> stream.take(up_to: 3)
   |> chunks_to_lists
   |> should.equal([[1, 1], [1, 1], [1, 1]])
+}
+
+pub fn chunks_of_checked_ok_matches_chunks_of_test() {
+  let assert Ok(s) =
+    stream.chunks_of_checked(over: from_list([1, 2, 3, 4, 5]), into: 2)
+  s |> chunks_to_lists |> should.equal([[1, 2], [3, 4], [5]])
+}
+
+pub fn chunks_of_checked_zero_returns_error_test() {
+  let assert Error(stream.NotPositive(function: name, given: g)) =
+    stream.chunks_of_checked(over: from_list([1, 2, 3]), into: 0)
+  name |> should.equal("chunks_of")
+  g |> should.equal(0)
+}
+
+pub fn chunks_of_checked_negative_returns_error_test() {
+  let assert Error(stream.NotPositive(function: name, given: g)) =
+    stream.chunks_of_checked(over: from_list([1, 2, 3]), into: -2)
+  name |> should.equal("chunks_of")
+  g |> should.equal(-2)
 }
 
 pub fn group_adjacent_groups_runs_of_equal_test() {


### PR DESCRIPTION
## Summary

Adds non-panicking `*_checked` variants for the remaining invariant-enforcing constructors so callers passing dynamic numeric input (CLI flags, config files, request parameters) can stay on a typed path instead of crashing the process. Completes the checked-API surface started in #191 (`take_checked` / `drop_checked` already shipped in 0.8.0).

## Changes

- **src/datastream/stream.gleam**: extend `StreamArgError` with `NotPositive` variant; add `buffer_checked` and `chunks_of_checked`.
- **src/datastream/binary.gleam**: add `BinaryArgError` (with `InvalidPrefixSize` and `NotPositiveSize` variants); add `length_prefixed_checked`, `length_prefixed_with_checked`, `fixed_size_checked`.
- **src/datastream/erlang/par.gleam**: add `ParArgError` (with `InvalidMaxWorkers`, `BufferLessThanWorkers`, `InvalidMaxBuffer` variants); add `map_unordered_with_checked`, `map_ordered_with_checked`, `each_unordered_with_checked`, `each_ordered_with_checked`, `merge_with_checked`. Refactor `merge_with` to share its body with the checked variant via `merge_with_unchecked`.
- **test/datastream/stream_test.gleam**, **test/datastream/binary_test.gleam**, **test/datastream/erlang/par_test.gleam**: add Ok-path and Error-path tests for each new checked variant; convert the existing `take_checked` / `drop_checked` tests to ` let assert ` to stay exhaustive against the extended `StreamArgError`.
- **README.md**: add a "Trusted vs. untrusted constructor inputs" subsection under "When to use" that names the contract for each module's panicking constructor and points at the matching checked variant.
- **CHANGELOG.md**: document the new APIs under `[Unreleased]`.

## Design Decisions

- **Per-module error types** (`StreamArgError`, `BinaryArgError`, `ParArgError`) rather than one shared error enum. Each module's invariants are different shape (`NegativeCount` / `NotPositive` / `InvalidPrefixSize` / two-field `BufferLessThanWorkers`), and a unified type would force every module to import every variant. Per-module typing also matches Gleam's natural module boundary.
- **Each variant carries `function: String`** so a caller routing many checked constructors through the same handler can produce a meaningful diagnostic without a separate dispatch.
- **Panicking constructors unchanged**: existing fast-path callers continue to crash on programmer error per the module-level invalid-argument policy. Checked variants delegate to the same internal builders so behaviour on success is identical.
- **`each_*_with_checked` covered too** because they take the same `max_workers` / `max_buffer` parameters and benefit from the same dynamic-input path; their no-arg counterparts (`each_ordered`, `each_unordered`, `merge`, `map_*`) use trusted defaults and don't need checked variants.

Closes #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `*_checked` constructor variants for stream buffering, binary framing, and parallel operations that return `Result` instead of panicking on invalid arguments.
  * New diagnostic error types that capture invalid parameter details for consistent error handling.

* **Documentation**
  * Added guidance on choosing between panicking and checked constructors based on input source (trusted compile-time constants vs. dynamic/untrusted inputs).
  * Updated changelog with new API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->