### PR TITLE
feat(stream): add broadcast_bounded with explicit per-consumer queue cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **stream**: `stream.broadcast_bounded(over: Stream(a), into: Int,
+  max_queue: Int)` — the bounded fan-out sibling of
+  `stream.broadcast`. Each per-consumer queue is capped at
+  `max_queue` elements; a fanned-out element that would push any
+  queue past the bound triggers a structured panic on the next
+  upstream pull instead of letting memory grow until OOM. Use this
+  in production fan-outs (HTTP multicast, websocket pub/sub, Kafka
+  producer tees, …) where a stalled slow consumer must surface as a
+  crash. The `broadcast` docstring now also documents the
+  `O(max_pull_distance × n)` worst-case memory footprint of the
+  unbounded variant, and the README's new "Backpressure" subsection
+  cross-links `buffer`, `broadcast`, and `broadcast_bounded` so
+  consumers pick the right tool. (#205)
+
 ### Documentation
 
 - **stream**: `take` and `drop` docstrings now spell out the

--- a/README.md
+++ b/README.md
@@ -312,6 +312,36 @@ The main checked families are:
 - `binary.length_prefixed_checked`, `binary.length_prefixed_with_checked`, `binary.fixed_size_checked`
 - `datastream/erlang/par.*_checked`
 
+## Backpressure
+
+Two combinators interact with backpressure between a producer and one
+or more consumers:
+
+- **`stream.buffer(stream, prefetch:)`** prefetches up to `prefetch`
+  elements ahead of the consumer, so a latency-bound upstream (HTTP body
+  bytes, slow disk reads) does not serialise the consumer's per-element
+  work. The buffer is bounded by `prefetch`; a slow consumer cannot
+  blow it past that capacity.
+- **`stream.broadcast(stream, n)`** fans one source out to `n`
+  independent consumers, each pulling at its own pace. Per-consumer
+  queues are **unbounded**: if one consumer pulls aggressively while
+  another pauses, the slow consumer's queue grows by the per-consumer
+  pull-distance. The worst-case memory footprint is
+  `O(max_pull_distance × n)`. For cardinality-unbounded sources
+  (`source.iterate`, `source.repeat`) this is a silent memory hazard.
+- **`stream.broadcast_bounded(stream, n, max_queue:)`** is the
+  bounded variant: any consumer queue exceeding `max_queue` triggers
+  a structured panic on the next upstream pull. Use it in production
+  fan-outs (HTTP multicast, websocket pub/sub, Kafka producer tees,
+  ...) where a stalled slow consumer must surface as a crash instead
+  of an OOM.
+
+If you only have one consumer and just want to overlap producer work
+with consumer work, reach for `buffer`. If you genuinely need fan-out
+to multiple consumers and your source is bounded, `broadcast` is fine.
+If the source is unbounded or production-critical, default to
+`broadcast_bounded`.
+
 ## Web framework compatibility
 
 `datastream` depends on `gleam_erlang >= 1.3.0` and

--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -819,6 +819,11 @@ type BroadcastState(a) {
     upstream: Option(Stream(a)),
     queues: List(List(a)),
     active: List(Bool),
+    /// `None` for `broadcast` (unbounded queues). `Some(k)` for
+    /// `broadcast_bounded`, where any consumer queue exceeding `k`
+    /// elements triggers a structured panic on the next upstream
+    /// pull.
+    max_queue: Option(Int),
   )
 }
 
@@ -837,12 +842,25 @@ type BroadcastState(a) {
 /// with a panic per the `datastream` module-level invalid-argument
 /// policy.
 ///
-/// **Buffer size:** the per-consumer queue is currently unbounded.
-/// A consumer that never pulls while another pulls aggressively will
-/// accumulate the entire stream in its queue; users with that risk
-/// should compose `broadcast(..., n) |> list.map(stream.take(_, k))`
-/// or its equivalent. A bounded variant with an explicit drop policy
-/// is left as a follow-up — see the Roadmap.
+/// **Buffer size — unbounded by design.** Per-consumer queues grow
+/// without limit. The worst-case memory footprint is
+/// `O(max_pull_distance × n)`, where `max_pull_distance` is the
+/// difference between the fastest and slowest consumer's pull count
+/// at any point in time, and `n` is the consumer count. Concretely:
+/// if consumer A pulls 1 000 000 elements while B is paused, B's
+/// queue holds 1 000 000 elements until B catches up.
+///
+/// For resource-backed sources of bounded cardinality this is fine.
+/// For cardinality-unbounded sources (`source.iterate`,
+/// `source.repeat`, `source.unfold` of an infinite seed) it is a
+/// silent memory hazard. Two safer composition patterns:
+///
+/// - **Cap each consumer**: `broadcast(s, n) |> list.map(stream.take(_, k))`
+///   so the slowest consumer's queue is bounded by `k - 1`.
+/// - **Use `broadcast_bounded(s, n, max_queue)`** for an explicit
+///   per-consumer queue limit. Exceeding the limit panics with a
+///   structured message rather than letting the process OOM in
+///   production.
 ///
 /// **Cross-target:** implemented via a small FFI-backed mutable
 /// reference (`datastream/internal/ref`). On Erlang the cell is a
@@ -863,10 +881,64 @@ pub fn broadcast(over stream: Stream(a), into n: Int) -> List(Stream(a)) {
           upstream: Some(stream),
           queues: list.repeat([], times: n),
           active: list.repeat(True, times: n),
+          max_queue: None,
         )
       let state_ref = ref.new(initial)
       build_consumers(state_ref, n, [])
     }
