### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-30
+
 ### Added
 
 - **examples**: `test/examples/` ships five compile-checked

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "datastream"
-version = "0.8.0"
+version = "0.9.0"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }


### PR DESCRIPTION
### Added

- **examples**: `test/examples/` ships five compile-checked
  end-to-end pipelines exercised on every CI build via `gleam test`:
  log-line ingestion (`log_pipeline_example`), HTTP-style
  length-prefixed framing (`length_prefixed_pipeline_example`),
  NDJSON-shaped per-line decoding (`ndjson_pipeline_example`),
  BEAM-only parallel batch processing (`parallel_pipeline_example`),
  and accumulating-validation request processing via `dataprep`
  (`dataprep_pipeline_example`). The README's "When to use" section
  links them all so adopters can map a real workflow to a
  first-party reference. `dataprep` is now a dev-dependency for the
  validation example. (#187)
- **stream**: `stream.buffer_checked` and `stream.chunks_of_checked`
  return `Result(Stream(_), StreamArgError)` instead of panicking
  on a non-positive argument. Use these when `capacity` / `size`
  comes from dynamic input (CLI, config, request parameters); the
  panicking `stream.buffer` and `stream.chunks_of` remain the right
  tool for trusted constants. `StreamArgError` gains a `NotPositive`
  variant for the new "must be `>= 1`" contract. (#189)
- **binary**: `binary.length_prefixed_checked`,
  `binary.length_prefixed_with_checked`, and
  `binary.fixed_size_checked` provide non-panicking variants of the
  framing constructors. The new `BinaryArgError` type exposes
  `InvalidPrefixSize` (for `prefix_size ∉ {1, 2, 4, 8}`) and
  `NotPositiveSize` (for `size < 1`). (#189)
- **erlang/par**: `par.map_unordered_with_checked`,
  `par.map_ordered_with_checked`, `par.each_unordered_with_checked`,
  `par.each_ordered_with_checked`, and `par.merge_with_checked`
  provide non-panicking variants of the parallel constructors. The
  new `ParArgError` type exposes `InvalidMaxWorkers`,
  `BufferLessThanWorkers`, and `InvalidMaxBuffer` so callers can
  diagnose which side of the contract failed. (#189)
- **README**: a "Trusted vs. untrusted constructor inputs" subsection
  documents the split and points dynamic-input callers at the
  `*_checked` variants. (#189)
