### PR TITLE
fix(stream): take/drop treat negative count as 0 instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `datastream/stream`: `stream.take(over: s, up_to: n)` and `stream.drop(over: s, up_to: n)` now treat a negative `n` as `0` instead of panicking with `count must be >= 0`. The lenient convention matches `gleam/list.take` and `gleam/list.drop`, so callers can hand the result of an arithmetic clamp directly to `take` / `drop` without first guarding against an off-by-one underflow. Callers that want the previous "reject and surface the bad value" behaviour can still reach for `take_checked` / `drop_checked`, which return `Error(NegativeCount(function: _, given: n))`. (#224)
+
 ## [0.17.0] - 2026-05-16
 
 ### Documentation

--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -71,9 +71,13 @@ fn filter_pull(
 /// Yield at most the first `n` elements; `n == 0` yields the empty
 /// stream.
 ///
-/// `n` MUST be `>= 0`. A negative `n` is rejected at construction
-/// time with a panic per the `datastream` module-level
-/// invalid-argument policy.
+/// Negative `n` is treated as `0` (the empty stream, with the same
+/// eager-close semantics as `take(s, 0)`). This matches
+/// `gleam/list.take`'s lenient convention so callers can hand
+/// `take` an arithmetic result without first clamping it. If you
+/// want the previous "reject and surface the bad value" behaviour,
+/// reach for `take_checked`, which returns `Error(NegativeCount(...))`
+/// on negative input.
 ///
 /// Stops pulling upstream the moment the `n`th element has been
 /// emitted, and closes the upstream on that early exit. This is what
@@ -114,7 +118,7 @@ fn filter_pull(
 /// regardless of which branch the runtime took.
 pub fn take(over stream: Stream(a), up_to n: Int) -> Stream(a) {
   case n < 0 {
-    True -> panic as "datastream/stream.take: count must be >= 0"
+    True -> take_active(stream, 0)
     False -> take_active(stream, n)
   }
 }
@@ -140,9 +144,12 @@ fn take_active(stream: Stream(a), n: Int) -> Stream(a) {
 
 /// Discard the first `n` elements; `n == 0` is the identity.
 ///
-/// `n` MUST be `>= 0`. A negative `n` is rejected at construction
-/// time with a panic per the `datastream` module-level
-/// invalid-argument policy.
+/// Negative `n` is treated as `0` (identity stream, no upstream
+/// pulls, no close). This matches `gleam/list.drop`'s lenient
+/// convention so callers can hand `drop` an arithmetic result
+/// without first clamping it. If you want the previous "reject
+/// and surface the bad value" behaviour, reach for `drop_checked`,
+/// which returns `Error(NegativeCount(...))` on negative input.
 ///
 /// **Resource handling at `n == 0`** — identity semantics: no
 /// upstream pull, no close. Asymmetric with `take(s, 0)` (which
@@ -153,7 +160,7 @@ fn take_active(stream: Stream(a), n: Int) -> Stream(a) {
 /// and recommended practice.
 pub fn drop(over stream: Stream(a), up_to n: Int) -> Stream(a) {
   case n < 0 {
-    True -> panic as "datastream/stream.drop: count must be >= 0"
+    True -> drop_active(stream, 0)
     False -> drop_active(stream, n)
   }
 }

--- a/test/datastream/stream_test.gleam
+++ b/test/datastream/stream_test.gleam
@@ -75,16 +75,18 @@ pub fn take_zero_yields_empty_test() {
   |> should.equal([])
 }
 
-@target(erlang)
-pub fn take_negative_panics_test() {
-  let did_panic =
-    panicked(fn() {
-      let _result =
-        from_list([1, 2, 3])
-        |> stream.take(up_to: -5)
-      Nil
-    })
-  did_panic |> should.be_true
+pub fn take_negative_yields_empty_test() {
+  from_list([1, 2, 3])
+  |> stream.take(up_to: -5)
+  |> fold.to_list
+  |> should.equal([])
+}
+
+pub fn take_very_negative_yields_empty_test() {
+  from_list([1, 2, 3, 4, 5])
+  |> stream.take(up_to: -1_000_000)
+  |> fold.to_list
+  |> should.equal([])
 }
 
 pub fn take_more_than_available_yields_all_test() {
@@ -115,16 +117,18 @@ pub fn drop_zero_is_identity_test() {
   |> should.equal([1, 2, 3])
 }
 
-@target(erlang)
-pub fn drop_negative_panics_test() {
-  let did_panic =
-    panicked(fn() {
-      let _result =
-        from_list([1, 2, 3])
-        |> stream.drop(up_to: -5)
-      Nil
-    })
-  did_panic |> should.be_true
+pub fn drop_negative_is_identity_test() {
+  from_list([1, 2, 3])
+  |> stream.drop(up_to: -5)
+  |> fold.to_list
+  |> should.equal([1, 2, 3])
+}
+
+pub fn drop_very_negative_is_identity_test() {
+  from_list([1, 2, 3, 4, 5])
+  |> stream.drop(up_to: -1_000_000)
+  |> fold.to_list
+  |> should.equal([1, 2, 3, 4, 5])
 }
 
 pub fn drop_more_than_available_yields_empty_test() {


### PR DESCRIPTION
## Summary

\`stream.take(s, up_to: -n)\` and \`stream.drop(s, up_to: -n)\` used to panic with \`count must be >= 0\`. The strict policy crashes callers that derive \`n\` from arithmetic (e.g. \`remaining_budget - already_taken\` underflowing past zero) where the natural interpretation is "no elements taken / nothing to drop", and is out of step with \`gleam/list.take\` and \`gleam/list.drop\` which both treat negative counts as zero.

## Changes

- \`src/datastream/stream.gleam\`: replace the panic branches in \`take\` and \`drop\` with calls to \`take_active(stream, 0)\` and \`drop_active(stream, 0)\` respectively. \`take(s, -n)\` yields the empty stream with the same eager-close semantics as \`take(s, 0)\`; \`drop(s, -n)\` is the identity, matching \`drop(s, 0)\`. Update both doc-comments to describe the new lenient contract and to point readers at \`take_checked\` / \`drop_checked\` if they want the previous "surface the bad value" behaviour.
- \`test/datastream/stream_test.gleam\`: replace \`take_negative_panics_test\` and \`drop_negative_panics_test\` with positive-fact tests covering both \`-5\` and \`-1_000_000\` against the new contract (\`take_negative_yields_empty\`, \`take_very_negative_yields_empty\`, \`drop_negative_is_identity\`, \`drop_very_negative_is_identity\`). The replacement tests no longer need the erlang-target panic helper, but other tests in the file still use it so the import stays.
- CHANGELOG \`### Changed\` entry under \`[Unreleased]\`. \`take_checked\` / \`drop_checked\` are unchanged.

## Design Decisions

The issue listed three options. 方針 A (clamp negative to \`0\`) matches \`gleam/list.take\` exactly and removes the discontinuity between \"caller derived a negative \`n\` from arithmetic\" and \"caller wrote \`0\` deliberately\" — both express \"no elements\" and now produce identical streams. 方針 B (\`take_checked\`-only) already exists; the issue is specifically that the default \`take\` is the wrong shape. 方針 C (docs-only) leaves the production-crash hazard in place.

## Limitations

This is a behaviour change for callers that depended on the panic to surface a programming error. Such callers should migrate to \`take_checked\` / \`drop_checked\`, which return \`Error(NegativeCount(function: _, given: n))\` and are themselves unchanged. The CHANGELOG entry documents the migration.

Closes #224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stream operations now gracefully handle negative input values by treating them as zero, instead of failing. Users requiring strict validation can use alternative functions.

* **Documentation**
  * Updated documentation to clarify the new lenient input handling behavior and document validation alternatives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/datastream/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->