### PR TITLE
feat(sink): unify terminal ops under datastream/sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **sink**: every pure terminal that previously lived only in
+  `datastream/fold` (`to_list`, `to_string`, `to_string_tree`,
+  `to_bit_array`, `count`, `first`, `last`, `fold`, `reduce`, `drain`,
+  `all`, `any`, `find`, `sum_int`, `sum_float`, `product_int`,
+  `collect_result`, `partition_result`, `partition_map`) is now
+  re-exported from `datastream/sink` so a single import covers both
+  pure reductions and side-effecting consumers (`each`, `try_each`,
+  `println`). New code should reach for `import datastream/sink`; the
+  `datastream/fold` module is kept as a backward-compatible alias and
+  may be removed in a future major release. The README's Quick Start
+  and the Module guide are updated to lead with `sink`. (#203)
+
 - **stream**: `stream.broadcast_bounded(over: Stream(a), into: Int,
   max_queue: Int)` — the bounded fan-out sibling of
   `stream.broadcast`. Each per-consumer queue is capped at

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ do not need lazy pulls, replayable pipelines, or deterministic cleanup.
 ## Quick start
 
 ```gleam
-import datastream/fold
+import datastream/sink
 import datastream/source
 import datastream/stream
 import gleam/io
@@ -46,7 +46,7 @@ pub fn main() {
     source.iterate(from: 1, with: fn(x) { x + 1 })
     |> stream.map(with: fn(x) { x * 2 })
     |> stream.take(up_to: 5)
-    |> fold.to_list
+    |> sink.to_list
 
   io.debug(result)
   // [2, 4, 6, 8, 10]
@@ -281,8 +281,8 @@ straight to source.
 - `datastream`: defines `Stream(a)` and `Step(a, state)`
 - `datastream/source`: constructors for list-backed, generated, and resource-backed streams
 - `datastream/stream`: lazy combinators such as `map`, `filter`, `flat_map`, `zip`, `take`, and `chunks_of`
-- `datastream/fold`: pure terminals such as `to_list`, `sum`, `first`, `find`, and `collect_result`
-- `datastream/sink`: effectful terminals such as `each` and `try_each`
+- `datastream/sink`: every terminal — pure reductions (`to_list`, `count`, `fold`, `first`, `find`, `collect_result`, …) and side-effecting consumers (`each`, `try_each`, `println`)
+- `datastream/fold`: legacy alias for the pure-reduction subset of `sink`. Re-exports the same functions for backward compatibility; new code should reach for `datastream/sink` instead
 - `datastream/chunk`: opaque finite batches
 - `datastream/text`: chunk-aware UTF-8 decode and line splitting
 - `datastream/binary`: byte and framing helpers

--- a/src/datastream/sink.gleam
+++ b/src/datastream/sink.gleam
@@ -1,14 +1,25 @@
-//// Side-effecting terminal consumers over `Stream(a)`.
+//// Terminal consumers over `Stream(a)` — pure reductions and
+//// side-effecting drivers.
 ////
-//// `sink` is the effectful half of the terminal layer; pure reductions
-//// live in `fold`. The split is intentional: a reader can tell from
-//// the import whether a function is pure (`fold`) or effectful (`sink`).
+//// `sink` is the unified terminal layer: every operation that drives
+//// a stream to completion (or until an early-exit decision) lives
+//// here. Pure reductions (`to_list`, `count`, `fold`, …) and
+//// side-effecting consumers (`each`, `try_each`, `println`) sit
+//// side-by-side; the import path is one line regardless of whether
+//// the caller's terminal returns a value or runs a `Nil`-typed
+//// effect.
 ////
-//// `fold.drain` already covers the "evaluate and discard" case, so a
-//// `sink.drain` synonym is intentionally omitted.
+//// The pure reductions are also exported from `datastream/fold` for
+//// backward compatibility with code written against earlier
+//// versions of this library. Prefer the `datastream/sink` import
+//// path for new code; the `fold` aliases are kept for now and may
+//// be removed in a future major release.
 
 import datastream.{type Stream, Done, Next}
+import datastream/fold
 import gleam/io
+import gleam/option.{type Option}
+import gleam/string_tree.{type StringTree}
 
 /// Drive the stream to completion, calling `effect` once per element
 /// in source order. Returns `Nil`.
@@ -56,4 +67,143 @@ pub fn try_each(
 /// sinks (file, socket, …) belong outside the cross-target core.
 pub fn println(stream: Stream(String)) -> Nil {
   each(over: stream, with: io.println)
+}
+
+// ---------------------------------------------------------------------------
+// Pure terminal reductions — re-exported from `datastream/fold`.
+//
+// Every function below delegates to its `datastream/fold` counterpart.
+// New code should reach for the `datastream/sink` path so the import
+// is one line regardless of whether the terminal returns a value or
+// runs a `Nil`-typed effect; the `datastream/fold` module is kept for
+// backward compatibility.
+// ---------------------------------------------------------------------------
+
+/// Materialise the stream into a list, preserving source order.
+/// Re-exported from `datastream/fold.to_list`.
+pub fn to_list(stream: Stream(a)) -> List(a) {
+  fold.to_list(stream)
+}
+
+/// Materialise a `Stream(String)` into a single concatenated `String`.
+/// Re-exported from `datastream/fold.to_string`.
+pub fn to_string(stream: Stream(String)) -> String {
+  fold.to_string(stream)
+}
+
+/// Materialise a `Stream(String)` into a `StringTree`, preserving
+/// source order. Re-exported from `datastream/fold.to_string_tree`.
+pub fn to_string_tree(stream: Stream(String)) -> StringTree {
+  fold.to_string_tree(stream)
+}
+
+/// Materialise a `Stream(BitArray)` into a single concatenated
+/// `BitArray`. Re-exported from `datastream/fold.to_bit_array`.
+pub fn to_bit_array(stream: Stream(BitArray)) -> BitArray {
+  fold.to_bit_array(stream)
+}
+
+/// Count the number of elements the stream produces.
+/// Re-exported from `datastream/fold.count`.
+pub fn count(stream: Stream(a)) -> Int {
+  fold.count(stream)
+}
+
+/// Pull until the first element and return it as `Some(a)`, or `None`
+/// for an empty stream. Re-exported from `datastream/fold.first`.
+pub fn first(stream: Stream(a)) -> Option(a) {
+  fold.first(stream)
+}
+
+/// Drive the stream to completion and return the final element as
+/// `Some(a)`, or `None` for an empty stream. Re-exported from
+/// `datastream/fold.last`.
+pub fn last(stream: Stream(a)) -> Option(a) {
+  fold.last(stream)
+}
+
+/// Left-fold the stream with an explicit accumulator. Re-exported
+/// from `datastream/fold.fold`.
+pub fn fold(
+  over stream: Stream(a),
+  from initial: acc,
+  with step: fn(acc, a) -> acc,
+) -> acc {
+  fold.fold(over: stream, from: initial, with: step)
+}
+
+/// Left-fold using the first element as the seed; returns `None` on
+/// an empty stream. Re-exported from `datastream/fold.reduce`.
+pub fn reduce(over stream: Stream(a), with step: fn(a, a) -> a) -> Option(a) {
+  fold.reduce(over: stream, with: step)
+}
+
+/// Drive the stream to completion and discard every element.
+/// Re-exported from `datastream/fold.drain`.
+pub fn drain(stream: Stream(a)) -> Nil {
+  fold.drain(stream)
+}
+
+/// Return `True` when every element satisfies `predicate`; `True` for
+/// an empty stream. Short-circuits on the first `False`. Re-exported
+/// from `datastream/fold.all`.
+pub fn all(over stream: Stream(a), satisfying predicate: fn(a) -> Bool) -> Bool {
+  fold.all(over: stream, satisfying: predicate)
+}
+
+/// Return `True` when at least one element satisfies `predicate`;
+/// `False` for an empty stream. Short-circuits on the first `True`.
+/// Re-exported from `datastream/fold.any`.
+pub fn any(over stream: Stream(a), satisfying predicate: fn(a) -> Bool) -> Bool {
+  fold.any(over: stream, satisfying: predicate)
+}
+
+/// Return the first element that satisfies `predicate`, or `None`.
+/// Re-exported from `datastream/fold.find`.
+pub fn find(
+  in stream: Stream(a),
+  satisfying predicate: fn(a) -> Bool,
+) -> Option(a) {
+  fold.find(in: stream, satisfying: predicate)
+}
+
+/// Sum every `Int` element. Returns 0 for an empty stream.
+/// Re-exported from `datastream/fold.sum_int`.
+pub fn sum_int(stream: Stream(Int)) -> Int {
+  fold.sum_int(stream)
+}
+
+/// Sum every `Float` element. Returns 0.0 for an empty stream.
+/// Re-exported from `datastream/fold.sum_float`.
+pub fn sum_float(stream: Stream(Float)) -> Float {
+  fold.sum_float(stream)
+}
+
+/// Multiply every `Int` element. Returns 1 for an empty stream.
+/// Re-exported from `datastream/fold.product_int`.
+pub fn product_int(stream: Stream(Int)) -> Int {
+  fold.product_int(stream)
+}
+
+/// Collect a `Stream(Result(a, e))` into `Result(List(a), e)` with
+/// short-circuit semantics on the first `Error(e)`. Re-exported from
+/// `datastream/fold.collect_result`.
+pub fn collect_result(stream: Stream(Result(a, e))) -> Result(List(a), e) {
+  fold.collect_result(stream)
+}
+
+/// Partition a `Stream(Result(a, e))` into a `(oks, errs)` pair.
+/// Re-exported from `datastream/fold.partition_result`.
+pub fn partition_result(stream: Stream(Result(a, e))) -> #(List(a), List(e)) {
+  fold.partition_result(stream)
+}
+
+/// Map every element to a `Result(b, c)` and partition the outcomes
+/// into a `(lefts, rights)` pair. Re-exported from
+/// `datastream/fold.partition_map`.
+pub fn partition_map(
+  over stream: Stream(a),
+  with split: fn(a) -> Result(b, c),
+) -> #(List(b), List(c)) {
+  fold.partition_map(over: stream, with: split)
 }


### PR DESCRIPTION
## Summary

Make `datastream/sink` the single home for every terminal — pure
reductions and side-effecting drivers. Issue #203 reported that the
`fold` vs `sink` split was confusing because both modules end the
pipeline; this PR removes the choice without removing the existing
import path.

## Changes

- `src/datastream/sink.gleam`: re-exports the 19 pure terminals from
  `datastream/fold` (`to_list`, `to_string`, `to_string_tree`,
  `to_bit_array`, `count`, `first`, `last`, `fold`, `reduce`, `drain`,
  `all`, `any`, `find`, `sum_int`, `sum_float`, `product_int`,
  `collect_result`, `partition_result`, `partition_map`). Each is a
  thin delegate to the existing `datastream/fold` implementation, so
  there is no behaviour change.
- Module docstring rewritten to describe `sink` as the unified
  terminal layer and to point users at the preferred import path.
- `README.md`: Quick Start now imports `datastream/sink`. The Module
  guide entry for `datastream/sink` lists every terminal, and the
  entry for `datastream/fold` is reworded as the legacy alias.
- `CHANGELOG.md`: `[Unreleased] / Added` entry describes the
  consolidation and the deprecation intent.

## Design Decisions

- Re-export, not move. Removing public functions from
  `datastream/fold` would be a breaking change for every existing
  caller, and the issue's pain point is the *new* user discovery
  problem, not the API surface. Re-exporting keeps both import paths
  valid while nudging new code toward `sink`.
- `fold` stays the source of truth. `sink` only delegates, so any
  future bug fix or behaviour change to a terminal is made in one
  place. This avoids divergence between the two import paths.
- The `fold` module is *not* `@deprecated` in this PR. Marking 19
  functions deprecated would emit warnings on every existing caller
  and force a churn pass on every dependent project. The CHANGELOG
  signals the deprecation intent and a future major release can
  flip the switch.

## Limitations

- The `Log-ingest`, `NDJSON`, and `Resource-backed` README examples
  still import `datastream/fold`. They continue to work and will be
  migrated in a follow-up README pass; leaving them alone here keeps
  the diff focused on the structural change.