+  }
+}
+
+/// Like `broadcast`, but each per-consumer queue is capped at
+/// `max_queue` elements. If a fanned-out element would push any
+/// consumer's queue beyond that bound, the next upstream pull panics
+/// with a structured message naming the limit. Use this in
+/// production wiring (HTTP fan-out, websocket multicast, Kafka
+/// producer tees, …) where a stalled slow consumer must surface as a
+/// crash instead of an OOM.
+///
+/// `n` MUST be `>= 1` and `max_queue` MUST be `>= 1`. Both checks
+/// are construction-time and panic on failure, matching the
+/// `datastream` module-level invalid-argument policy.
+///
+/// Behaviour on success is identical to `broadcast(s, n)` until the
+/// queue bound is hit. Until then there is no overhead beyond a
+/// per-pull `list.length` check on the freshly-enqueued queues.
+///
+/// **What "exceeded" means.** The check fires *after* the producing
+/// pull has already enqueued the element to every still-alive
+/// consumer that wasn't the puller. A consumer queue that was at
+/// `max_queue - 1` and gets one more element is fine; one that was
+/// at `max_queue` and would become `max_queue + 1` triggers the
+/// panic. The slowest consumer therefore has up to `max_queue`
+/// elements in its queue before the next overflowing pull stops the
+/// pipeline.
+///
+/// Pair with `broadcast`'s docstring above for the queue-growth
+/// formula and the unbounded baseline.
+pub fn broadcast_bounded(
+  over stream: Stream(a),
+  into n: Int,
+  max_queue max_queue: Int,
+) -> List(Stream(a)) {
+  case n < 1 {
+    True -> panic as "datastream/stream.broadcast_bounded: n must be >= 1"
+    False ->
+      case max_queue < 1 {
+        True ->
+          panic as "datastream/stream.broadcast_bounded: max_queue must be >= 1"
+        False -> {
+          let initial =
+            BroadcastState(
+              upstream: Some(stream),
+              queues: list.repeat([], times: n),
+              active: list.repeat(True, times: n),
+              max_queue: Some(max_queue),
+            )
+          let state_ref = ref.new(initial)
+          build_consumers(state_ref, n, [])
+        }
+      }
   }
 }
 
@@ -911,6 +983,7 @@ fn broadcast_pull(
           upstream: state.upstream,
           queues: new_queues,
           active: state.active,
+          max_queue: state.max_queue,
         ),
       )
       Next(head, broadcast_consumer(state_ref, consumer_id))
@@ -927,28 +1000,19 @@ fn broadcast_pull(
                   upstream: None,
                   queues: state.queues,
                   active: state.active,
+                  max_queue: state.max_queue,
                 ),
               )
               Done
             }
-            Next(element, rest) -> {
-              let new_queues =
-                fanout_to_others(
-                  state.queues,
-                  state.active,
-                  consumer_id,
-                  element,
-                )
-              ref.set(
+            Next(element, rest) ->
+              broadcast_emit_and_fan_out(
                 state_ref,
-                BroadcastState(
-                  upstream: Some(rest),
-                  queues: new_queues,
-                  active: state.active,
-                ),
+                consumer_id,
+                state,
+                element,
+                rest,
               )
-              Next(element, broadcast_consumer(state_ref, consumer_id))
-            }
           }
       }
   }
@@ -967,6 +1031,7 @@ fn broadcast_close(state_ref: Ref(BroadcastState(a)), consumer_id: Int) -> Nil {
           upstream: state.upstream,
           queues: cleared_queue,
           active: new_active,
+          max_queue: state.max_queue,
         ),
       )
     False, Some(upstream) -> {
@@ -977,6 +1042,7 @@ fn broadcast_close(state_ref: Ref(BroadcastState(a)), consumer_id: Int) -> Nil {
           upstream: None,
           queues: cleared_queue,
           active: new_active,
+          max_queue: state.max_queue,
         ),
       )
     }
