### PR TITLE
chore(release): prepare v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-08
+
 ### Added
 - **fold / sink**: `to_string_join(stream:, with: separator)` and the
   `StringTree`-returning sibling `to_string_tree_join/2` are the

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "datastream"
-version = "0.13.0"
+version = "0.14.0"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }


### PR DESCRIPTION
### Added
- **fold / sink**: `to_string_join(stream:, with: separator)` and the
  `StringTree`-returning sibling `to_string_tree_join/2` are the
  streaming counterpart of `gleam/string.join/2`. They concatenate the
  elements of a `Stream(String)` with `separator` between consecutive
  elements (no leading or trailing separator) and accumulate into a
  `StringTree` so the cost stays `O(total length)` on long streams.
  Use when emitting CSV / NDJSON / log lines / single-line digests
  that need a fixed delimiter without breaking the laziness of the
  upstream pipeline. Available on both `datastream/fold` (canonical)
  and `datastream/sink` (re-export). Empty stream → `""`; single
  element → the element itself with no separator. (#213)
