### PR TITLE
fix(stream): broadcast/broadcast_bounded treat non-positive consumer count as empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `datastream/stream`: `stream.broadcast(over: s, into: n)` and `stream.broadcast_bounded(over: s, into: n, max_queue: _)` now treat a non-positive `n` as "no consumers" — the upstream is closed immediately and the function returns the empty list — instead of panicking with `n must be >= 1`. The lenient policy matches the matching change to `stream.take` / `stream.drop` and follows the same `gleam/list.take` convention. `broadcast_bounded`'s `max_queue` validation is unchanged (a non-positive buffer capacity has no meaningful interpretation) and still panics on `max_queue < 1`. (#225)
 - `datastream/stream`: `stream.take(over: s, up_to: n)` and `stream.drop(over: s, up_to: n)` now treat a negative `n` as `0` instead of panicking with `count must be >= 0`. The lenient convention matches `gleam/list.take` and `gleam/list.drop`, so callers can hand the result of an arithmetic clamp directly to `take` / `drop` without first guarding against an off-by-one underflow. Callers that want the previous "reject and surface the bad value" behaviour can still reach for `take_checked` / `drop_checked`, which return `Error(NegativeCount(function: _, given: n))`. (#224)
 
 ## [0.17.0] - 2026-05-16

--- a/src/datastream/stream.gleam
+++ b/src/datastream/stream.gleam
@@ -845,9 +845,11 @@ type BroadcastState(a) {
 /// without forcing the source to be re-evaluated, which matters for
 /// resource-backed and otherwise non-replayable sources.
 ///
-/// `n` MUST be `>= 1`. A `n < 1` is rejected at construction time
-/// with a panic per the `datastream` module-level invalid-argument
-/// policy.
+/// `n <= 0` is treated as "no consumers": the upstream is closed
+/// immediately and `broadcast` returns the empty list. The lenient
+/// convention matches `stream.take` / `stream.drop` and lets callers
+/// hand `broadcast` an arithmetic result without first guarding
+/// against an off-by-one underflow.
 ///
 /// **Buffer size — unbounded by design.** Per-consumer queues grow
 /// without limit. The worst-case memory footprint is
@@ -881,7 +883,10 @@ type BroadcastState(a) {
 /// first it self-closes, and the close callbacks are no-ops.
 pub fn broadcast(over stream: Stream(a), into n: Int) -> List(Stream(a)) {
   case n < 1 {
-    True -> panic as "datastream/stream.broadcast: n must be >= 1"
+    True -> {
+      datastream.close(stream)
+      []
+    }
     False -> {
       let initial =
         BroadcastState(
@@ -904,9 +909,12 @@ pub fn broadcast(over stream: Stream(a), into n: Int) -> List(Stream(a)) {
 /// producer tees, …) where a stalled slow consumer must surface as a
 /// crash instead of an OOM.
 ///
-/// `n` MUST be `>= 1` and `max_queue` MUST be `>= 1`. Both checks
-/// are construction-time and panic on failure, matching the
-/// `datastream` module-level invalid-argument policy.
+/// `n <= 0` is treated as "no consumers" (the upstream is closed
+/// immediately and the function returns the empty list), matching
+/// `broadcast`'s lenient convention. `max_queue` MUST still be
+/// `>= 1` — a non-positive buffer capacity has no meaningful
+/// interpretation — and is rejected at construction time with a
+/// panic that names the function.
 ///
 /// Behaviour on success is identical to `broadcast(s, n)` until the
 /// queue bound is hit. Until then there is no overhead beyond a
@@ -929,7 +937,10 @@ pub fn broadcast_bounded(
   max_queue max_queue: Int,
 ) -> List(Stream(a)) {
   case n < 1 {
-    True -> panic as "datastream/stream.broadcast_bounded: n must be >= 1"
+    True -> {
+      datastream.close(stream)
+      []
+    }
     False ->
       case max_queue < 1 {
         True ->

--- a/test/datastream/stream_test.gleam
+++ b/test/datastream/stream_test.gleam
@@ -602,24 +602,16 @@ pub fn broadcast_consumer_with_take_zero_does_not_block_other_test() {
   fold.to_list(b) |> should.equal([1, 2, 3])
 }
 
-@target(erlang)
-pub fn broadcast_zero_panics_test() {
-  let did_panic =
-    panicked(fn() {
-      let _result = stream.broadcast(over: from_list([1, 2, 3]), into: 0)
-      Nil
-    })
-  did_panic |> should.be_true
+pub fn broadcast_zero_returns_empty_list_test() {
+  stream.broadcast(over: from_list([1, 2, 3]), into: 0)
+  |> list.length
+  |> should.equal(0)
 }
 
-@target(erlang)
-pub fn broadcast_negative_panics_test() {
-  let did_panic =
-    panicked(fn() {
-      let _result = stream.broadcast(over: from_list([1, 2, 3]), into: -3)
-      Nil
-    })
-  did_panic |> should.be_true
+pub fn broadcast_negative_returns_empty_list_test() {
+  stream.broadcast(over: from_list([1, 2, 3]), into: -3)
+  |> list.length
+  |> should.equal(0)
 }
 
 // --- broadcast_bounded ----------------------------------------------------
@@ -664,19 +656,16 @@ pub fn broadcast_bounded_panics_when_slow_consumer_overflows_test() {
   did_panic |> should.be_true
 }
 
-@target(erlang)
-pub fn broadcast_bounded_zero_consumers_panics_test() {
-  let did_panic =
-    panicked(fn() {
-      let _result =
-        stream.broadcast_bounded(
-          over: from_list([1, 2, 3]),
-          into: 0,
-          max_queue: 4,
-        )
-      Nil
-    })
-  did_panic |> should.be_true
+pub fn broadcast_bounded_zero_consumers_returns_empty_list_test() {
+  stream.broadcast_bounded(over: from_list([1, 2, 3]), into: 0, max_queue: 4)
+  |> list.length
+  |> should.equal(0)
+}
+
+pub fn broadcast_bounded_negative_consumers_returns_empty_list_test() {
+  stream.broadcast_bounded(over: from_list([1, 2, 3]), into: -3, max_queue: 4)
+  |> list.length
+  |> should.equal(0)
 }
 
 @target(erlang)


### PR DESCRIPTION
## Summary

\`stream.broadcast(s, into: n)\` and \`stream.broadcast_bounded(s, into: n, max_queue: _)\` used to panic with \`n must be >= 1\` whenever a caller's arithmetic produced a zero or negative consumer count. That follows the same fail-loud pattern #224 already rewrote for \`stream.take\` / \`stream.drop\`, with the same downside: a single off-by-one underflow takes down the process for a case whose natural interpretation is "fan out to nobody".

## Changes

- \`src/datastream/stream.gleam\`: replace the \`n < 1\` panic branches in \`broadcast\` and \`broadcast_bounded\` with \`datastream.close(stream); []\`. Closing eagerly means no upstream resource leaks behind the no-op fan-out. Update both doc-comments to describe the new lenient contract. \`broadcast_bounded\`'s \`max_queue < 1\` check stays as a panic — a non-positive buffer capacity has no meaningful interpretation, and there is no \`gleam/list\` precedent to align with.
- \`test/datastream/stream_test.gleam\`: replace \`broadcast_zero_panics_test\`, \`broadcast_negative_panics_test\`, and \`broadcast_bounded_zero_consumers_panics_test\` with positive-fact \`*_returns_empty_list\` tests covering both \`0\` and \`-3\` against the new contract. \`broadcast_bounded_zero_max_queue_panics_test\` stays in place because \`max_queue\` still panics. The bounded-queue overflow panic test is unchanged.
- CHANGELOG \`### Changed\` entry under \`[Unreleased]\`, sitting alongside the matching #224 entry so the two \"count-taking operator panic\" changes read as one policy decision.

## Design Decisions

The issue listed three options. 方針 A (clamp non-positive to "no consumers") matches the change \`stream.take\` / \`stream.drop\` already received in #224 and gives the same continuity between "caller wrote \`0\` deliberately" and "caller derived a negative \`n\` from arithmetic". The bounded-queue \`max_queue\` parameter is left strict because it is a structural invariant of the bounded variant, not a count of work — a "no-buffer" mode would be a different combinator (likely just \`broadcast\` itself).

## Limitations

This is a behaviour change for callers that depended on the panic to surface a programming error in their consumer-count arithmetic. Such callers should validate \`n\` themselves before calling, or pattern-match the returned list (\`let assert [a, b] = ...\` still surfaces a deeper crash if \`n\` came out wrong). The CHANGELOG entry documents the migration.

Closes #225