@@ -987,8 +1053,61 @@ fn broadcast_close(state_ref: Ref(BroadcastState(a)), consumer_id: Int) -> Nil {
           upstream: None,
           queues: cleared_queue,
           active: new_active,
+          max_queue: state.max_queue,
         ),
       )
+  }
+}
+
+/// Fan a freshly-pulled element out to other consumers, enforce the
+/// optional `max_queue` bound, persist the new state, and yield the
+/// element to the puller. Extracted from `broadcast_pull` to keep
+/// nesting shallow.
+fn broadcast_emit_and_fan_out(
+  state_ref: Ref(BroadcastState(a)),
+  consumer_id: Int,
+  state: BroadcastState(a),
+  element: a,
+  rest: Stream(a),
+) -> Step(a, Stream(a)) {
+  let new_queues =
+    fanout_to_others(state.queues, state.active, consumer_id, element)
+  maybe_assert_queue_bound(new_queues, state.max_queue)
+  ref.set(
+    state_ref,
+    BroadcastState(
+      upstream: Some(rest),
+      queues: new_queues,
+      active: state.active,
+      max_queue: state.max_queue,
+    ),
+  )
+  Next(element, broadcast_consumer(state_ref, consumer_id))
+}
+
+/// `broadcast` (unbounded) passes `None` and short-circuits;
+/// `broadcast_bounded` passes `Some(k)` and walks the post-fanout
+/// queues, panicking on overflow.
+fn maybe_assert_queue_bound(
+  queues: List(List(a)),
+  max_queue: Option(Int),
+) -> Nil {
+  case max_queue {
+    None -> Nil
+    Some(limit) -> assert_queue_bound(queues, limit)
+  }
+}
+
+/// Walk every consumer queue in the post-fanout state and panic if
+/// any of them now exceeds the bound. Called only by
+/// `broadcast_bounded`. The structured panic message is the public
+/// signal that a slow consumer has stalled the pipeline beyond the
+/// caller's tolerated buffer size.
+fn assert_queue_bound(queues: List(List(a)), max: Int) -> Nil {
+  case list.find(queues, fn(q) { list.length(q) > max }) {
+    Ok(_) ->
+      panic as "datastream/stream.broadcast_bounded: a consumer's queue exceeded max_queue (slow consumer stalling fast producer)"
+    Error(_) -> Nil
   }
 }
 

--- a/test/datastream/stream_test.gleam
+++ b/test/datastream/stream_test.gleam
@@ -618,6 +618,78 @@ pub fn broadcast_negative_panics_test() {
   did_panic |> should.be_true
 }
 
