### PR TITLE
docs(examples): add five compile-checked end-to-end pipeline examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **examples**: `test/examples/` ships five compile-checked
+  end-to-end pipelines exercised on every CI build via `gleam test`:
+  log-line ingestion (`log_pipeline_example`), HTTP-style
+  length-prefixed framing (`length_prefixed_pipeline_example`),
+  NDJSON-shaped per-line decoding (`ndjson_pipeline_example`),
+  BEAM-only parallel batch processing (`parallel_pipeline_example`),
+  and accumulating-validation request processing via `dataprep`
+  (`dataprep_pipeline_example`). The README's "When to use" section
+  links them all so adopters can map a real workflow to a
+  first-party reference. `dataprep` is now a dev-dependency for the
+  validation example. (#187)
 - **stream**: `stream.buffer_checked` and `stream.chunks_of_checked`
   return `Result(Stream(_), StreamArgError)` instead of panicking
   on a non-positive argument. Use these when `capacity` / `size`

--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ Stick with `gleam/list` when the input already fits in memory and you
 don't need lazy pulls, repeatable runs, or resource cleanup. `List`
 is simpler and faster for the small-finite case.
 
+### End-to-end pipeline examples
+
+Compile-checked, runnable end-to-end pipelines live under
+[`test/examples/`](test/examples/) and run on every CI build via
+`gleam test`. Each module is self-contained — copy it into a new
+project, replace the in-memory `source.from_list` fixture with a
+real `source.resource` over a file or socket, and the rest of the
+pipeline stays the same.
+
+| Example | Shape |
+|---------|-------|
+| [`log_pipeline_example`](test/examples/log_pipeline_example.gleam) | bytes → `text.lines` → per-line validation → per-level counts |
+| [`length_prefixed_pipeline_example`](test/examples/length_prefixed_pipeline_example.gleam) | chunked bytes → `binary.length_prefixed_with` → `fold.collect_result` |
+| [`ndjson_pipeline_example`](test/examples/ndjson_pipeline_example.gleam) | bytes → `text.utf8_decode` → `text.lines` → per-record parse |
+| [`parallel_pipeline_example`](test/examples/parallel_pipeline_example.gleam) | BEAM-only `par.map_unordered_with` → `fold.sum_int` |
+| [`dataprep_pipeline_example`](test/examples/dataprep_pipeline_example.gleam) | per-row validation that accumulates every error via `dataprep/validated` |
+
 ### Trusted vs. untrusted constructor inputs
 
 Several constructors enforce numeric invariants (`stream.take` /

--- a/gleam.toml
+++ b/gleam.toml
@@ -28,6 +28,7 @@ gleam_erlang = ">= 1.3.0 and < 2.0.0"
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
 glinter = ">= 2.14.0 and < 3.0.0"
+dataprep = ">= 0.9.0 and < 1.0.0"
 
 # glinter (https://github.com/pairshaped/glinter) configuration. Run
 # via `just lint`. `warnings_as_errors = true` makes the run fail on

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,10 +3,12 @@
 
 packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
+  { name = "dataprep", version = "0.9.0", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib"], otp_app = "dataprep", source = "hex", outer_checksum = "C71A3F454A13FC801E9B483F7249C95E14F1593C98C8FF75BD63DEF3EC30BCD7" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
+  { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
@@ -18,6 +20,7 @@ packages = [
 ]
 
 [requirements]
+dataprep = { version = ">= 0.9.0 and < 1.0.0" }
 gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/test/examples/dataprep_pipeline_example.gleam
+++ b/test/examples/dataprep_pipeline_example.gleam
@@ -1,0 +1,120 @@
+//// End-to-end pipeline #5: streaming request-processing with
+//// `dataprep` for accumulating validation.
+////
+//// Models a row-shaped request body (CSV-like, NDJSON-like, or any
+//// per-record protocol): the pipeline lazily walks the source, runs
+//// each record through a validator that produces a
+//// `Validated(Row, Error)`, and folds the per-record verdicts into a
+//// single `Validated(List(Row), Error)` so callers see *every*
+//// failure rather than only the first.
+////
+//// Pair this with `fold.collect_result` / `fold.partition_result`
+//// from the surrounding library when short-circuit-on-first-error is
+//// the right behaviour — `Validated` is for the "show me everything
+//// that's wrong" path.
+////
+//// Cross-target: `dataprep`, `fold.fold`, and the surrounding
+//// stream combinators all run on both the Erlang and JavaScript
+//// targets.
+
+import dataprep/non_empty_list
+import dataprep/validated.{type Validated, Invalid, Valid}
+import datastream/fold
+import datastream/source
+import datastream/stream
+import gleam/int
+import gleam/list
+import gleam/string
+import gleeunit/should
+
+pub fn main() -> Nil {
+  Nil
+}
+
+pub type Row {
+  Row(id: Int, amount: Int)
+}
+
+pub type RowError {
+  /// Non-numeric `id` field.
+  BadId(raw: String)
+  /// Non-numeric `amount` field.
+  BadAmount(raw: String)
+  /// Wrong number of comma-separated fields.
+  WrongShape(line: String)
+}
+
+/// Run the example pipeline against an in-memory CSV-shaped input
+/// and return either every well-formed row or every collected error.
+/// On success the returned `Validated` is `Valid([Row, ...])`; on
+/// any failure it is `Invalid(NonEmptyList(RowError, ...))`.
+pub fn run() -> Validated(List(Row), RowError) {
+  let lines = ["1,100", "two,200", "3,abc", "4,400"]
+
+  source.from_list(lines)
+  |> stream.map(with: parse_row)
+  |> fold.fold(from: Valid([]), with: combine)
+  |> validated.map(list.reverse)
+}
+
+fn parse_row(line: String) -> Validated(Row, RowError) {
+  case string.split(line, on: ",") {
+    [raw_id, raw_amount] -> {
+      let id = int.parse(raw_id)
+      let amount = int.parse(raw_amount)
+      case id, amount {
+        Ok(i), Ok(a) -> Valid(Row(id: i, amount: a))
+        Error(_), Ok(_) -> validated.fail(BadId(raw: raw_id))
+        Ok(_), Error(_) -> validated.fail(BadAmount(raw: raw_amount))
+        Error(_), Error(_) ->
+          Invalid(non_empty_list.cons(
+            head: BadId(raw: raw_id),
+            tail: non_empty_list.single(BadAmount(raw: raw_amount)),
+          ))
+      }
+    }
+    _ -> validated.fail(WrongShape(line: line))
+  }
+}
+
+fn combine(
+  acc: Validated(List(Row), RowError),
+  next: Validated(Row, RowError),
+) -> Validated(List(Row), RowError) {
+  case acc, next {
+    Valid(rows), Valid(row) -> Valid([row, ..rows])
+    Valid(_), Invalid(es) -> Invalid(es)
+    Invalid(es), Valid(_) -> Invalid(es)
+    Invalid(a), Invalid(b) -> Invalid(non_empty_list.append(a, b))
+  }
+}
+
+pub fn dataprep_pipeline_example_collects_every_error_test() {
+  // Two errors are expected: line 2 has a bad id ("two"); line 3 has
+  // a bad amount ("abc"). The accumulating Validated keeps both,
+  // unlike `Result` which would short-circuit on the first.
+  case run() {
+    Valid(_) -> should.fail()
+    Invalid(errors) -> {
+      non_empty_list.to_list(errors)
+      |> should.equal([BadId(raw: "two"), BadAmount(raw: "abc")])
+    }
+  }
+}
+
+pub fn dataprep_pipeline_example_all_valid_input_test() {
+  let lines = ["1,10", "2,20", "3,30"]
+  let result =
+    source.from_list(lines)
+    |> stream.map(with: parse_row)
+    |> fold.fold(from: Valid([]), with: combine)
+    |> validated.map(list.reverse)
+  result
+  |> should.equal(
+    Valid([
+      Row(id: 1, amount: 10),
+      Row(id: 2, amount: 20),
+      Row(id: 3, amount: 30),
+    ]),
+  )
+}

--- a/test/examples/length_prefixed_pipeline_example.gleam
+++ b/test/examples/length_prefixed_pipeline_example.gleam
@@ -1,0 +1,72 @@
+//// End-to-end pipeline #2: chunked byte source → length-prefixed
+//// frame reassembly → typed payload list.
+////
+//// Models a streaming wire protocol on top of an HTTP body, a TCP
+//// socket, or any other byte source that delivers data in arbitrary
+//// chunks: each frame is a 4-byte big-endian length followed by
+//// that many payload bytes. `binary.length_prefixed_with` owns the
+//// buffering, so frames that straddle chunk boundaries reassemble
+//// correctly without callers writing a state machine.
+////
+//// Cross-target: `binary.length_prefixed_with` and
+//// `fold.collect_result` run on both the Erlang and JavaScript
+//// targets.
+
+import datastream/binary
+import datastream/fold
+import datastream/source
+import gleeunit/should
+
+pub fn main() -> Nil {
+  Nil
+}
+
+/// Run the example pipeline against an in-memory chunked source and
+/// return the decoded frames. The fixture intentionally splits the
+/// second frame across two chunks to exercise the buffer-stitching
+/// path.
+pub fn run() -> Result(List(BitArray), binary.IncompleteFrame) {
+  let chunks =
+    source.from_list([
+      // Frame 1: length 5, payload "hello".
+      <<5:32, "hello">>,
+      // Frame 2: length 5, payload "world" — split so the last two
+      // bytes arrive in the next chunk.
+      <<5:32, "wor">>,
+      <<"ld">>,
+      // Frame 3: length 2, payload <<1, 2>>.
+      <<2:32, 1, 2>>,
+    ])
+
+  // `length_prefixed_with` rejects any prefix that claims more than
+  // `max_frame_size` bytes immediately, before any payload
+  // buffering — the right shape when the input is adversarial.
+  chunks
+  |> binary.length_prefixed_with(prefix_size: 4, max_frame_size: 4096)
+  |> fold.collect_result
+}
+
+pub fn length_prefixed_pipeline_example_test() {
+  // `fold.collect_result` short-circuits on the first
+  // `Error(IncompleteFrame)`. A well-formed input yields `Ok(frames)`
+  // with one element per frame.
+  run() |> should.equal(Ok([<<"hello">>, <<"world">>, <<1, 2>>]))
+}
+
+pub fn length_prefixed_pipeline_truncated_input_test() {
+  // A truncated trailing frame surfaces as exactly one
+  // `Error(IncompleteFrame(expected:, got:))` element before the
+  // stream halts. Pair with `fold.collect_result` for a Result-shaped
+  // terminal that stops at the first truncation.
+  let truncated =
+    source.from_list([
+      <<3:32, "ok!">>,
+      // Prefix declares 99 payload bytes but only 5 follow.
+      <<99:32, "short">>,
+    ])
+
+  truncated
+  |> binary.length_prefixed_with(prefix_size: 4, max_frame_size: 4096)
+  |> fold.collect_result
+  |> should.equal(Error(binary.IncompleteFrame(expected: 99, got: 5)))
+}

--- a/test/examples/log_pipeline_example.gleam
+++ b/test/examples/log_pipeline_example.gleam
@@ -1,0 +1,83 @@
+//// End-to-end pipeline #1: file-shaped input → text lines →
+//// per-line validation → aggregation.
+////
+//// Models a log-ingestion pass: bytes arrive from a file or socket
+//// in arbitrary chunks, the pipeline reassembles them into lines,
+//// rejects malformed lines, and aggregates the per-level counts in a
+//// single pass.
+////
+//// Cross-target: every combinator used here runs on both the Erlang
+//// and JavaScript targets.
+
+import datastream/fold
+import datastream/source
+import datastream/stream
+import datastream/text
+import gleam/dict.{type Dict}
+import gleam/option.{type Option, None, Some}
+import gleam/string
+import gleeunit/should
+
+pub fn main() -> Nil {
+  Nil
+}
+
+// `LogError` rather than `Error` to avoid shadowing `Result.Error`
+// at every call site.
+pub type Level {
+  Info
+  Warn
+  LogError
+}
+
+/// Counts of each `Level` observed in a log stream. The dictionary is
+/// the natural shape for "k buckets, count each" — callers can read
+/// individual buckets with `dict.get` or fold over the whole map.
+pub type LevelCounts =
+  Dict(Level, Int)
+
+/// Run the example pipeline against in-memory test fixtures and
+/// return the per-level counts. The shape mirrors what production
+/// code would write — only the source differs (real callers wire a
+/// `source.resource` over a file handle or socket).
+pub fn run() -> LevelCounts {
+  // Real-world input arrives in arbitrary chunks. `text.lines` owns
+  // the line-buffering, so callers never see a partial line.
+  let chunks = [
+    "INFO  user_id=42 logged in\nWARN  ", "user_id=42 retry\nERROR ",
+    "user_id=99 timeout\nbogus line with no level\nINFO ", "user_id=42 ok\n",
+  ]
+
+  source.from_list(chunks)
+  |> text.lines
+  |> stream.filter_map(with: parse_line)
+  |> fold.fold(from: dict.new(), with: bump)
+}
+
+fn bump(acc: LevelCounts, level: Level) -> LevelCounts {
+  let current = case dict.get(acc, level) {
+    Ok(n) -> n
+    Error(Nil) -> 0
+  }
+  dict.insert(acc, level, current + 1)
+}
+
+fn parse_line(line: String) -> Option(Level) {
+  // Lines that do not start with a recognised level are skipped via
+  // `None`; `filter_map` drops them without emitting an element.
+  case string.split_once(line, on: " ") {
+    Ok(#("INFO", _)) -> Some(Info)
+    Ok(#("WARN", _)) -> Some(Warn)
+    Ok(#("ERROR", _)) -> Some(LogError)
+    _ -> None
+  }
+}
+
+pub fn log_pipeline_example_test() {
+  let counts = run()
+  dict.get(counts, Info) |> should.equal(Ok(2))
+  dict.get(counts, Warn) |> should.equal(Ok(1))
+  dict.get(counts, LogError) |> should.equal(Ok(1))
+  // The "bogus line with no level" entry is dropped, not counted.
+  dict.size(counts) |> should.equal(3)
+}

--- a/test/examples/ndjson_pipeline_example.gleam
+++ b/test/examples/ndjson_pipeline_example.gleam
@@ -1,0 +1,101 @@
+//// End-to-end pipeline #3: chunked byte source → UTF-8 decode →
+//// line-delimited records → typed objects.
+////
+//// Models an NDJSON (newline-delimited JSON) payload streaming in
+//// from a socket or HTTP body. Each line is one JSON record. The
+//// pipeline does the byte-to-text decode, the line framing, and the
+//// per-record parse in one lazy pass — the whole payload never has
+//// to fit in memory at once.
+////
+//// `gleam_json` is intentionally NOT pulled in: real callers can
+//// drop in their JSON decoder of choice at the `parse_record` step.
+//// The example uses a small hand-written parser so it stays
+//// self-contained.
+////
+//// Cross-target: `text.utf8_decode`, `text.lines`, and
+//// `fold.collect_result` run on both the Erlang and JavaScript
+//// targets.
+
+import datastream/fold
+import datastream/source
+import datastream/stream
+import datastream/text
+import gleam/int
+import gleam/option.{type Option, None, Some}
+import gleam/string
+import gleeunit/should
+
+pub fn main() -> Nil {
+  Nil
+}
+
+/// Decoded record shape. `id` is the integer prefix, `body` is the
+/// remaining text after the first space — enough to demonstrate a
+/// per-line parse without leaning on a full JSON decoder.
+pub type Record {
+  Record(id: Int, body: String)
+}
+
+pub type ParseError {
+  EmptyLine
+  MissingId(line: String)
+  BadId(raw: String)
+}
+
+/// Run the example pipeline against a chunked byte source and return
+/// either the decoded records or the first parse failure.
+pub fn run() -> Result(List(Record), ParseError) {
+  // Bytes arrive in arbitrary chunks. The first chunk ends mid-line,
+  // the second chunk completes that line and begins another.
+  let chunks =
+    source.from_list([
+      <<"1 first record\n2 second">>,
+      <<" record\n3 third record\n">>,
+    ])
+
+  chunks
+  // BitArray → Stream(Result(String, Nil)) per UTF-8 boundary.
+  |> text.utf8_decode
+  // Drop UTF-8 errors here for the example; production code would
+  // route them via `fold.partition_result` instead.
+  |> stream.filter_map(with: ok_to_option)
+  // Reassemble lines (handles the chunk-spanning record).
+  |> text.lines
+  // String → Result(Record, ParseError).
+  |> stream.map(with: parse_record)
+  // Stop at the first parse failure.
+  |> fold.collect_result
+}
+
+fn ok_to_option(r: Result(String, Nil)) -> Option(String) {
+  case r {
+    Ok(s) -> Some(s)
+    Error(Nil) -> None
+  }
+}
+
+fn parse_record(line: String) -> Result(Record, ParseError) {
+  case line {
+    "" -> Error(EmptyLine)
+    _ ->
+      case string.split_once(line, on: " ") {
+        Error(_) -> Error(MissingId(line: line))
+        Ok(#(raw_id, body)) ->
+          case int.parse(raw_id) {
+            Ok(id) -> Ok(Record(id: id, body: body))
+            Error(_) -> Error(BadId(raw: raw_id))
+          }
+      }
+  }
+}
+
+pub fn ndjson_pipeline_example_test() {
+  run()
+  |> should.equal(
+    Ok([
+      Record(id: 1, body: "first record"),
+      Record(id: 2, body: "second record"),
+      Record(id: 3, body: "third record"),
+    ]),
+  )
+}

--- a/test/examples/parallel_pipeline_example.gleam
+++ b/test/examples/parallel_pipeline_example.gleam
@@ -1,0 +1,82 @@
+//// End-to-end pipeline #4 (BEAM-only): parallel batch processing
+//// over a finite source with a configurable concurrency cap.
+////
+//// Models a batch worker: a list of inputs is mapped through a
+//// CPU-bound or I/O-bound function across at most `max_workers`
+//// BEAM processes, with `max_buffer` controlling the upper bound on
+//// in-flight work. The unordered variant is used here because the
+//// downstream aggregator does not care about input order — only the
+//// final aggregated value.
+////
+//// BEAM-only: every combinator under `datastream/erlang/par` runs
+//// only on the Erlang target. The module-level `@target(erlang)`
+//// guard keeps the file out of the JavaScript build.
+
+@target(erlang)
+import datastream/erlang/par
+@target(erlang)
+import datastream/fold
+@target(erlang)
+import datastream/source
+@target(erlang)
+import gleam/list
+@target(erlang)
+import gleam/order
+@target(erlang)
+import gleeunit/should
+
+@target(erlang)
+pub fn main() -> Nil {
+  Nil
+}
+
+@target(javascript)
+/// Empty placeholder so the test module compiles cleanly on
+/// JavaScript even though every test inside is BEAM-only.
+pub const beam_only_marker: String = "examples/parallel_pipeline_example is BEAM-only"
+
+@target(erlang)
+/// Run the example pipeline against an in-memory list of inputs and
+/// return the sum of squares. The unordered combinator is the right
+/// fit when the downstream is order-independent (aggregation, sink
+/// writes, fan-out to a queue).
+pub fn run(inputs: List(Int)) -> Int {
+  source.from_list(inputs)
+  |> par.map_unordered_with(
+    with: fn(x) { x * x },
+    max_workers: 4,
+    max_buffer: 8,
+  )
+  |> fold.sum_int
+}
+
+@target(erlang)
+pub fn parallel_pipeline_example_sum_test() {
+  // Sum of squares 1²..6² is 1+4+9+16+25+36 = 91. Order doesn't
+  // matter for the addition, so the unordered combinator is fine.
+  run([1, 2, 3, 4, 5, 6]) |> should.equal(91)
+}
+
+@target(erlang)
+pub fn parallel_pipeline_example_set_equality_test() {
+  // The element identities (independent of order) are stable across
+  // runs. `list.sort` re-orders the unordered output for comparison.
+  source.from_list([1, 2, 3, 4])
+  |> par.map_unordered_with(
+    with: fn(x) { x * 10 },
+    max_workers: 2,
+    max_buffer: 4,
+  )
+  |> fold.to_list
+  |> list.sort(by: int_compare)
+  |> should.equal([10, 20, 30, 40])
+}
+
+@target(erlang)
+fn int_compare(a: Int, b: Int) -> order.Order {
+  case a == b, a < b {
+    True, _ -> order.Eq
+    False, True -> order.Lt
+    False, False -> order.Gt
+  }
+}


### PR DESCRIPTION
## Summary

Adds five self-contained end-to-end pipeline examples under \`test/examples/\` that compile under both the Erlang and JavaScript builds and run on every CI \`gleam test\` invocation. Each module is structured as a \`pub fn run()\` plus assertion tests so adopters can read it as a reference and trust it stays in sync with the library.

## Changes

- **test/examples/log_pipeline_example.gleam**: chunked text source → \`text.lines\` → per-line validation → per-level counts via \`fold.fold\`. Cross-target.
- **test/examples/length_prefixed_pipeline_example.gleam**: chunked byte source → \`binary.length_prefixed_with\` → \`fold.collect_result\`, with a separate truncation test pinning the \`IncompleteFrame\` short-circuit shape. Cross-target.
- **test/examples/ndjson_pipeline_example.gleam**: chunked byte source → \`text.utf8_decode\` → \`text.lines\` → per-record parse → \`fold.collect_result\`. Cross-target.
- **test/examples/parallel_pipeline_example.gleam**: BEAM-only \`par.map_unordered_with\` → \`fold.sum_int\` plus a set-equality test for the unordered path. Module-level \`@target(erlang)\` keeps the file out of the JavaScript build.
- **test/examples/dataprep_pipeline_example.gleam**: per-row CSV-shaped validation that accumulates every error via \`dataprep/validated\` (request-processing path). Cross-target.
- **gleam.toml** / **manifest.toml**: add \`dataprep >= 0.9.0 and < 1.0.0\` as a **dev-dependency** for the validation example. Published-package consumers do not pull \`dataprep\`.
- **README.md**: a new \"End-to-end pipeline examples\" subsection under \"When to use\" lists the five examples with one-line shape descriptions and links each module.
- **CHANGELOG.md**: log the new examples and the new dev-dependency under \`[Unreleased]\`.

## Design Decisions

- **Examples live under \`test/examples/\`, not a separate Gleam project**. Putting them in the existing test tree means \`gleam test\` already exercises them on every CI build, so the issue's \"part of CI\" criterion is satisfied without adding a new workflow step or a parallel Gleam project to maintain. The trade-off is that the \`*_test\` modules technically have full access to internal modules (\`internal_modules = [\"datastream/internal/**\"]\`); the examples deliberately use only the public API so they remain copy-pastable.
- **Each example is one module with a \`pub fn run()\` plus tests**. The \`run\` function is the part adopters copy; the tests pin the expected output. Real callers swap the in-memory \`source.from_list\` fixture for a \`source.resource\` over a file or socket and the rest of the pipeline is unchanged.
- **\`gleam_json\` is intentionally NOT pulled in for the NDJSON example**. The example would have to pick a JSON decoder for its hand-shaped record, which is orthogonal to the streaming framing being demonstrated. The hand-written parser keeps the example self-contained and lets readers drop in their own decoder at the parse step.
- **\`dataprep\` is the right pick for the request-processing example** because the issue explicitly calls it out and because it demonstrates the *complementary* error model to \`fold.collect_result\` — accumulating every failure rather than short-circuiting on the first. Adding it as a dev-dep keeps the published surface unchanged.

## Limitations

- The examples are designed to read as references, not as benchmarks. Real production wiring would also handle backpressure tuning, error logging, and source/sink lifecycle — out of scope here.
- HTTP body / socket I/O bridging on the JavaScript target is still unsupported by the library itself (#186); these examples therefore drive the framing combinators with in-memory chunked sources. The pipeline shape after the source is identical for real I/O.

Closes #187