### PR TITLE
chore(release): prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-07
+
 ### Added
 
 - **source**: `range_strict` and `range_descending` — directional

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "datastream"
-version = "0.12.0"
+version = "0.13.0"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }


### PR DESCRIPTION
### Added

- **source**: `range_strict` and `range_descending` — directional
  siblings of `source.range` that fail loudly on swapped arguments.
  `range_strict(from:, to:)` returns `Error(DescendingNotAllowed)`
  when `from > to`, and `range_descending(from:, to:)` returns
  `Error(AscendingNotAllowed)` when `from < to`. Reach for these
  when the caller's intent is directional (buffer indices, time
  bounds, paginated offsets) and a swapped pair of inputs should
  surface as an error rather than a silent backwards stream.
  `from == to` stays the empty-stream success case on both. (#210)

### Documentation

- **source.range**: hoisted the "argument order signals direction"
  surprise out of the long docstring into a dedicated
  `## Surprising behaviour` callout, with explicit cross-links to
  `gleam/int.range` (stop-EXCLUSIVE, rejects `from > to`) and
  `gleam/list.range` (stop-INCLUSIVE, direction-implicit) so users
  coming from the stdlib can see at a glance which convention
  `source.range` follows. (#210)
