### PR TITLE
feat(fold,sink): add to_string_join for lazy text export with separator (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **fold / sink**: `to_string_join(stream:, with: separator)` and the
+  `StringTree`-returning sibling `to_string_tree_join/2` are the
+  streaming counterpart of `gleam/string.join/2`. They concatenate the
+  elements of a `Stream(String)` with `separator` between consecutive
+  elements (no leading or trailing separator) and accumulate into a
+  `StringTree` so the cost stays `O(total length)` on long streams.
+  Use when emitting CSV / NDJSON / log lines / single-line digests
+  that need a fixed delimiter without breaking the laziness of the
+  upstream pipeline. Available on both `datastream/fold` (canonical)
+  and `datastream/sink` (re-export). Empty stream → `""`; single
+  element → the element itself with no separator. (#213)
+
 ## [0.13.0] - 2026-05-07
 
 ### Added

--- a/src/datastream/fold.gleam
+++ b/src/datastream/fold.gleam
@@ -50,6 +50,49 @@ pub fn to_string_tree(stream: Stream(String)) -> StringTree {
   })
 }
 
+/// Materialise a `Stream(String)` into a single `String` with `separator`
+/// inserted between consecutive elements (but not before the first or
+/// after the last). Streaming counterpart of `gleam/string.join/2`.
+///
+/// Internally accumulates into a `StringTree`, so the cost stays
+/// `O(total length)` even for long streams — no intermediate list
+/// materialisation. Returns `""` on an empty stream and the lone
+/// element on a single-element stream (no separator).
+///
+/// Use when emitting CSV / NDJSON / log lines / single-line digests
+/// that need a fixed delimiter between elements without breaking the
+/// laziness of the upstream pipeline. (#213)
+pub fn to_string_join(
+  stream stream: Stream(String),
+  with separator: String,
+) -> String {
+  stream
+  |> to_string_tree_join(with: separator)
+  |> string_tree.to_string
+}
+
+/// `StringTree` variant of `to_string_join` for callers that want to
+/// keep building the tree — prepending a header, joining with another
+/// tree — before producing the final `String`. Same separator
+/// semantics as `to_string_join`. (#213)
+pub fn to_string_tree_join(
+  stream stream: Stream(String),
+  with separator: String,
+) -> StringTree {
+  let #(tree, _seen) =
+    fold(over: stream, from: #(string_tree.new(), False), with: fn(acc, chunk) {
+      let #(tree, seen) = acc
+      case seen {
+        False -> #(string_tree.append(tree, chunk), True)
+        True -> {
+          let with_sep = string_tree.append(tree, separator)
+          #(string_tree.append(with_sep, chunk), True)
+        }
+      }
+    })
+  tree
+}
+
 /// Materialise a `Stream(BitArray)` into a single concatenated `BitArray`.
 ///
 /// Internally accumulates into a `BytesTree`, which bridges to Erlang's

--- a/src/datastream/sink.gleam
+++ b/src/datastream/sink.gleam
@@ -97,6 +97,26 @@ pub fn to_string_tree(stream: Stream(String)) -> StringTree {
   fold.to_string_tree(stream)
 }
 
+/// Materialise a `Stream(String)` into a single `String` with
+/// `separator` between consecutive elements. Streaming counterpart of
+/// `gleam/string.join/2`. Re-exported from
+/// `datastream/fold.to_string_join`. (#213)
+pub fn to_string_join(
+  stream stream: Stream(String),
+  with separator: String,
+) -> String {
+  fold.to_string_join(stream:, with: separator)
+}
+
+/// `StringTree` variant of `to_string_join`. Re-exported from
+/// `datastream/fold.to_string_tree_join`. (#213)
+pub fn to_string_tree_join(
+  stream stream: Stream(String),
+  with separator: String,
+) -> StringTree {
+  fold.to_string_tree_join(stream:, with: separator)
+}
+
 /// Materialise a `Stream(BitArray)` into a single concatenated
 /// `BitArray`. Re-exported from `datastream/fold.to_bit_array`.
 pub fn to_bit_array(stream: Stream(BitArray)) -> BitArray {

--- a/test/datastream/fold_test.gleam
+++ b/test/datastream/fold_test.gleam
@@ -303,3 +303,60 @@ pub fn partition_map_routes_via_split_test() {
   })
   |> should.equal(#([2, 4], [1, 3]))
 }
