### PR TITLE
feat(text): add utf8_decode_lossy for direct Stream(BitArray) -> Stream(String)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **text**: `datastream/text.utf8_decode_lossy` is a convenience wrapper
+  over `utf8_decode` that drops chunks which fail to decode and yields
+  a plain `Stream(String)`. The chunked-bytes → lines → records pipeline
+  (the most common shape) now composes directly without a hand-rolled
+  `Result(String, Nil) -> Option(String)` shim:
+  `chunks |> text.utf8_decode_lossy |> text.lines |> ...`. The strict
+  `utf8_decode` remains the right tool when callers need to observe
+  decode errors via `fold.partition_result`. README and the
+  `ndjson_pipeline_example` are updated to lead with the lossy variant.
+  (#200)
+
 ## [0.10.0] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ import datastream/stream
 import datastream/text
 import gleam/int
 import gleam/io
-import gleam/option.{type Option, None, Some}
 import gleam/string
 
 pub type Record {
@@ -152,20 +151,12 @@ pub fn main() {
     ])
 
   chunks
-  |> text.utf8_decode
-  |> stream.filter_map(with: ok_to_option)
+  |> text.utf8_decode_lossy
   |> text.lines
   |> stream.map(with: parse_record)
   |> fold.collect_result
   |> io.debug
   // Ok([Record(1, "first record"), Record(2, "second record"), ...])
-}
-
-fn ok_to_option(r: Result(String, Nil)) -> Option(String) {
-  case r {
-    Ok(s) -> Some(s)
-    Error(Nil) -> None
-  }
 }
 
 fn parse_record(line: String) -> Result(Record, ParseError) {

--- a/src/datastream/text.gleam
+++ b/src/datastream/text.gleam
@@ -495,6 +495,41 @@ fn consume_continuation(
   }
 }
 
+/// Decode a stream of UTF-8 byte chunks into a stream of decoded
+/// strings, silently dropping any chunk that fails to decode.
+///
+/// Convenience wrapper for the common "I just want strings" pipeline:
+/// `chunks |> text.utf8_decode_lossy |> text.lines |> ...` typechecks
+/// without a hand-rolled `Result(String, Nil) -> Option(String)` shim.
+///
+/// Use this when invalid UTF-8 should be tolerated as data corruption
+/// the caller does not need to observe (most file/socket reads of
+/// known-good text). Use `utf8_decode` directly when the caller needs
+/// to surface decode errors — for example via
+/// `fold.partition_result` to log them while still streaming the
+/// successful records through.
+pub fn utf8_decode_lossy(over stream: Stream(BitArray)) -> Stream(String) {
+  utf8_decode_lossy_active(utf8_decode(over: stream))
+}
+
+fn utf8_decode_lossy_active(
+  source: Stream(Result(String, Nil)),
+) -> Stream(String) {
+  datastream.make(pull: fn() { utf8_decode_lossy_pull(source) }, close: fn() {
+    datastream.close(source)
+  })
+}
+
+fn utf8_decode_lossy_pull(
+  source: Stream(Result(String, Nil)),
+) -> Step(String, Stream(String)) {
+  case datastream.pull(source) {
+    Done -> Done
+    Next(Ok(s), rest) -> Next(s, utf8_decode_lossy_active(rest))
+    Next(Error(Nil), rest) -> utf8_decode_lossy_pull(rest)
+  }
+}
+
 /// Encode a stream of strings as UTF-8 byte chunks.
 ///
 /// Each input string maps to its UTF-8 encoding as a single

--- a/test/datastream/text_test.gleam
+++ b/test/datastream/text_test.gleam
@@ -362,6 +362,61 @@ pub fn utf8_decode_rejects_consecutive_lone_continuation_bytes_test() {
   |> should.equal([Error(Nil), Error(Nil)])
 }
 
