### PR TITLE
docs(sink): add a 'Choosing a sink' table to the module doc-comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- `datastream/sink`: module doc-comment now opens with a "Choosing a sink" table that lists every typed-terminal sink (`to_string`, `to_string_tree`, `to_string_join`, `to_string_tree_join`, `println`, `to_bit_array`, `sum_int`, `product_int`, `sum_float`, `collect_result`, `partition_result`) alongside the stream element type each one consumes and, where relevant, the adapter to pipe through (notably `text.utf8_encode/1` for `Stream(String)` → `Stream(BitArray)`). The polymorphic sinks (`to_list`, `count`, `first`, `last`, `fold`, `reduce`, `drain`, `all`, `any`, `find`, `each`, `try_each`, `partition_map`) are called out together so callers know they never need an adapter. Includes a runnable example for the bytes-out-from-strings case raised in the issue. (#221)
+
 ## [0.16.0] - 2026-05-11
 
 ### Changed

--- a/src/datastream/sink.gleam
+++ b/src/datastream/sink.gleam
@@ -9,6 +9,42 @@
 //// the caller's terminal returns a value or runs a `Nil`-typed
 //// effect.
 ////
+//// ## Choosing a sink
+////
+//// Sinks that require a specific stream element type. Pipe through
+//// the listed adapter when the upstream type does not match.
+////
+//// | Sink                  | Requires            | Adapter for other element types                       |
+//// | --------------------- | ------------------- | ----------------------------------------------------- |
+//// | `to_string`           | `Stream(String)`    | —                                                     |
+//// | `to_string_tree`      | `Stream(String)`    | —                                                     |
+//// | `to_string_join`      | `Stream(String)`    | —                                                     |
+//// | `to_string_tree_join` | `Stream(String)`    | —                                                     |
+//// | `println`             | `Stream(String)`    | —                                                     |
+//// | `to_bit_array`        | `Stream(BitArray)`  | `Stream(String)` → pipe through `text.utf8_encode/1`  |
+//// | `sum_int`             | `Stream(Int)`       | —                                                     |
+//// | `product_int`         | `Stream(Int)`       | —                                                     |
+//// | `sum_float`           | `Stream(Float)`     | —                                                     |
+//// | `collect_result`      | `Stream(Result(a, e))` | —                                                  |
+//// | `partition_result`    | `Stream(Result(a, e))` | —                                                  |
+////
+//// Sinks below accept any `Stream(a)` (and any `Stream(Result(a, e))`
+//// for `partition_map`), so they never need an adapter: `to_list`,
+//// `count`, `first`, `last`, `fold`, `reduce`, `drain`, `all`, `any`,
+//// `find`, `each`, `try_each`, `partition_map`.
+////
+//// Example — writing a `Stream(String)` out as bytes:
+////
+//// ```gleam
+//// import datastream/sink
+//// import datastream/source
+//// import datastream/text
+////
+//// source.from_list(["a,b,c\n", "1,2,3\n"])
+//// |> text.utf8_encode
+//// |> sink.to_bit_array
+//// ```
+////
 //// The pure reductions are also exported from `datastream/fold` for
 //// backward compatibility with code written against earlier
 //// versions of this library. Prefer the `datastream/sink` import


### PR DESCRIPTION
## Summary

Adds a "Choosing a sink" table at the top of the `datastream/sink` module doc-comment listing each typed terminal sink alongside the stream element type it requires and, where relevant, the adapter callers should pipe through. The polymorphic sinks are called out together so a reader knows when no adapter is needed. The current `sink` doc-comment did not surface the typed-stream-vs-typed-sink contract, so the natural first attempt of `source.from_list(["a,b,c\n", ...]) |> sink.to_bit_array` failed to compile and the missing encoder boundary (`text.utf8_encode`) was not visible from the page.

## Changes

- `src/datastream/sink.gleam`: expand the module doc-comment with a `## Choosing a sink` section. The table covers the typed sinks (`to_string`, `to_string_tree`, `to_string_join`, `to_string_tree_join`, `println`, `to_bit_array`, `sum_int`, `product_int`, `sum_float`, `collect_result`, `partition_result`) and is followed by a single line listing the polymorphic sinks so callers know `to_list` / `count` / `fold` / etc. never need an adapter. Ends with a runnable `text.utf8_encode |> sink.to_bit_array` example matching the case raised in the issue.
- `CHANGELOG.md`: `[Unreleased]` entry under `### Documentation` describing the new section.

## Design Decisions

The table lives at the top of `datastream/sink.gleam` rather than in the README because that's the page the compiler error points readers at, and the page hexdocs renders by default when callers click through from a type signature. Keeping the typed/polymorphic split visually separate (table for typed, single sentence for polymorphic) avoids cluttering the table with `Stream(a)` rows that carry no useful information.

`text.utf8_encode/1` is named in the adapter column for `to_bit_array` rather than linked because the doc-comment renders both on hex.docs and inside editors via LSP hover — a literal name surfaces in both contexts. The runnable example at the end pins the exact pipe shape so the table is not the only source of truth.

## Test plan

- [x] `gleam build --warnings-as-errors`: clean
- [x] `gleam test` (Erlang target): 498 passed
- [x] `gleam test --target javascript`: 372 passed
- [x] `gleam format --check src test`: clean

Closes #221
