### PR TITLE
feat(source): add range_strict / range_descending directional siblings (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **source**: `range_strict` and `range_descending` — directional
+  siblings of `source.range` that fail loudly on swapped arguments.
+  `range_strict(from:, to:)` returns `Error(DescendingNotAllowed)`
+  when `from > to`, and `range_descending(from:, to:)` returns
+  `Error(AscendingNotAllowed)` when `from < to`. Reach for these
+  when the caller's intent is directional (buffer indices, time
+  bounds, paginated offsets) and a swapped pair of inputs should
+  surface as an error rather than a silent backwards stream.
+  `from == to` stays the empty-stream success case on both. (#210)
+
+### Documentation
+
+- **source.range**: hoisted the "argument order signals direction"
+  surprise out of the long docstring into a dedicated
+  `## Surprising behaviour` callout, with explicit cross-links to
+  `gleam/int.range` (stop-EXCLUSIVE, rejects `from > to`) and
+  `gleam/list.range` (stop-INCLUSIVE, direction-implicit) so users
+  coming from the stdlib can see at a glance which convention
+  `source.range` follows. (#210)
+
 ## [0.12.0] - 2026-05-07
 
 ### Added

--- a/src/datastream/source.gleam
+++ b/src/datastream/source.gleam
@@ -59,10 +59,34 @@ pub fn from_list(list: List(a)) -> Stream(a) {
 /// source.range(from: 5, to: 1) |> fold.to_list  // [5, 4, 3, 2]
 /// ```
 ///
+/// ## Surprising behaviour: argument order signals direction
+///
+/// `range` is **direction-implicit**: passing `from > to` produces a
+/// **descending** stream, not the empty stream. Callers who think they
+/// are guarding against negative iteration with
+/// `source.range(from: end, to: start)` get a backwards stream of
+/// indices instead.
+///
+/// Pick the variant that matches your intent:
+///
+/// - Want **ascending only** and an explicit failure on swapped
+///   arguments? Use `range_strict` — it returns
+///   `Error(DescendingNotAllowed)` when `from > to`.
+/// - Want **descending only** and an explicit failure on swapped
+///   arguments? Use `range_descending` — it returns
+///   `Error(AscendingNotAllowed)` when `from < to`.
+/// - Don't care about direction? Stick with `range`.
+///
+/// ## Stop-EXCLUSIVE vs. stop-INCLUSIVE in the stdlib
+///
 /// Stdlib has two `range` shapes with different conventions:
 ///
 /// - `gleam/int.range` (fold form) is **stop-EXCLUSIVE**, matching this
-///   function.
+///   function. `int.range` also rejects `from > to` by yielding the
+///   empty fold rather than reversing direction.
+/// - `gleam/list.range` is **stop-INCLUSIVE** *and* direction-implicit:
+///   `list.range(1, 5)` yields `[1, 2, 3, 4, 5]`, `list.range(5, 1)`
+///   yields `[5, 4, 3, 2, 1]`.
 /// - `gleam/yielder.range` (pull-based stream form) is
 ///   **stop-INCLUSIVE** — `yielder.range(from: 1, to: 5)` yields
 ///   `[1, 2, 3, 4, 5]` and `yielder.range(from: 0, to: 0)` yields
@@ -87,6 +111,82 @@ pub fn range(from start: Int, to stop: Int) -> Stream(Int) {
         }
       })
     }
+  }
+}
+
+/// Reasons a directional range constructor can refuse the inputs.
+///
+/// `DescendingNotAllowed` is returned by `range_strict` when
+/// `from > to`. `AscendingNotAllowed` is returned by `range_descending`
+/// when `from < to`. Both keep `from == to` as the empty-stream case
+/// (success) so callers do not have to special-case zero-width ranges.
+pub type RangeError {
+  DescendingNotAllowed
+  AscendingNotAllowed
+}
+
+/// Stop-EXCLUSIVE **ascending-only** integer range.
+///
+/// Mirrors `range` for `from <= to` and rejects `from > to` with
+/// `Error(DescendingNotAllowed)`. Reach for this when "swapped
+/// arguments" should be a hard error rather than a silent backwards
+/// stream — the typical case when `from`/`to` are derived from caller
+/// state (buffer indices, time bounds, paginated offsets).
+///
+/// `from == to` produces `Ok(empty())`, matching `range`'s zero-width
+/// behaviour.
+///
+/// Examples:
+///
+/// ```gleam
+/// source.range_strict(from: 1, to: 5)
+/// // Ok(<stream of [1, 2, 3, 4]>)
+///
+/// source.range_strict(from: 3, to: 3)
+/// // Ok(<empty stream>)
+///
+/// source.range_strict(from: 5, to: 1)
+/// // Error(DescendingNotAllowed)
+/// ```
+pub fn range_strict(
+  from start: Int,
+  to stop: Int,
+) -> Result(Stream(Int), RangeError) {
+  case start > stop {
+    True -> Error(DescendingNotAllowed)
+    False -> Ok(range(from: start, to: stop))
+  }
+}
+
+/// Stop-EXCLUSIVE **descending-only** integer range.
+///
+/// Mirrors `range` for `from >= to` and rejects `from < to` with
+/// `Error(AscendingNotAllowed)`. Use this when descending iteration is
+/// the deliberate intent (reverse traversal, countdowns) and an
+/// accidentally ascending pair of inputs should fail loudly.
+///
+/// `from == to` produces `Ok(empty())`, matching `range`'s zero-width
+/// behaviour.
+///
+/// Examples:
+///
+/// ```gleam
+/// source.range_descending(from: 5, to: 1)
+/// // Ok(<stream of [5, 4, 3, 2]>)
+///
+/// source.range_descending(from: 3, to: 3)
+/// // Ok(<empty stream>)
+///
+/// source.range_descending(from: 1, to: 5)
+/// // Error(AscendingNotAllowed)
+/// ```
+pub fn range_descending(
+  from start: Int,
+  to stop: Int,
+) -> Result(Stream(Int), RangeError) {
+  case start < stop {
+    True -> Error(AscendingNotAllowed)
+    False -> Ok(range(from: start, to: stop))
   }
 }
 

