### PR TITLE
chore(release): prepare v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-05-20
+
 ### Changed
 
 - `datastream/stream`: `stream.broadcast(over: s, into: n)` and `stream.broadcast_bounded(over: s, into: n, max_queue: _)` now treat a non-positive `n` as "no consumers" — the upstream is closed immediately and the function returns the empty list — instead of panicking with `n must be >= 1`. The lenient policy matches the matching change to `stream.take` / `stream.drop` and follows the same `gleam/list.take` convention. `broadcast_bounded`'s `max_queue` validation is unchanged (a non-positive buffer capacity has no meaningful interpretation) and still panics on `max_queue < 1`. (#225)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "datastream"
-version = "0.17.0"
+version = "0.18.0"
 description = "Compositional, resource-safe streams for Gleam — runs on Erlang and JavaScript targets"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "datastream" }


### PR DESCRIPTION
### Changed

- `datastream/stream`: `stream.broadcast(over: s, into: n)` and `stream.broadcast_bounded(over: s, into: n, max_queue: _)` now treat a non-positive `n` as "no consumers" — the upstream is closed immediately and the function returns the empty list — instead of panicking with `n must be >= 1`. The lenient policy matches the matching change to `stream.take` / `stream.drop` and follows the same `gleam/list.take` convention. `broadcast_bounded`'s `max_queue` validation is unchanged (a non-positive buffer capacity has no meaningful interpretation) and still panics on `max_queue < 1`. (#225)
- `datastream/stream`: `stream.take(over: s, up_to: n)` and `stream.drop(over: s, up_to: n)` now treat a negative `n` as `0` instead of panicking with `count must be >= 0`. The lenient convention matches `gleam/list.take` and `gleam/list.drop`, so callers can hand the result of an arithmetic clamp directly to `take` / `drop` without first guarding against an off-by-one underflow. Callers that want the previous "reject and surface the bad value" behaviour can still reach for `take_checked` / `drop_checked`, which return `Error(NegativeCount(function: _, given: n))`. (#224)
