### PR TITLE
docs(stream): document take(s, 0) and drop(s, 0) resource asymmetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- **stream**: `take` and `drop` docstrings now spell out the
+  `n == 0` resource-handling asymmetry side-by-side: `take(s, 0)`
+  closes the upstream eagerly on the first pull; `drop(s, 0)` is the
+  identity and does not pre-close. The `take` docstring carries the
+  authoritative table, and `drop` cross-references it. Callers
+  building `drop(s, 0)` for unknown `n` and discarding the stream
+  without consuming it must close `s` themselves; the recommended
+  practice (drive through a terminal regardless of which branch the
+  runtime took) is documented inline. (#204)
+
 ## [0.11.0] - 2026-05-05
 
 ### Added

--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -78,6 +78,40 @@ fn filter_pull(
 /// Stops pulling upstream the moment the `n`th element has been
 /// emitted, and closes the upstream on that early exit. This is what
 /// makes `take` safe on infinite resource-backed sources.
+///
+/// **Resource handling at `n == 0`** — early-exit semantics extend to
+/// the degenerate case: the first `pull` returns `Done` *and* closes
+/// the upstream. This is asymmetric with `drop(s, 0)`, which is the
+/// identity (no close, no pull). For dynamic-`n` pipelines built from
+/// `take_checked` / `drop_checked` where `n` may end up `0`, see the
+/// "Asymmetry of `take(s, 0)` and `drop(s, 0)`" subsection below for
+/// guidance.
+///
+/// ## Asymmetry of `take(s, 0)` and `drop(s, 0)`
+///
+/// | Constructor   | Pull behaviour at `n == 0`           | Resource handling      |
+/// |---------------|---------------------------------------|------------------------|
+/// | `take(s, 0)`  | First pull returns `Done`            | Closes `s` eagerly     |
+/// | `drop(s, 0)`  | Identity (first pull pulls from `s`) | Does **not** pre-close |
+///
+/// Both choices follow each constructor's primary semantics
+/// (`take` is early-exit; `drop` is identity), but the combination
+/// surprises callers who treat the two as duals. Practical
+/// consequences:
+///
+/// - **`take(s, 0)` discarded without consumption** — upstream is
+///   auto-closed on the first pull, but if no terminal ever pulls,
+///   the resource stays open until the calling process exits.
+/// - **`drop(s, 0)` discarded without consumption** — upstream is
+///   never touched. Callers that build `drop(s, 0)` and throw away
+///   the result must close `s` themselves to avoid leaking
+///   resource-backed sources (`source.try_resource`, file handles,
+///   sockets).
+///
+/// When `n` comes from config / CLI / request parameters and may be
+/// `0`, prefer driving the resulting stream through a terminal
+/// (`fold.to_list`, `sink.each`, …) so the close path runs
+/// regardless of which branch the runtime took.
 pub fn take(from stream: Stream(a), up_to n: Int) -> Stream(a) {
   case n < 0 {
     True -> panic as "datastream/stream.take: count must be >= 0"
@@ -109,6 +143,14 @@ fn take_active(stream: Stream(a), n: Int) -> Stream(a) {
 /// `n` MUST be `>= 0`. A negative `n` is rejected at construction
 /// time with a panic per the `datastream` module-level
 /// invalid-argument policy.
+///
+/// **Resource handling at `n == 0`** — identity semantics: no
+/// upstream pull, no close. Asymmetric with `take(s, 0)` (which
+/// closes eagerly). Callers building `drop(s, 0)` for unknown `n`
+/// and discarding the result without consuming it are responsible
+/// for closing `s` themselves. See `take`'s "Asymmetry of `take(s,
+/// 0)` and `drop(s, 0)`" subsection above for the side-by-side table
+/// and recommended practice.
 pub fn drop(from stream: Stream(a), up_to n: Int) -> Stream(a) {
   case n < 0 {
     True -> panic as "datastream/stream.drop: count must be >= 0"


### PR DESCRIPTION
## Summary

`stream.take(s, 0)` closes the upstream eagerly on the first `pull` (early-exit semantics extended to the degenerate case). `stream.drop(s, 0)` is the identity — no upstream pull, no close. Both behaviours individually follow each constructor's primary contract, but the combination surprises callers who treat the two as duals: a `drop(s, 0)` that is built and discarded leaks the upstream, while `take(s, 0)` does not.

This PR takes Option 3 from issue #204: document the asymmetry in the function docstrings prominently, with a side-by-side table and concrete guidance for dynamic-`n` pipelines. No behavioural change.

## Changes

- \`src/datastream/stream.gleam\`:
  - \`take\` docstring expanded with a new \"Asymmetry of \`take(s, 0)\` and \`drop(s, 0)\`\" subsection. Two-row table (\`take\` early-exit close vs \`drop\` identity), two practical-consequence bullet points, and a recommendation: drive the resulting stream through a terminal so the close path runs regardless of which branch the runtime took.
  - \`drop\` docstring expanded to call out the identity semantics at \`n == 0\` and cross-reference the \`take\` table (single source of truth, no duplicated content).
- \`CHANGELOG.md\` — \`[Unreleased]\` documents the docs improvement.

## Design Decisions

- **Option 3, not Option 1 or Option 2.** Issue #204 listed three approaches:
  - (1) Make \`drop(s, 0)\` symmetric (lose identity semantics).
  - (2) Make \`take(s, 0)\` symmetric (lose early-exit close optimisation).
  - (3) Document the asymmetry.
  Each constructor's \`n == 0\` behaviour is individually defensible — \`take\` at \`n == 0\` is the limit of \"stop early on n elements emitted\" and the early close is what makes \`take\` safe on infinite resource-backed streams. Changing either is breaking and arguably worse; users rely on both.
- **One canonical table.** Putting the side-by-side table in \`take\`'s docstring and cross-referencing from \`drop\` keeps the source of truth in one place.
- **Recommendation: drive through a terminal.** The most common safe pattern for dynamic-\`n\` pipelines is to consume the resulting stream with \`fold.to_list\` / \`sink.each\` / \`fold.drain\`. The recommendation is included inline.

## Limitations

- **Doc-only.** Behaviour is unchanged.

Closes #204