### PR TITLE
docs(readme): inline log-ingest and NDJSON examples for onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Use `datastream` when you need one or more of these:
 - the work is naturally chunked text or bytes
 - the Erlang target needs bounded parallel work or time-based stream operators
 
+For a hands-on tour, jump to the runnable
+[Log-ingest example](#log-ingest-example-bytes--lines--per-level-counts)
+or the [NDJSON example](#ndjson-example-chunked-bytes--typed-records).
+The full catalog of compile-checked end-to-end pipelines lives under
+[Example pipelines](#example-pipelines).
+
 Stay with `gleam/list` when the whole input is already in memory and you
 do not need lazy pulls, replayable pipelines, or deterministic cleanup.
 
@@ -46,6 +52,143 @@ pub fn main() {
   // [2, 4, 6, 8, 10]
 }
 ```
+
+## Log-ingest example: bytes -> lines -> per-level counts
+
+A common shape: bytes arrive in arbitrary chunks (file, socket), the
+pipeline reassembles them into lines, drops malformed rows, and produces
+per-level counts in a single pass. `text.lines` owns the line buffering,
+so the chunk boundaries shown below never split a record across two
+emitted strings.
+
+```gleam
+import datastream/fold
+import datastream/source
+import datastream/stream
+import datastream/text
+import gleam/dict
+import gleam/io
+import gleam/option.{type Option, None, Some}
+import gleam/string
+
+pub type Level {
+  Info
+  Warn
+  LogError
+}
+
+pub fn main() {
+  // Real-world input arrives in arbitrary chunks. Note how `WARN` and
+  // `INFO` records straddle chunk boundaries — `text.lines` reassembles.
+  let chunks = [
+    "INFO  user_id=42 logged in\nWARN  ", "user_id=42 retry\nERROR ",
+    "user_id=99 timeout\nbogus line with no level\nINFO ",
+    "user_id=42 ok\n",
+  ]
+
+  source.from_list(chunks)
+  |> text.lines
+  |> stream.filter_map(with: parse_line)
+  |> fold.fold(from: dict.new(), with: bump)
+  |> io.debug
+  // dict.from_list([#(Info, 2), #(Warn, 1), #(LogError, 1)])
+}
+
+fn parse_line(line: String) -> Option(Level) {
+  case string.split_once(line, on: " ") {
+    Ok(#("INFO", _)) -> Some(Info)
+    Ok(#("WARN", _)) -> Some(Warn)
+    Ok(#("ERROR", _)) -> Some(LogError)
+    _ -> None
+  }
+}
+
+fn bump(acc: dict.Dict(Level, Int), level: Level) -> dict.Dict(Level, Int) {
+  let current = case dict.get(acc, level) {
+    Ok(n) -> n
+    Error(Nil) -> 0
+  }
+  dict.insert(acc, level, current + 1)
+}
+```
+
+Production callers swap `source.from_list(chunks)` for a
+`source.resource` over a real file handle or socket — the rest of the
+pipeline is unchanged. Full source:
+[`test/examples/log_pipeline_example.gleam`](https://github.com/nao1215/datastream/blob/main/test/examples/log_pipeline_example.gleam).
+
+## NDJSON example: chunked bytes -> typed records
+
+Newline-delimited JSON (one record per line) over a chunked byte source.
+The same lazy pass does UTF-8 decode, line framing, and per-record
+parsing without holding the whole payload in memory.
+
+```gleam
+import datastream/fold
+import datastream/source
+import datastream/stream
+import datastream/text
+import gleam/int
+import gleam/io
+import gleam/option.{type Option, None, Some}
+import gleam/string
+
+pub type Record {
+  Record(id: Int, body: String)
+}
+
+pub type ParseError {
+  EmptyLine
+  MissingId(line: String)
+  BadId(raw: String)
+}
+
+pub fn main() {
+  // The first chunk ends mid-line; the second completes that record.
+  let chunks =
+    source.from_list([
+      <<"1 first record\n2 second">>,
+      <<" record\n3 third record\n">>,
+    ])
+
+  chunks
+  |> text.utf8_decode
+  |> stream.filter_map(with: ok_to_option)
+  |> text.lines
+  |> stream.map(with: parse_record)
+  |> fold.collect_result
+  |> io.debug
+  // Ok([Record(1, "first record"), Record(2, "second record"), ...])
+}
+
+fn ok_to_option(r: Result(String, Nil)) -> Option(String) {
+  case r {
+    Ok(s) -> Some(s)
+    Error(Nil) -> None
+  }
+}
+
+fn parse_record(line: String) -> Result(Record, ParseError) {
+  case line {
+    "" -> Error(EmptyLine)
+    _ ->
+      case string.split_once(line, on: " ") {
+        Error(_) -> Error(MissingId(line: line))
+        Ok(#(raw_id, body)) ->
+          case int.parse(raw_id) {
+            Ok(id) -> Ok(Record(id: id, body: body))
+            Error(_) -> Error(BadId(raw: raw_id))
+          }
+      }
+  }
+}
+```
+
+`fold.collect_result` short-circuits at the first parse failure; swap in
+`fold.partition_result` to surface every successful record alongside
+every error. Drop in your JSON decoder of choice at `parse_record`.
+Full source:
+[`test/examples/ndjson_pipeline_example.gleam`](https://github.com/nao1215/datastream/blob/main/test/examples/ndjson_pipeline_example.gleam).
 
 ## Resource-backed streams
 
@@ -130,15 +273,17 @@ so resource-backed pipelines still release handles promptly.
 
 ## Example pipelines
 
-Compile-checked examples live under `test/examples/` and run in CI.
+Compile-checked examples live under `test/examples/` and run in CI. The
+log-ingest and NDJSON entries are inlined above; the rest are linked
+straight to source.
 
 | Example | Shape |
 | --- | --- |
-| `test/examples/log_pipeline_example.gleam` | bytes -> `text.lines` -> validation -> per-level counts |
-| `test/examples/length_prefixed_pipeline_example.gleam` | chunked bytes -> `binary.length_prefixed_with` -> collection |
-| `test/examples/ndjson_pipeline_example.gleam` | bytes -> UTF-8 decode -> lines -> per-record parse |
-| `test/examples/parallel_pipeline_example.gleam` | BEAM-only bounded parallel map |
-| `test/examples/dataprep_pipeline_example.gleam` | per-row validation with accumulated errors |
+| [`log_pipeline_example.gleam`](https://github.com/nao1215/datastream/blob/main/test/examples/log_pipeline_example.gleam) | bytes -> `text.lines` -> validation -> per-level counts |
+| [`ndjson_pipeline_example.gleam`](https://github.com/nao1215/datastream/blob/main/test/examples/ndjson_pipeline_example.gleam) | bytes -> UTF-8 decode -> lines -> per-record parse |
+| [`length_prefixed_pipeline_example.gleam`](https://github.com/nao1215/datastream/blob/main/test/examples/length_prefixed_pipeline_example.gleam) | chunked bytes -> `binary.length_prefixed_with` -> collection |
+| [`parallel_pipeline_example.gleam`](https://github.com/nao1215/datastream/blob/main/test/examples/parallel_pipeline_example.gleam) | BEAM-only bounded parallel map |
+| [`dataprep_pipeline_example.gleam`](https://github.com/nao1215/datastream/blob/main/test/examples/dataprep_pipeline_example.gleam) | per-row validation with accumulated errors |
 
 ## Module guide
 


### PR DESCRIPTION
## Summary

- Inline two end-to-end pipelines (log-ingest, NDJSON) in the README so first-time readers see a runnable shape before the module guide.
- Update the When to use it section to point straight at those sections.
- Convert the Example pipelines catalog into GitHub blob links so each row is a single click away from full source.

## Changes

- `README.md`: add Log-ingest example and NDJSON example sections between Quick start and Resource-backed streams. The snippets are condensed but compile-equivalent to `test/examples/log_pipeline_example.gleam` and `test/examples/ndjson_pipeline_example.gleam`. The catalog table at the bottom keeps every example, just as live links.

No source/test changes — kept internal cleanup out of scope per the issue's guidance.

## Test plan

- `just all` (clean + deps + format-check + glinter + Erlang/JS check + Erlang/JS build with --warnings-as-errors + Erlang/JS test + docs build) — 442 Erlang + 319 JavaScript tests pass

Closes #197