### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-07
+
 ### Added
 
 - **sink**: every pure terminal that previously lived only in

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "datastream"
-version = "0.11.0"
+version = "0.12.0"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }


### PR DESCRIPTION
### Added

- **sink**: every pure terminal that previously lived only in
  `datastream/fold` (`to_list`, `to_string`, `to_string_tree`,
  `to_bit_array`, `count`, `first`, `last`, `fold`, `reduce`, `drain`,
  `all`, `any`, `find`, `sum_int`, `sum_float`, `product_int`,
  `collect_result`, `partition_result`, `partition_map`) is now
  re-exported from `datastream/sink` so a single import covers both
  pure reductions and side-effecting consumers (`each`, `try_each`,
  `println`). New code should reach for `import datastream/sink`; the
  `datastream/fold` module is kept as a backward-compatible alias and
  may be removed in a future major release. The README's Quick Start
  and the Module guide are updated to lead with `sink`. (#203)

- **stream**: `stream.broadcast_bounded(over: Stream(a), into: Int,
  max_queue: Int)` — the bounded fan-out sibling of
  `stream.broadcast`. Each per-consumer queue is capped at
  `max_queue` elements; a fanned-out element that would push any
  queue past the bound triggers a structured panic on the next
  upstream pull instead of letting memory grow until OOM. Use this
  in production fan-outs (HTTP multicast, websocket pub/sub, Kafka
  producer tees, …) where a stalled slow consumer must surface as a
  crash. The `broadcast` docstring now also documents the
  `O(max_pull_distance × n)` worst-case memory footprint of the
  unbounded variant, and the README's new "Backpressure" subsection
  cross-links `buffer`, `broadcast`, and `broadcast_bounded` so
  consumers pick the right tool. (#205)

### Documentation

- **stream**: `take` and `drop` docstrings now spell out the
  `n == 0` resource-handling asymmetry side-by-side: `take(s, 0)`
  closes the upstream eagerly on the first pull; `drop(s, 0)` is the
  identity and does not pre-close. The `take` docstring carries the
  authoritative table, and `drop` cross-references it. Callers
  building `drop(s, 0)` for unknown `n` and discarding the stream
  without consuming it must close `s` themselves; the recommended
  practice (drive through a terminal regardless of which branch the
  runtime took) is documented inline. (#204)