+// --- utf8_decode_lossy ----------------------------------------------------
+
+pub fn utf8_decode_lossy_simple_ascii_test() {
+  from_list([<<104, 105>>])
+  |> text.utf8_decode_lossy
+  |> fold.to_list
+  |> should.equal(["hi"])
+}
+
+pub fn utf8_decode_lossy_drops_invalid_lead_byte_test() {
+  // 0xFF is not a valid lead byte. The lossy variant drops the error
+  // entirely rather than emitting Error(Nil), so the surrounding ASCII
+  // bytes pass through as plain strings.
+  from_list([<<104, 255, 105>>])
+  |> text.utf8_decode_lossy
+  |> fold.to_list
+  |> should.equal(["h", "i"])
+}
+
+pub fn utf8_decode_lossy_drops_incomplete_trailing_sequence_test() {
+  // A 4-byte lead with only 2 bytes available at EOF is invalid; the
+  // lossy variant drops it without yielding any element.
+  from_list([<<240, 159>>])
+  |> text.utf8_decode_lossy
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn utf8_decode_lossy_reassembles_split_codepoint_test() {
+  // The boundary-spanning multi-byte codepoint still reassembles —
+  // the lossy variant only drops actual decode errors, it does not
+  // change the chunk-boundary handling of the underlying decoder.
+  from_list([<<240, 159>>, <<145, 141>>])
+  |> text.utf8_decode_lossy
+  |> fold.to_list
+  |> should.equal(["👍"])
+}
+
+pub fn utf8_decode_lossy_empty_source_test() {
+  from_list([])
+  |> text.utf8_decode_lossy
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn utf8_decode_lossy_composes_with_lines_test() {
+  // The motivating use case from issue #200: BitArray chunks → UTF-8
+  // → line framing without a hand-rolled Result-to-Option shim.
+  from_list([<<"1 first\n2 sec">>, <<"ond\n3 third\n">>])
+  |> text.utf8_decode_lossy
+  |> text.lines
+  |> fold.to_list
+  |> should.equal(["1 first", "2 second", "3 third"])
+}
+
 // --- utf8_encode ----------------------------------------------------------
 
 pub fn utf8_encode_ascii_test() {

--- a/test/examples/ndjson_pipeline_example.gleam
+++ b/test/examples/ndjson_pipeline_example.gleam
@@ -21,7 +21,6 @@ import datastream/source
 import datastream/stream
 import datastream/text
 import gleam/int
-import gleam/option.{type Option, None, Some}
 import gleam/string
 import gleeunit/should
 
@@ -54,24 +53,17 @@ pub fn run() -> Result(List(Record), ParseError) {
     ])
 
   chunks
-  // BitArray → Stream(Result(String, Nil)) per UTF-8 boundary.
-  |> text.utf8_decode
-  // Drop UTF-8 errors here for the example; production code would
-  // route them via `fold.partition_result` instead.
-  |> stream.filter_map(with: ok_to_option)
+  // BitArray → Stream(String), dropping any UTF-8 decode errors.
+  // Production code that needs to surface those errors should use
+  // `text.utf8_decode` and route the resulting `Stream(Result(...))`
+  // via `fold.partition_result` instead.
+  |> text.utf8_decode_lossy
   // Reassemble lines (handles the chunk-spanning record).
   |> text.lines
   // String → Result(Record, ParseError).
   |> stream.map(with: parse_record)
   // Stop at the first parse failure.
   |> fold.collect_result
-}
-
-fn ok_to_option(r: Result(String, Nil)) -> Option(String) {
-  case r {
-    Ok(s) -> Some(s)
-    Error(Nil) -> None
-  }
 }
 
 fn parse_record(line: String) -> Result(Record, ParseError) {


### PR DESCRIPTION
## Summary

Adds `datastream/text.utf8_decode_lossy : Stream(BitArray) -> Stream(String)` so the canonical chunked-bytes → lines → records pipeline composes directly:

```gleam
chunks
|> text.utf8_decode_lossy
|> text.lines
|> stream.map(with: parse_record)
|> fold.collect_result
```

Previously the same shape required every caller to hand-roll a `Result(String, Nil) -> Option(String)` filter because the strict `utf8_decode` yields `Stream(Result(String, _))` while `text.lines` consumes `Stream(String)`. The README's own NDJSON example needed this private helper — that gap is what #200 was reporting.

The strict `utf8_decode` remains the right tool when callers need to surface decode errors (e.g. via `fold.partition_result`); `utf8_decode_lossy` is the right tool when invalid UTF-8 should be tolerated as data corruption the caller does not need to observe (most file/socket reads of known-good text).

## Changes

- `src/datastream/text.gleam`: new `utf8_decode_lossy` and its private `utf8_decode_lossy_active` / `utf8_decode_lossy_pull` helpers. Implementation reuses the existing `utf8_decode` so all UTF-8 boundary handling, multi-byte reassembly, and error classification stay in one place.
- `test/datastream/text_test.gleam`: 6 new tests covering ASCII passthrough, invalid lead bytes, incomplete trailing sequences, codepoints split across chunk boundaries, empty source, and the motivating `utf8_decode_lossy |> text.lines` composition.
- `README.md`, `test/examples/ndjson_pipeline_example.gleam`: lead with `utf8_decode_lossy`, drop the `ok_to_option` shim and the `gleam/option` import.
- `CHANGELOG.md`: `[Unreleased]` entry under `Added`.

## Design Decisions

- **Picked direction (1) "lossy variant" from the issue's three options.** It is additive (no breaking changes), removes the shim from the canonical pipeline, and stays internal-buffer-free by reusing the strict decoder. Direction (2) (`text.lines` accepting `Stream(Result(...))`) would require either an overload or a new function and changes the line-framing surface; direction (3) (a generic `unwrap_ok` helper) leaks `Result`-handling into the text module's vocabulary. (1) is the cheapest fix that closes the reported gap.
- **`utf8_decode_lossy` composes `utf8_decode` rather than duplicating its decoder.** The cost is one extra `Result` wrapper per element — cheap, and it keeps all UTF-8 boundary correctness centralised.

## Test Plan

- [x] `just all` (Erlang + JS targets, format-check, lint, build, test, docs) passes locally.
- [x] New tests cover the six observable behaviours of `utf8_decode_lossy`.
- [x] CI to confirm both targets remain green.

Closes #200