+// --- broadcast_bounded ----------------------------------------------------
+
+pub fn broadcast_bounded_within_limit_works_like_broadcast_test() {
+  // While both consumers stay within `max_queue` elements of each
+  // other, behaviour is identical to `broadcast`.
+  let assert [a, b] =
+    stream.broadcast_bounded(over: from_list([1, 2, 3]), into: 2, max_queue: 5)
+  fold.to_list(a) |> should.equal([1, 2, 3])
+  fold.to_list(b) |> should.equal([1, 2, 3])
+}
+
+pub fn broadcast_bounded_high_limit_matches_broadcast_test() {
+  // With a max_queue at least as large as the source length, the
+  // bound is never reached and behaviour matches `broadcast`.
+  let assert [a, b] =
+    stream.broadcast_bounded(
+      over: from_list([1, 2, 3, 4, 5]),
+      into: 2,
+      max_queue: 100,
+    )
+  fold.to_list(a) |> should.equal([1, 2, 3, 4, 5])
+  fold.to_list(b) |> should.equal([1, 2, 3, 4, 5])
+}
+
+@target(erlang)
+pub fn broadcast_bounded_panics_when_slow_consumer_overflows_test() {
+  // a pulls aggressively while b stays paused. After enough fanouts
+  // b's queue exceeds max_queue and the next a-pull panics.
+  let did_panic =
+    panicked(fn() {
+      let assert [a, _b] =
+        stream.broadcast_bounded(
+          over: from_list([1, 2, 3, 4, 5]),
+          into: 2,
+          max_queue: 2,
+        )
+      let _drained = fold.to_list(a)
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
+@target(erlang)
+pub fn broadcast_bounded_zero_consumers_panics_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result =
+        stream.broadcast_bounded(
+          over: from_list([1, 2, 3]),
+          into: 0,
+          max_queue: 4,
+        )
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
+@target(erlang)
+pub fn broadcast_bounded_zero_max_queue_panics_test() {
+  let did_panic =
+    panicked(fn() {
+      let _result =
+        stream.broadcast_bounded(
+          over: from_list([1, 2, 3]),
+          into: 2,
+          max_queue: 0,
+        )
+      Nil
+    })
+  did_panic |> should.be_true
+}
+
 pub fn unzip_round_trip_with_zip_test() {
   let zipped = stream.zip(from_list([1, 2, 3]), from_list(["a", "b", "c"]))
   let #(left, right) = stream.unzip(zipped)


### PR DESCRIPTION
## Summary

\`stream.broadcast(s, n)\` keeps a per-consumer queue of buffered elements with no upper bound. If one consumer pulls aggressively while another stalls, the slow consumer's queue grows without limit — silent memory hazard for cardinality-unbounded sources (\`source.iterate\`, \`source.repeat\`). This PR adds \`broadcast_bounded\`, the explicit-cap sibling: a per-consumer queue exceeding \`max_queue\` triggers a structured panic on the next upstream pull. Production fan-outs (HTTP multicast, websocket pub/sub, Kafka tees) can now fail loudly instead of OOM.

The \`broadcast\` docstring also gains an \`O(max_pull_distance × n)\` worst-case formula and points readers at the bounded variant; the README adds a new \"Backpressure\" subsection cross-linking \`buffer\`, \`broadcast\`, and \`broadcast_bounded\`.

## Changes

- \`src/datastream/stream.gleam\`:
  - New public \`broadcast_bounded(over, into, max_queue)\`. Construction-time validation rejects \`n < 1\` and \`max_queue < 1\` with the project's standard structured-panic policy.
  - \`BroadcastState\` carries a \`max_queue: Option(Int)\` field; \`broadcast\` initialises it to \`None\` (unchanged behaviour) and \`broadcast_bounded\` to \`Some(k)\`.
  - \`broadcast_pull\`'s Next branch is extracted into \`broadcast_emit_and_fan_out\` for readability and to keep nesting under glinter's \`deep_nesting\` rule.
  - \`maybe_assert_queue_bound\` short-circuits the unbounded path; \`assert_queue_bound\` walks the post-fanout queues and panics on overflow.
  - \`broadcast\` docstring gains the queue-growth memory formula and the safer-composition recommendations.
- \`test/datastream/stream_test.gleam\`:
  - 4 new regression tests: bound never reached → matches \`broadcast\`; bound exceeded by lagging consumer → panics; \`n < 1\` panics; \`max_queue < 1\` panics.
- \`README.md\`:
  - New \"Backpressure\" section between \"Checked constructors\" and \"Web framework compatibility\". Cross-links \`buffer\`, \`broadcast\`, and \`broadcast_bounded\` with explicit guidance on which to reach for.
- \`CHANGELOG.md\`:
  - \`[Unreleased]\` documents the additive helper.

## Design Decisions

- **Panic, not Result.** \`broadcast_bounded\` panics rather than returning \`Result\` because the bound exists to crash production loudly when a slow consumer stalls a fast producer. The whole point is to surface the situation as a fault — wrapping it in \`Result\` would invite \"keep retrying / silently drop\" patterns that are exactly what \`broadcast\` already provides if you want them.
- **Construction-time validation matches existing module policy.** \`n < 1\` and \`max_queue < 1\` panic at construction, not on the first pull, mirroring \`broadcast\`'s existing posture and the project's invalid-argument unification (#145).
- **\`Option(Int)\` field on \`BroadcastState\`.** Keeps the unbounded fast path zero-overhead beyond a \`None\` match, and avoids forking the state machine into two type variants. The bound check is a single \`list.find\` over the post-fanout queues; \`O(n × max_queue)\` per overflowing pull is acceptable because the pipeline is about to abort.
- **\"What 'exceeded' means\" pinned in the docstring.** A consumer queue that was at \`max_queue - 1\` and gets one more element is fine; one that was at \`max_queue\` and would become \`max_queue + 1\` triggers the panic. This off-by-one is documented inline so callers picking a bound can reason about it.

## Limitations

- The bound is a hard limit, not a back-pressure signal. There is no \"slow producer down to consumer pace\" mechanism. If callers want that they should use \`buffer\` for single-consumer prefetch or compose \`broadcast(...) |> list.map(stream.take(_, k))\` for fixed-size capping.
- The \`list.length\` bound check is O(n) per consumer queue per overflowing pull. For multi-thousand-element queues with many consumers this could be measurable; in practice the bound exists to stop the pipeline early, so the overhead stays small.

Closes #205