### PR TITLE
refactor!: unify stream/find container label as `over:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: Stream operators that accept a stream as their
+  primary input now use the unified `over:` label, replacing the
+  previous mix of `from:` and `in:`. Affected functions:
+  `stream.take`, `stream.drop`, `stream.take_checked`,
+  `stream.drop_checked`, `stream.take_while`, `stream.drop_while`,
+  `stream.interrupt_when`, `fold.find`, and `sink.find` (which
+  re-exports `fold.find`). The previous labels were inconsistent
+  across the API — `take(from:, up_to:)`, `take_while(in:, satisfying:)`,
+  `filter(over:, keeping:)`, `chunks_of(over:, into:)`, etc. — which
+  forced callers to remember 5 different conventions for the
+  "container" argument. Unifying on `over:` matches the majority of
+  combinators and the shape used by `fold.fold`, `fold.all`,
+  `fold.any`. Migration: rename `from:` and `in:` to `over:` at
+  every call site of the listed functions; positional / pipe-style
+  calls like `|> stream.take(up_to: 5)` are unchanged. The other
+  `from:` / `in:` labels in the package (`source.range(from:, to:)`,
+  `source.iterate(from:, with:)`, `source.unfold(from:, with:)`,
+  `scan(over:, from: initial, ...)`, `fold(over:, from: initial, ...)`)
+  refer to *initial values* and *directional bounds*, not to the
+  container, and are intentionally left unchanged. (#218)
+
 ## [0.15.0] - 2026-05-09
 
 ### Added

--- a/src/datastream/fold.gleam
+++ b/src/datastream/fold.gleam
@@ -220,7 +220,7 @@ pub fn any(over stream: Stream(a), satisfying predicate: fn(a) -> Bool) -> Bool 
 ///
 /// Stops pulling upstream the moment a match is observed.
 pub fn find(
-  in stream: Stream(a),
+  over stream: Stream(a),
   satisfying predicate: fn(a) -> Bool,
 ) -> Option(a) {
   case datastream.pull(stream) {
@@ -231,7 +231,7 @@ pub fn find(
           datastream.close(rest)
           Some(element)
         }
-        False -> find(in: rest, satisfying: predicate)
+        False -> find(over: rest, satisfying: predicate)
       }
   }
 }

--- a/src/datastream/sink.gleam
+++ b/src/datastream/sink.gleam
@@ -181,10 +181,10 @@ pub fn any(over stream: Stream(a), satisfying predicate: fn(a) -> Bool) -> Bool 
 /// Return the first element that satisfies `predicate`, or `None`.
 /// Re-exported from `datastream/fold.find`.
 pub fn find(
-  in stream: Stream(a),
+  over stream: Stream(a),
   satisfying predicate: fn(a) -> Bool,
 ) -> Option(a) {
-  fold.find(in: stream, satisfying: predicate)
+  fold.find(over: stream, satisfying: predicate)
 }
 
 /// Sum every `Int` element. Returns 0 for an empty stream.

--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -112,7 +112,7 @@ fn filter_pull(
 /// `0`, prefer driving the resulting stream through a terminal
 /// (`fold.to_list`, `sink.each`, …) so the close path runs
 /// regardless of which branch the runtime took.
-pub fn take(from stream: Stream(a), up_to n: Int) -> Stream(a) {
+pub fn take(over stream: Stream(a), up_to n: Int) -> Stream(a) {
   case n < 0 {
     True -> panic as "datastream/stream.take: count must be >= 0"
     False -> take_active(stream, n)
@@ -151,7 +151,7 @@ fn take_active(stream: Stream(a), n: Int) -> Stream(a) {
 /// for closing `s` themselves. See `take`'s "Asymmetry of `take(s,
 /// 0)` and `drop(s, 0)`" subsection above for the side-by-side table
 /// and recommended practice.
-pub fn drop(from stream: Stream(a), up_to n: Int) -> Stream(a) {
+pub fn drop(over stream: Stream(a), up_to n: Int) -> Stream(a) {
   case n < 0 {
     True -> panic as "datastream/stream.drop: count must be >= 0"
     False -> drop_active(stream, n)
@@ -187,19 +187,19 @@ pub type StreamArgError {
 /// dynamic input (CLI, config, request parameters).
 ///
 /// On success the stream behaves identically to
-/// `take(from: stream, up_to: n)`.
+/// `take(over: stream, up_to: n)`.
 ///
 /// The caller is responsible for closing `stream` if the
 /// constructor returns `Error` — no upstream pull happens, but the
 /// upstream is otherwise untouched.
 ///
 /// Example:
-///   case stream.take_checked(from: src, up_to: configured_limit) {
+///   case stream.take_checked(over: src, up_to: configured_limit) {
 ///     Ok(s) -> ...
 ///     Error(stream.NegativeCount(function: _, given: g)) -> ...
 ///   }
 pub fn take_checked(
-  from stream: Stream(a),
+  over stream: Stream(a),
   up_to n: Int,
 ) -> Result(Stream(a), StreamArgError) {
   case n < 0 {
@@ -213,12 +213,12 @@ pub fn take_checked(
 /// dynamic input.
 ///
 /// On success the stream behaves identically to
-/// `drop(from: stream, up_to: n)`.
+/// `drop(over: stream, up_to: n)`.
 ///
 /// The caller is responsible for closing `stream` if the
 /// constructor returns `Error`.
 pub fn drop_checked(
-  from stream: Stream(a),
+  over stream: Stream(a),
   up_to n: Int,
 ) -> Result(Stream(a), StreamArgError) {
   case n < 0 {
@@ -254,7 +254,7 @@ fn drop_pull(stream: Stream(a), n: Int) -> Step(a, Stream(a)) {
 /// `False`, so `take_while` terminates on infinite resource-backed
 /// sources whose prefix eventually fails the predicate.
 pub fn take_while(
-  in stream: Stream(a),
+  over stream: Stream(a),
   satisfying predicate: fn(a) -> Bool,
 ) -> Stream(a) {
   datastream.make(
@@ -262,7 +262,7 @@ pub fn take_while(
       case datastream.pull(stream) {
         Next(element, rest) ->
           case predicate(element) {
-            True -> Next(element, take_while(in: rest, satisfying: predicate))
+            True -> Next(element, take_while(over: rest, satisfying: predicate))
             False -> {
               datastream.close(rest)
               Done
@@ -277,7 +277,7 @@ pub fn take_while(
 
 /// Discard the longest prefix where `predicate` holds, then yield the rest.
 pub fn drop_while(
-  in stream: Stream(a),
+  over stream: Stream(a),
   satisfying predicate: fn(a) -> Bool,
 ) -> Stream(a) {
   datastream.make(
@@ -755,7 +755,7 @@ fn buffer_fill(
 /// is closed first, then `stream` — right-before-left, matching
 /// `zip` and `flat_map`.
 pub fn interrupt_when(
-  in stream: Stream(a),
+  over stream: Stream(a),
   signal signal: Stream(Bool),
 ) -> Stream(a) {
   interrupt_active(stream, Some(signal))

--- a/test/datastream/stream_test.gleam
+++ b/test/datastream/stream_test.gleam
@@ -135,30 +135,30 @@ pub fn drop_more_than_available_yields_empty_test() {
 }
 
 pub fn take_checked_ok_matches_take_test() {
-  let assert Ok(s) = stream.take_checked(from: from_list([1, 2, 3]), up_to: 2)
+  let assert Ok(s) = stream.take_checked(over: from_list([1, 2, 3]), up_to: 2)
   s |> fold.to_list |> should.equal([1, 2])
 }
 
 pub fn take_checked_zero_yields_empty_test() {
-  let assert Ok(s) = stream.take_checked(from: from_list([1, 2, 3]), up_to: 0)
+  let assert Ok(s) = stream.take_checked(over: from_list([1, 2, 3]), up_to: 0)
   s |> fold.to_list |> should.equal([])
 }
 
 pub fn take_checked_negative_returns_error_test() {
   let assert Error(stream.NegativeCount(function: name, given: g)) =
-    stream.take_checked(from: from_list([1, 2, 3]), up_to: -5)
+    stream.take_checked(over: from_list([1, 2, 3]), up_to: -5)
   name |> should.equal("take")
   g |> should.equal(-5)
 }
 
 pub fn drop_checked_ok_matches_drop_test() {
-  let assert Ok(s) = stream.drop_checked(from: from_list([1, 2, 3]), up_to: 1)
+  let assert Ok(s) = stream.drop_checked(over: from_list([1, 2, 3]), up_to: 1)
   s |> fold.to_list |> should.equal([2, 3])
 }
 
 pub fn drop_checked_negative_returns_error_test() {
   let assert Error(stream.NegativeCount(function: name, given: g)) =
-    stream.drop_checked(from: from_list([1, 2, 3]), up_to: -3)
+    stream.drop_checked(over: from_list([1, 2, 3]), up_to: -3)
   name |> should.equal("drop")
   g |> should.equal(-3)
 }

--- a/test/datastream_metamon_test.gleam
+++ b/test/datastream_metamon_test.gleam
@@ -125,7 +125,7 @@ pub fn take_count_is_bounded_test() -> Nil {
     fn(pair) {
       let #(items, n) = pair
       let taken =
-        fold.count(stream.take(from: source.from_list(items), up_to: n))
+        fold.count(stream.take(over: source.from_list(items), up_to: n))
       taken <= n && taken <= list.length(items)
     },
   )
@@ -140,7 +140,7 @@ pub fn take_matches_list_take_test() -> Nil {
     fn(pair) {
       let #(items, n) = pair
       let taken =
-        fold.to_list(stream.take(from: source.from_list(items), up_to: n))
+        fold.to_list(stream.take(over: source.from_list(items), up_to: n))
       taken == list.take(items, n)
     },
   )
@@ -155,7 +155,7 @@ pub fn drop_matches_list_drop_test() -> Nil {
     fn(pair) {
       let #(items, n) = pair
       let dropped =
-        fold.to_list(stream.drop(from: source.from_list(items), up_to: n))
+        fold.to_list(stream.drop(over: source.from_list(items), up_to: n))
       dropped == list.drop(items, n)
     },
   )
@@ -170,9 +170,9 @@ pub fn take_then_drop_concat_recovers_original_test() -> Nil {
     fn(pair) {
       let #(items, n) = pair
       let taken =
-        fold.to_list(stream.take(from: source.from_list(items), up_to: n))
+        fold.to_list(stream.take(over: source.from_list(items), up_to: n))
       let dropped =
-        fold.to_list(stream.drop(from: source.from_list(items), up_to: n))
+        fold.to_list(stream.drop(over: source.from_list(items), up_to: n))
       list.append(taken, dropped) == items
     },
   )
@@ -180,13 +180,13 @@ pub fn take_then_drop_concat_recovers_original_test() -> Nil {
 
 pub fn take_zero_yields_empty_test() -> Nil {
   metamon.forall(small_int_list_generator(), fn(items) {
-    fold.to_list(stream.take(from: source.from_list(items), up_to: 0)) == []
+    fold.to_list(stream.take(over: source.from_list(items), up_to: 0)) == []
   })
 }
 
 pub fn drop_zero_is_identity_test() -> Nil {
   metamon.forall(small_int_list_generator(), fn(items) {
-    fold.to_list(stream.drop(from: source.from_list(items), up_to: 0)) == items
+    fold.to_list(stream.drop(over: source.from_list(items), up_to: 0)) == items
   })
 }
 


### PR DESCRIPTION
## Summary

Pre-1.0 cleanup of label-name inconsistency across the stream API.
Renames \`from:\`/\`in:\` to \`over:\` on every stream-taking public
function whose label was inconsistent with the rest of the package.

## Changes

| Function | Before | After |
|----------|--------|-------|
| \`stream.take\` | \`from:\` | \`over:\` |
| \`stream.drop\` | \`from:\` | \`over:\` |
| \`stream.take_checked\` | \`from:\` | \`over:\` |
| \`stream.drop_checked\` | \`from:\` | \`over:\` |
| \`stream.take_while\` | \`in:\` | \`over:\` |
| \`stream.drop_while\` | \`in:\` | \`over:\` |
| \`stream.interrupt_when\` | \`in:\` | \`over:\` |
| \`fold.find\` | \`in:\` | \`over:\` |
| \`sink.find\` | \`in:\` | \`over:\` (re-export of fold.find) |

After this PR, every stream-container label across the public API is
\`over:\`. The predicate / quantity / arg labels on those functions
(\`up_to:\`, \`satisfying:\`, \`signal:\`) are unchanged.

## Design decisions

- **\`over\` chosen over \`in\` / \`from\`**: the survey showed 14
  functions already use \`over:\` (\`map\`, \`filter\`, \`filter_map\`,
  \`flat_map\`, \`scan\`, \`map_accum\`, \`intersperse\`, \`tap\`,
  \`buffer\`, \`buffer_checked\`, \`broadcast\`, \`broadcast_bounded\`,
  \`chunks_of\`, \`chunks_of_checked\`, \`group_adjacent\`) plus all the
  fold combinators that take a stream + something else (\`fold.fold\`,
  \`fold.all\`, \`fold.any\`, \`fold.partition_map\`, \`fold.reduce\`).
  Renaming the 8 outliers to \`over:\` is the change with the smallest
  blast radius.
- **\`from:\` / \`in:\` are intentionally preserved on non-container
  arguments**: \`source.range(from:, to:)\`, \`source.iterate(from:,
  with:)\`, \`source.unfold(from:, with:)\`, \`scan(over:, from: initial,
  with:)\`, \`fold(over:, from: initial, with:)\`,
  \`beam_source.from_subject(from:, while:)\`. These \`from:\` labels
  name *initial values* or *directional bounds*, not the container.
  Renaming them would be wrong.
- **Internal helper functions left untouched**: only public-API labels
  changed. Private \`take_active\`, \`drop_pull\`, \`drop_while_pull\`,
  \`interrupt_active\`, etc. take positional arguments and are
  unaffected.
- **Pipe-style and positional calls are unaffected**: \`|> stream.take(up_to: 5)\`
  continues to work because no label is used at the call site for the
  piped stream argument.

## Migration guide for callers

For each call site of the listed functions, rename the label:

\`\`\`diff
- stream.take(from: src, up_to: 5)
+ stream.take(over: src, up_to: 5)

- stream.take_while(in: src, satisfying: pred)
+ stream.take_while(over: src, satisfying: pred)

- fold.find(in: src, satisfying: pred)
+ fold.find(over: src, satisfying: pred)
\`\`\`

Pipe-style calls need no change:

\`\`\`gleam
src |> stream.take(up_to: 5) |> fold.to_list  // unchanged
\`\`\`

## Verification

- \`just all\` passes: format-check, lint, both-target builds, both-target
  tests (498 erlang + 372 javascript = 870 total), docs build.
- All updated call sites compile and the assertions still hold.

## Limitations

- The CHANGELOG marks this as a BREAKING CHANGE. External callers
  using the old labels will get a clear \"Did you mean \`over\`?\"
  compile error pointing them at the rename.
- Out of scope (deferred): \`source.range\`'s \`from:\`/\`to:\` directional
  labels are unusual but semantically defensible. \`buffer\` uses
  \`prefetch:\` for capacity which doesn't fit the \`over:\`/\`up_to:\`
  pattern but is descriptive. \`broadcast_bounded\` uses \`max_queue:\`
  for the same reason. These were not touched to keep the PR focused.

Closes #218