+
+// --- to_string_join: streaming counterpart of string.join (#213) ---
+
+pub fn to_string_join_empty_returns_empty_string_test() {
+  from_list([])
+  |> fold.to_string_join(with: ",")
+  |> should.equal("")
+}
+
+pub fn to_string_join_single_element_no_separator_test() {
+  // Single element: separator must NOT appear before or after.
+  from_list(["alone"])
+  |> fold.to_string_join(with: ",")
+  |> should.equal("alone")
+}
+
+pub fn to_string_join_three_elements_test() {
+  from_list(["a", "b", "c"])
+  |> fold.to_string_join(with: ",")
+  |> should.equal("a,b,c")
+}
+
+pub fn to_string_join_newline_separator_test() {
+  from_list(["row1", "row2", "row3"])
+  |> fold.to_string_join(with: "\n")
+  |> should.equal("row1\nrow2\nrow3")
+}
+
+pub fn to_string_join_multi_char_separator_test() {
+  from_list(["a", "b", "c"])
+  |> fold.to_string_join(with: " | ")
+  |> should.equal("a | b | c")
+}
+
+pub fn to_string_join_empty_separator_matches_to_string_test() {
+  // Empty separator must produce the same output as plain `to_string`.
+  let stream_join = fold.to_string_join(from_list(["x", "y", "z"]), with: "")
+  let stream_concat = fold.to_string(from_list(["x", "y", "z"]))
+  stream_join |> should.equal(stream_concat)
+}
+
+pub fn to_string_join_preserves_empty_string_elements_test() {
+  // Empty-string element must still trigger separator emission;
+  // the output ", , " has two separators between three elements.
+  from_list(["", "", ""])
+  |> fold.to_string_join(with: ", ")
+  |> should.equal(", , ")
+}
+
+pub fn to_string_tree_join_matches_to_string_join_test() {
+  let stream = from_list(["a", "b", "c"])
+  let via_tree =
+    fold.to_string_tree_join(stream, with: "-")
+    |> string_tree.to_string
+  let via_string = fold.to_string_join(from_list(["a", "b", "c"]), with: "-")
+  via_tree |> should.equal(via_string)
+}

--- a/test/datastream/sink_test.gleam
+++ b/test/datastream/sink_test.gleam
@@ -1,6 +1,7 @@
 import datastream.{Done, Next}
 import datastream/sink
 import datastream/source
+import gleam/string_tree
 import gleeunit
 import gleeunit/should
 
@@ -88,4 +89,29 @@ pub fn try_each_does_not_visit_elements_after_error_test() {
 
 pub fn println_runs_to_completion_on_empty_test() {
   source.empty() |> sink.println |> should.equal(Nil)
+}
+
+// --- to_string_join re-export (#213) ---
+
+pub fn sink_to_string_join_re_export_test() {
+  from_list(["row1", "row2", "row3"])
+  |> sink.to_string_join(with: "\n")
+  |> should.equal("row1\nrow2\nrow3")
+}
+
+pub fn sink_to_string_join_empty_test() {
+  source.empty()
+  |> sink.to_string_join(with: ",")
+  |> should.equal("")
+}
+
+pub fn sink_to_string_tree_join_re_export_test() {
+  // The tree variant must produce the same final String once the
+  // tree is materialised as the direct sink.to_string_join would.
+  let direct = from_list(["a", "b", "c"]) |> sink.to_string_join(with: "-")
+  let via_tree =
+    from_list(["a", "b", "c"])
+    |> sink.to_string_tree_join(with: "-")
+    |> string_tree.to_string
+  via_tree |> should.equal(direct)
 }


### PR DESCRIPTION
## Summary

Adds `to_string_join(stream, with: separator)` and its `StringTree`-returning sibling `to_string_tree_join/2` — the streaming counterpart of `gleam/string.join/2`. CSV / NDJSON / log-line export paths can now keep their pipeline lazy end-to-end instead of materialising a list and then `string.join`-ing it. Closes #213.

## Changes

- `src/datastream/fold.gleam`
  - New `pub fn to_string_join(stream stream: Stream(String), with separator: String) -> String`. Folds the stream into a `StringTree`, emitting `separator` before every element except the first; flattens to `String` at the end.
  - New `pub fn to_string_tree_join(stream stream: Stream(String), with separator: String) -> StringTree` — same but stops at the tree, for callers that want to keep building before flattening.
- `src/datastream/sink.gleam`: thin re-exports of both.
- `test/datastream/fold_test.gleam`: 8 new tests pinning the empty / single / multi cases, multi-char separator, the `with: ""` parity with plain `to_string`, the empty-string-element edge case (separator still emitted), and parity between `to_string_join` and `to_string_tree_join |> string_tree.to_string`.
- `test/datastream/sink_test.gleam`: 3 re-export smoke tests.
- `CHANGELOG.md`: documents the addition under `[Unreleased]`.

## Design Decisions

- **`StringTree` accumulator, not `List(String) ++ string.join`**: the whole point of `datastream/sink` is to avoid the intermediate list. Folding into a `StringTree` keeps the cost `O(total length)` even for long streams. Same shape as the existing `to_string_tree` implementation.
- **No leading or trailing separator**: matches `gleam/string.join` exactly. Empty stream → `""`. Single element → that element with no separator.
- **Separator emitted before subsequent empty elements** (`["", "", ""]` with `, ` → `", , "`): matches `string.join(["", "", ""], ", ")` byte-for-byte.
- **Both modules expose the symbol**. `fold` is canonical (consistent with where `to_string` / `to_string_tree` live); `sink` re-exports for callers that already only import `datastream/sink`.
- **Same-name labels (`stream:` / `with:`)**: matches the rest of the module's labelled-arg style and keeps `glinter`'s `label_possible` rule happy.

## Limitations

None. Additive change; no existing call sites touched. The companion `to_bit_array_join` is not added in this PR — bytes-with-separator has a different ergonomics (separator usually a `BitArray` literal, not a `String`) and was not requested in the issue.

Closes #213