--- a/test/datastream/source_test.gleam
+++ b/test/datastream/source_test.gleam
@@ -40,8 +40,43 @@ pub fn range_counts_down_when_start_greater_than_stop_test() {
   source.range(from: 5, to: 0) |> fold.to_list |> should.equal([5, 4, 3, 2, 1])
 }
 
+// Regression pin for the documented "from > to auto-reverses" surprise.
+pub fn range_descending_silently_when_args_swapped_test() {
+  source.range(from: 5, to: 1) |> fold.to_list |> should.equal([5, 4, 3, 2])
+}
+
 pub fn range_is_empty_when_start_equals_stop_test() {
   source.range(from: 3, to: 3) |> fold.to_list |> should.equal([])
+}
+
+pub fn range_strict_yields_ascending_when_start_less_than_stop_test() {
+  let assert Ok(s) = source.range_strict(from: 0, to: 5)
+  s |> fold.to_list |> should.equal([0, 1, 2, 3, 4])
+}
+
+pub fn range_strict_yields_empty_when_start_equals_stop_test() {
+  let assert Ok(s) = source.range_strict(from: 3, to: 3)
+  s |> fold.to_list |> should.equal([])
+}
+
+pub fn range_strict_errors_when_start_greater_than_stop_test() {
+  source.range_strict(from: 5, to: 1)
+  |> should.equal(Error(source.DescendingNotAllowed))
+}
+
+pub fn range_descending_yields_descending_when_start_greater_than_stop_test() {
+  let assert Ok(s) = source.range_descending(from: 5, to: 0)
+  s |> fold.to_list |> should.equal([5, 4, 3, 2, 1])
+}
+
+pub fn range_descending_yields_empty_when_start_equals_stop_test() {
+  let assert Ok(s) = source.range_descending(from: 3, to: 3)
+  s |> fold.to_list |> should.equal([])
+}
+
+pub fn range_descending_errors_when_start_less_than_stop_test() {
+  source.range_descending(from: 1, to: 5)
+  |> should.equal(Error(source.AscendingNotAllowed))
 }
 
 pub fn repeat_with_take_yields_n_copies_test() {


### PR DESCRIPTION
## Summary

Closes #210.

`source.range(from:, to:)` is direction-implicit — passing `from > to`
yields a descending stream rather than the empty stream. The
behaviour is documented but easy to mistake for an empty-range guard,
especially for callers coming from `gleam/int.range` (rejects
`from > to`) or `gleam/list.range` (stop-INCLUSIVE).

### What changes

- **`source.range_strict(from:, to:) -> Result(Stream(Int), RangeError)`**
  Returns `Error(DescendingNotAllowed)` when `from > to`. Use when
  ascending iteration is the intent and a swapped pair of inputs
  (buffer indices, time bounds, paginated offsets) should surface as
  an error rather than a silent backwards stream.
- **`source.range_descending(from:, to:) -> Result(Stream(Int), RangeError)`**
  Returns `Error(AscendingNotAllowed)` when `from < to`. Use for
  deliberate descending iteration where an accidentally ascending
  pair must fail loudly.
- Both keep `from == to` as the empty-stream success case (`Ok(empty)`)
  so callers do not have to special-case zero-width ranges.
- New shared error type `RangeError` (`DescendingNotAllowed |
  AscendingNotAllowed`) is exported.
- `range` docstring restructured: the "argument order signals
  direction" surprise is hoisted into a dedicated
  `## Surprising behaviour` callout, and a stdlib-comparison
  subsection cross-links `gleam/int.range` and `gleam/list.range`.

### Compatibility

Non-breaking — `range` is unchanged in semantics; the new variants
are purely additive.

## Test plan

- [x] `gleam test` (460 passed, no failures)
- [x] Regression pin: `range(from: 5, to: 1) |> fold.to_list == [5, 4, 3, 2]`
- [x] `range_strict`: ascending / `from == to` / `from > to` (error)
- [x] `range_descending`: descending / `from == to` / `from < to` (error)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `range_strict()` and `range_descending()` functions for explicitly directional integer ranges that error on swapped arguments
  * New `RangeError` type to indicate direction conflicts

* **Documentation**
  * Enhanced documentation clarifying argument ordering and directional behavior in range functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->