### PR TITLE
chore(release): prepare v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-05
+
 ### Added
 
 - **text**: `datastream/text.utf8_decode_lossy` is a convenience wrapper

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "datastream"
-version = "0.10.0"
+version = "0.11.0"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }


### PR DESCRIPTION
### Added

- **text**: `datastream/text.utf8_decode_lossy` is a convenience wrapper
  over `utf8_decode` that drops chunks which fail to decode and yields
  a plain `Stream(String)`. The chunked-bytes → lines → records pipeline
  (the most common shape) now composes directly without a hand-rolled
  `Result(String, Nil) -> Option(String)` shim:
  `chunks |> text.utf8_decode_lossy |> text.lines |> ...`. The strict
  `utf8_decode` remains the right tool when callers need to observe
  decode errors via `fold.partition_result`. README and the
  `ndjson_pipeline_example` are updated to lead with the lossy variant.
  (#200)
